### PR TITLE
feat(payments): add client-facing invoice payments via Stripe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,11 @@ BETTER_AUTH_SECRET="change-me-in-production-min-32-chars"
 # STRIPE_LIVE_PRO_PRICE_ID=""
 # STRIPE_LIVE_LIFETIME_PRICE_ID=""
 
+# ── Stripe Connect (optional — enables client invoice payments) ──
+# STRIPE_CONNECT_CLIENT_ID=""           # Platform Connect client ID (ca_xxx)
+# STRIPE_CONNECT_WEBHOOK_SECRET=""      # Webhook secret for Connect events
+# STRIPE_CURRENCY="usd"                 # Currency for invoice payments (ISO 4217)
+
 # ── Analytics / Tracking (optional) ─────────────────────
 # JSON array of script tags. Each object's keys become attributes on a <script> tag.
 # Supports any tracker (Umami, Plausible, Fathom, etc.) — add as many as you need.

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -24,6 +24,7 @@ import { DocumentsModule } from "./documents/documents.module";
 import { ActivityModule } from "./activity/activity.module";
 import { CommentsModule } from "./comments/comments.module";
 import { LabelsModule } from "./labels/labels.module";
+import { PaymentsModule } from "./payments/payments.module";
 import { HealthController } from "./health.controller";
 import { SessionMiddleware } from "./auth/session.middleware";
 import { AllExceptionsFilter } from "./common";
@@ -75,6 +76,7 @@ import { PlanGuard } from "./common/guards/plan.guard";
     ActivityModule,
     CommentsModule,
     LabelsModule,
+    PaymentsModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/apps/api/src/billing/billing.module.ts
+++ b/apps/api/src/billing/billing.module.ts
@@ -7,6 +7,6 @@ import { WebhookController } from "./webhook.controller";
 @Module({
   controllers: [BillingController, WebhookController],
   providers: [BillingService, StripeService],
-  exports: [BillingService],
+  exports: [BillingService, StripeService],
 })
 export class BillingModule {}

--- a/apps/api/src/invoices/invoices.service.ts
+++ b/apps/api/src/invoices/invoices.service.ts
@@ -318,6 +318,12 @@ export class InvoicesService {
     });
     if (!invoice) throw new NotFoundException("Invoice not found");
 
+    if (invoice.stripePaymentIntentId) {
+      throw new BadRequestException(
+        "Cannot delete an invoice that was paid via Stripe. The payment record must be preserved.",
+      );
+    }
+
     await this.prisma.invoice.delete({ where: { id, organizationId: orgId } });
   }
 

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -6,6 +6,7 @@ import {
   ProjectUpdateEmail,
   TaskAssignedEmail,
   InvoiceSentEmail,
+  InvoicePaidEmail,
   DecisionClosedEmail,
   DocumentUploadedEmail,
   DocumentRespondedEmail,
@@ -16,6 +17,7 @@ import { MailService } from "../mail/mail.service";
 import { PrismaService } from "../prisma/prisma.service";
 import { InAppNotificationsService } from "./in-app-notifications.service";
 import { PushService } from "./push.service";
+import { calculateInvoiceTotal } from "../payments/invoice-total";
 
 @Injectable()
 export class NotificationsService {
@@ -74,6 +76,110 @@ export class NotificationsService {
         "Failed to send invoice sent notifications",
       );
     });
+  }
+
+  /**
+   * Notify org owners/admins that an invoice was paid via Stripe.
+   * Fire-and-forget: errors are logged but never thrown.
+   */
+  notifyInvoicePaid(invoiceId: string): void {
+    this.sendInvoicePaidEmails(invoiceId).catch((err) => {
+      this.logger.error(
+        { err, invoiceId },
+        "Failed to send invoice paid notifications",
+      );
+    });
+  }
+
+  private async sendInvoicePaidEmails(invoiceId: string): Promise<void> {
+    const invoice = await this.prisma.invoice.findUnique({
+      where: { id: invoiceId },
+      include: {
+        lineItems: { select: { quantity: true, unitPrice: true } },
+        project: { select: { id: true, name: true } },
+      },
+    });
+    if (!invoice) return;
+
+    const totalCents = calculateInvoiceTotal(invoice);
+    const amount = `$${(totalCents / 100).toFixed(2)}`;
+    const projectName = invoice.project?.name ?? "Unknown project";
+
+    const admins = await this.getOrgAdmins(invoice.organizationId, true);
+    if (admins.length === 0) return;
+
+    const dashboardUrl = invoice.project
+      ? `${this.webUrl}/dashboard/projects/${invoice.project.id}`
+      : `${this.webUrl}/dashboard`;
+    const link = invoice.project
+      ? `/dashboard/projects/${invoice.project.id}`
+      : `/dashboard`;
+
+    // In-app + push
+    this.createInAppAndPush(
+      admins.map((a) => a.userId),
+      invoice.organizationId,
+      "invoice_paid",
+      `Invoice ${invoice.invoiceNumber} paid`,
+      `${amount} received for ${projectName}`,
+      link,
+    );
+
+    await Promise.allSettled(
+      admins.map(async (admin) => {
+        try {
+          const html = await render(
+            InvoicePaidEmail({
+              recipientName: admin.user.name,
+              invoiceNumber: invoice.invoiceNumber,
+              amount,
+              projectName,
+              dashboardUrl,
+            }),
+          );
+          await this.mail.send(
+            admin.user.email,
+            `Invoice ${invoice.invoiceNumber} paid — ${amount}`,
+            html,
+            invoice.organizationId,
+          );
+        } catch (err) {
+          this.logger.warn(
+            { err, email: admin.user.email, invoiceId },
+            "Failed to send invoice paid email to admin",
+          );
+        }
+      }),
+    );
+  }
+
+  /**
+   * Notify org owners that their Stripe account was disconnected externally.
+   * Fire-and-forget.
+   */
+  notifyStripeDisconnected(organizationId: string): void {
+    this.sendStripeDisconnectedNotifications(organizationId).catch((err) => {
+      this.logger.error(
+        { err, organizationId },
+        "Failed to send Stripe disconnected notifications",
+      );
+    });
+  }
+
+  private async sendStripeDisconnectedNotifications(
+    organizationId: string,
+  ): Promise<void> {
+    const admins = await this.getOrgAdmins(organizationId);
+    if (admins.length === 0) return;
+
+    this.createInAppAndPush(
+      admins.map((a) => a.userId),
+      organizationId,
+      "stripe_disconnected",
+      "Stripe account disconnected",
+      "Your Stripe account was disconnected. Clients can no longer pay invoices online. Reconnect from Settings.",
+      "/dashboard/settings/system",
+    );
   }
 
   private async sendProjectUpdateEmails(
@@ -292,14 +398,7 @@ export class NotificationsService {
     const clients = await this.getProjectClients(invoice.projectId);
     if (clients.length === 0) return;
 
-    const totalCents =
-      invoice.type === "uploaded" && invoice.amount != null
-        ? invoice.amount
-        : invoice.lineItems.reduce(
-            (sum: number, item: { quantity: number; unitPrice: number }) =>
-              sum + item.quantity * item.unitPrice,
-            0,
-          );
+    const totalCents = calculateInvoiceTotal(invoice);
     const amount = `$${(totalCents / 100).toFixed(2)}`;
     const dueDate = invoice.dueDate
       ? invoice.dueDate.toLocaleDateString("en-US", {
@@ -475,16 +574,7 @@ export class NotificationsService {
 
     const clientName = respondent?.name || "A client";
 
-    const admins = await this.prisma.member.findMany({
-      where: {
-        organizationId: doc.organizationId,
-        role: { in: ["owner", "admin"] },
-      },
-      select: {
-        userId: true,
-        user: { select: { name: true, email: true } },
-      },
-    });
+    const admins = await this.getOrgAdmins(doc.organizationId, true);
     if (admins.length === 0) return;
 
     const dashboardUrl = `${this.webUrl}/dashboard/projects/${doc.projectId}`;
@@ -755,14 +845,7 @@ export class NotificationsService {
     const isClientComment = authorRole === "member";
 
     if (isClientComment) {
-      // Notify org owners/admins
-      const admins = await this.prisma.member.findMany({
-        where: {
-          organizationId,
-          role: { in: ["owner", "admin"] },
-        },
-        select: { userId: true },
-      });
+      const admins = await this.getOrgAdmins(organizationId);
       const adminIds = admins.map((a) => a.userId);
       if (adminIds.length === 0) return;
 
@@ -793,9 +876,27 @@ export class NotificationsService {
     }
   }
 
-  /**
-   * Fetch all client users assigned to a project with their name + email.
-   */
+  private async getOrgAdmins(
+    organizationId: string,
+    includeDetails?: false,
+  ): Promise<Array<{ userId: string }>>;
+  private async getOrgAdmins(
+    organizationId: string,
+    includeDetails: true,
+  ): Promise<Array<{ userId: string; user: { name: string; email: string } }>>;
+  private async getOrgAdmins(organizationId: string, includeDetails = false) {
+    return this.prisma.member.findMany({
+      where: {
+        organizationId,
+        role: { in: ["owner", "admin"] },
+      },
+      select: {
+        userId: true,
+        ...(includeDetails && { user: { select: { name: true, email: true } } }),
+      },
+    });
+  }
+
   private async getProjectClients(
     projectId: string,
   ): Promise<Array<{ id: string; name: string; email: string }>> {

--- a/apps/api/src/payments/connect-webhook.controller.ts
+++ b/apps/api/src/payments/connect-webhook.controller.ts
@@ -1,0 +1,79 @@
+import {
+  Controller,
+  Post,
+  Param,
+  Req,
+  RawBodyRequest,
+  BadRequestException,
+  Logger,
+} from "@nestjs/common";
+import { SkipThrottle } from "@nestjs/throttler";
+import { Request } from "express";
+import { Public } from "../common";
+import { StripeService } from "../billing/stripe.service";
+import { PaymentsService } from "./payments.service";
+
+@Controller("payments")
+export class ConnectWebhookController {
+  private readonly logger = new Logger(ConnectWebhookController.name);
+
+  constructor(
+    private paymentsService: PaymentsService,
+    private stripeService: StripeService,
+  ) {}
+
+  /** Connect mode webhook (platform-level, no org in path). */
+  @Post("webhook")
+  @Public()
+  @SkipThrottle()
+  async handleConnectWebhook(@Req() req: RawBodyRequest<Request>) {
+    const sig = req.headers["stripe-signature"] as string;
+    const rawBody = req.rawBody;
+    if (!sig || !rawBody) {
+      throw new BadRequestException("Missing webhook signature or body");
+    }
+
+    const secret = this.paymentsService.getConnectWebhookSecret();
+    if (!secret) {
+      throw new BadRequestException("Connect webhook secret not configured");
+    }
+
+    try {
+      const event = this.stripeService.stripe.webhooks.constructEvent(rawBody, sig, secret);
+      await this.paymentsService.handleWebhookEvent(event);
+      return { received: true };
+    } catch (err) {
+      this.logger.error("Connect webhook verification failed", err);
+      throw new BadRequestException("Webhook signature verification failed");
+    }
+  }
+
+  /** Direct keys mode webhook (org-scoped, secret from DB). */
+  @Post("webhook/:orgId")
+  @Public()
+  @SkipThrottle()
+  async handleDirectWebhook(
+    @Param("orgId") orgId: string,
+    @Req() req: RawBodyRequest<Request>,
+  ) {
+    const sig = req.headers["stripe-signature"] as string;
+    const rawBody = req.rawBody;
+    if (!sig || !rawBody) {
+      throw new BadRequestException("Missing webhook signature or body");
+    }
+
+    const secret = await this.paymentsService.getOrgWebhookSecret(orgId);
+    if (!secret) {
+      throw new BadRequestException("Webhook secret not found for this organization");
+    }
+
+    try {
+      const event = this.stripeService.stripe.webhooks.constructEvent(rawBody, sig, secret);
+      await this.paymentsService.handleWebhookEvent(event, orgId);
+      return { received: true };
+    } catch (err) {
+      this.logger.error(`Direct webhook verification failed for org ${orgId}`, err);
+      throw new BadRequestException("Webhook signature verification failed");
+    }
+  }
+}

--- a/apps/api/src/payments/invoice-total.ts
+++ b/apps/api/src/payments/invoice-total.ts
@@ -1,0 +1,17 @@
+/**
+ * Calculate the total amount in cents for an invoice.
+ * Works for both uploaded (fixed amount) and itemized (line items) invoices.
+ */
+export function calculateInvoiceTotal(invoice: {
+  type: string;
+  amount?: number | null;
+  lineItems: Array<{ quantity: number; unitPrice: number }>;
+}): number {
+  if (invoice.type === "uploaded" && invoice.amount != null) {
+    return invoice.amount;
+  }
+  return invoice.lineItems.reduce(
+    (sum, item) => sum + item.quantity * item.unitPrice,
+    0,
+  );
+}

--- a/apps/api/src/payments/payments.controller.ts
+++ b/apps/api/src/payments/payments.controller.ts
@@ -1,0 +1,109 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  Res,
+  UseGuards,
+} from "@nestjs/common";
+import { Response } from "express";
+import { PaymentsService } from "./payments.service";
+import { CreateCheckoutDto, ConnectAuthorizeDto, SaveDirectKeysDto } from "./payments.dto";
+import { AuthGuard, RolesGuard, Roles, CurrentUser, CurrentOrg, Public } from "../common";
+
+@Controller("payments")
+@UseGuards(AuthGuard, RolesGuard)
+export class PaymentsController {
+  constructor(private paymentsService: PaymentsService) {}
+
+  // ── Unified status ──
+
+  @Get("status")
+  @Roles("owner")
+  getPaymentStatus(@CurrentOrg("id") orgId: string) {
+    return this.paymentsService.getPaymentStatus(orgId);
+  }
+
+  @Get("enabled")
+  async isEnabled(@CurrentOrg("id") orgId: string) {
+    const status = await this.paymentsService.getPaymentStatus(orgId);
+    return { enabled: status.enabled };
+  }
+
+  // ── Direct keys mode ──
+
+  @Post("direct/save-key")
+  @Roles("owner")
+  saveDirectKey(
+    @CurrentOrg("id") orgId: string,
+    @Body() dto: SaveDirectKeysDto,
+  ) {
+    return this.paymentsService.saveDirectKeys(orgId, dto.stripeSecretKey);
+  }
+
+  @Post("direct/remove-key")
+  @Roles("owner")
+  removeDirectKey(@CurrentOrg("id") orgId: string) {
+    return this.paymentsService.removeDirectKeys(orgId);
+  }
+
+  // ── Connect OAuth mode ──
+
+  @Post("connect/authorize")
+  @Roles("owner")
+  getAuthorizeUrl(
+    @CurrentOrg("id") orgId: string,
+    @Body() dto: ConnectAuthorizeDto,
+  ) {
+    return this.paymentsService.getConnectAuthorizeUrl(orgId, dto.returnUrl);
+  }
+
+  @Get("connect/callback")
+  @Public()
+  async handleCallback(
+    @Query("code") code: string,
+    @Query("state") state: string,
+    @Query("error") error: string,
+    @Res() res: Response,
+  ) {
+    if (error || !code) {
+      res.redirect(this.paymentsService.buildOAuthErrorRedirect(error));
+      return;
+    }
+
+    try {
+      // Auth is via HMAC-signed state (orgId embedded + verified), not session
+      const { returnUrl } = await this.paymentsService.handleOAuthCallback(code, state);
+      const separator = returnUrl.includes("?") ? "&" : "?";
+      res.redirect(`${returnUrl}${separator}stripe=connected`);
+    } catch {
+      res.redirect(this.paymentsService.buildOAuthErrorRedirect());
+    }
+  }
+
+  @Post("connect/disconnect")
+  @Roles("owner")
+  disconnect(@CurrentOrg("id") orgId: string) {
+    return this.paymentsService.disconnectAccount(orgId);
+  }
+
+  // ── Checkout (any authenticated user — access checked at service level) ──
+
+  @Post("checkout/:invoiceId")
+  createCheckout(
+    @Param("invoiceId") invoiceId: string,
+    @CurrentUser("id") userId: string,
+    @CurrentOrg("id") orgId: string,
+    @Body() dto: CreateCheckoutDto,
+  ) {
+    return this.paymentsService.createCheckoutSession(
+      invoiceId,
+      userId,
+      orgId,
+      dto.successUrl,
+      dto.cancelUrl,
+    );
+  }
+}

--- a/apps/api/src/payments/payments.dto.ts
+++ b/apps/api/src/payments/payments.dto.ts
@@ -1,0 +1,30 @@
+import { IsString, IsUrl, MaxLength, MinLength } from "class-validator";
+
+const urlOptions = {
+  protocols: ["https", "http"],
+  require_protocol: true,
+  require_tld: false,
+};
+
+export class CreateCheckoutDto {
+  @IsString()
+  @IsUrl(urlOptions, { message: "successUrl must be a valid HTTP(S) URL" })
+  successUrl!: string;
+
+  @IsString()
+  @IsUrl(urlOptions, { message: "cancelUrl must be a valid HTTP(S) URL" })
+  cancelUrl!: string;
+}
+
+export class ConnectAuthorizeDto {
+  @IsString()
+  @IsUrl(urlOptions, { message: "returnUrl must be a valid HTTP(S) URL" })
+  returnUrl!: string;
+}
+
+export class SaveDirectKeysDto {
+  @IsString()
+  @MinLength(20)
+  @MaxLength(500)
+  stripeSecretKey!: string;
+}

--- a/apps/api/src/payments/payments.module.ts
+++ b/apps/api/src/payments/payments.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { BillingModule } from "../billing/billing.module";
+import { NotificationsModule } from "../notifications/notifications.module";
+import { SettingsModule } from "../settings/settings.module";
+import { PaymentsController } from "./payments.controller";
+import { ConnectWebhookController } from "./connect-webhook.controller";
+import { PaymentsService } from "./payments.service";
+
+@Module({
+  imports: [BillingModule, NotificationsModule, SettingsModule],
+  controllers: [PaymentsController, ConnectWebhookController],
+  providers: [PaymentsService],
+  exports: [PaymentsService],
+})
+export class PaymentsModule {}

--- a/apps/api/src/payments/payments.service.ts
+++ b/apps/api/src/payments/payments.service.ts
@@ -1,0 +1,602 @@
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+  ForbiddenException,
+  Logger,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { createHmac, timingSafeEqual } from "crypto";
+import Stripe from "stripe";
+import { PrismaService } from "../prisma/prisma.service";
+import { StripeService } from "../billing/stripe.service";
+import { SettingsService } from "../settings/settings.service";
+import { NotificationsService } from "../notifications/notifications.service";
+import { calculateInvoiceTotal } from "./invoice-total";
+
+interface StripeConfig {
+  stripe: Stripe;
+  stripeAccount?: string;
+}
+
+@Injectable()
+export class PaymentsService {
+  private readonly logger = new Logger(PaymentsService.name);
+  private readonly webUrl: string;
+  private readonly apiUrl: string;
+  private readonly appOrigin: string;
+  private readonly currency: string;
+  private readonly hmacSecret: string;
+
+  private static readonly PAYMENTS_CLEAR_DATA = {
+    stripeSecretKey: null,
+    stripeWebhookSecret: null,
+    stripeConnectAccountId: null,
+    stripeConnectEnabled: false,
+    stripeConnectLivemode: false,
+  } as const;
+
+  constructor(
+    private prisma: PrismaService,
+    private stripeService: StripeService,
+    private settingsService: SettingsService,
+    private config: ConfigService,
+    private notifications: NotificationsService,
+  ) {
+    this.webUrl = this.config.get("WEB_URL", "http://localhost:3000");
+    this.apiUrl = this.config.get("API_URL", "http://localhost:3001");
+    this.appOrigin = new URL(this.webUrl).origin;
+    this.currency = this.config.get("STRIPE_CURRENCY", "usd").toLowerCase();
+    this.hmacSecret = this.config.getOrThrow<string>("BETTER_AUTH_SECRET");
+  }
+
+  // ── Helpers ──
+
+  isConnectMode(): boolean {
+    return !!this.config.get<string>("STRIPE_CONNECT_CLIENT_ID");
+  }
+
+  private async getStripeConfig(orgId: string): Promise<StripeConfig> {
+    const settings = await this.prisma.systemSettings.findUnique({
+      where: { organizationId: orgId },
+    });
+
+    // Connect mode: platform stripe instance + stripeAccount param
+    if (settings?.stripeConnectEnabled && settings.stripeConnectAccountId) {
+      return {
+        stripe: this.stripeService.stripe,
+        stripeAccount: settings.stripeConnectAccountId,
+      };
+    }
+
+    // Direct keys mode: agency's own stripe instance
+    if (settings?.stripeSecretKey) {
+      const key = this.settingsService.decrypt(settings.stripeSecretKey);
+      if (!key) {
+        throw new BadRequestException("Failed to decrypt Stripe key. Re-enter your key in Settings.");
+      }
+      return { stripe: new Stripe(key) };
+    }
+
+    throw new BadRequestException("Online payments are not configured");
+  }
+
+  private signState(payload: string): string {
+    return `${payload}.${createHmac("sha256", this.hmacSecret).update(payload).digest("base64url")}`;
+  }
+
+  private verifyState(state: string): string {
+    const lastDot = state.lastIndexOf(".");
+    if (lastDot === -1) throw new BadRequestException("Invalid OAuth state");
+    const payload = state.slice(0, lastDot);
+    const sig = state.slice(lastDot + 1);
+    const expected = createHmac("sha256", this.hmacSecret).update(payload).digest("base64url");
+    if (
+      sig.length !== expected.length ||
+      !timingSafeEqual(Buffer.from(sig), Buffer.from(expected))
+    ) {
+      throw new BadRequestException("Invalid OAuth state signature");
+    }
+    return payload;
+  }
+
+  private validateAppUrl(url: string): void {
+    try {
+      const parsed = new URL(url);
+      if (parsed.origin !== this.appOrigin) {
+        throw new BadRequestException("URL must be on the application domain");
+      }
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      throw new BadRequestException("Invalid URL");
+    }
+  }
+
+  buildOAuthErrorRedirect(error?: string): string {
+    const status = error === "access_denied" ? "cancelled" : "error";
+    return `${this.webUrl}/dashboard/settings/system?stripe=${status}`;
+  }
+
+  // ── Unified status ──
+
+  async getPaymentStatus(orgId: string) {
+    const settings = await this.prisma.systemSettings.findUnique({
+      where: { organizationId: orgId },
+    });
+    const connectMode = this.isConnectMode();
+
+    if (connectMode && settings?.stripeConnectAccountId) {
+      return {
+        mode: "connect" as const,
+        enabled: settings.stripeConnectEnabled,
+        livemode: settings.stripeConnectLivemode,
+      };
+    }
+
+    if (settings?.stripeSecretKey) {
+      return {
+        mode: "direct" as const,
+        enabled: settings.stripeConnectEnabled,
+        livemode: settings.stripeConnectLivemode,
+      };
+    }
+
+    return {
+      mode: connectMode ? ("connect" as const) : ("direct" as const),
+      enabled: false,
+      livemode: false,
+    };
+  }
+
+  // ── Direct Keys mode ──
+
+  async saveDirectKeys(orgId: string, secretKey: string) {
+    if (!secretKey.startsWith("sk_test_") && !secretKey.startsWith("sk_live_") && !secretKey.startsWith("rk_test_") && !secretKey.startsWith("rk_live_")) {
+      throw new BadRequestException("Invalid Stripe key format. Use a secret key (sk_) or restricted key (rk_).");
+    }
+
+    const livemode = secretKey.startsWith("sk_live_") || secretKey.startsWith("rk_live_");
+
+    // Clean up old webhook if replacing an existing key
+    const existing = await this.prisma.systemSettings.findUnique({
+      where: { organizationId: orgId },
+      select: { stripeSecretKey: true },
+    });
+    if (existing?.stripeSecretKey) {
+      try {
+        const oldKey = this.settingsService.decrypt(existing.stripeSecretKey);
+        if (oldKey) {
+          const oldStripe = new Stripe(oldKey);
+          const webhookUrl = `${this.apiUrl}/api/payments/webhook/${orgId}`;
+          const endpoints = await oldStripe.webhookEndpoints.list({ limit: 100 });
+          for (const ep of endpoints.data) {
+            if (ep.url === webhookUrl) await oldStripe.webhookEndpoints.del(ep.id);
+          }
+        }
+      } catch {
+        // Best-effort cleanup
+      }
+    }
+
+    const encrypted = this.settingsService.encrypt(secretKey);
+
+    const stripe = new Stripe(secretKey);
+    try {
+      await stripe.balance.retrieve();
+    } catch {
+      throw new BadRequestException("Invalid Stripe key. Could not connect to your Stripe account.");
+    }
+
+    // Auto-register webhook endpoint on the agency's Stripe account
+    const webhookUrl = `${this.apiUrl}/api/payments/webhook/${orgId}`;
+    let webhookSecret: string;
+    try {
+      const endpoint = await stripe.webhookEndpoints.create({
+        url: webhookUrl,
+        enabled_events: [
+          "checkout.session.completed",
+          "checkout.session.expired",
+        ],
+      });
+      if (!endpoint.secret) {
+        throw new Error("Stripe did not return a webhook signing secret");
+      }
+      webhookSecret = endpoint.secret;
+    } catch (err) {
+      this.logger.error("Failed to register webhook endpoint", err);
+      throw new BadRequestException(
+        "Failed to register webhook on your Stripe account. Check that your API URL is publicly accessible.",
+      );
+    }
+
+    await this.prisma.systemSettings.upsert({
+      where: { organizationId: orgId },
+      create: {
+        organizationId: orgId,
+        stripeSecretKey: encrypted,
+        stripeWebhookSecret: this.settingsService.encrypt(webhookSecret),
+        stripeConnectEnabled: true,
+        stripeConnectLivemode: livemode,
+      },
+      update: {
+        stripeSecretKey: encrypted,
+        stripeWebhookSecret: this.settingsService.encrypt(webhookSecret),
+        stripeConnectEnabled: true,
+        stripeConnectLivemode: livemode,
+        // Clear any Connect fields
+        stripeConnectAccountId: null,
+      },
+    });
+
+    this.logger.log(`Saved direct Stripe key for org ${orgId} (livemode: ${livemode})`);
+    return { livemode };
+  }
+
+  async removeDirectKeys(orgId: string) {
+    const settings = await this.prisma.systemSettings.findUnique({
+      where: { organizationId: orgId },
+    });
+
+    if (!settings?.stripeSecretKey) {
+      throw new BadRequestException("No Stripe key configured");
+    }
+
+    // Try to clean up the webhook endpoint on Stripe's side
+    try {
+      const key = this.settingsService.decrypt(settings.stripeSecretKey);
+      const stripe = new Stripe(key);
+      const webhookUrl = `${this.apiUrl}/api/payments/webhook/${orgId}`;
+      const endpoints = await stripe.webhookEndpoints.list({ limit: 100 });
+      for (const ep of endpoints.data) {
+        if (ep.url === webhookUrl) {
+          await stripe.webhookEndpoints.del(ep.id);
+        }
+      }
+    } catch (err) {
+      this.logger.warn("Failed to delete webhook endpoint on Stripe side", err);
+    }
+
+    await this.prisma.systemSettings.update({
+      where: { organizationId: orgId },
+      data: PaymentsService.PAYMENTS_CLEAR_DATA,
+    });
+
+    this.logger.log(`Removed direct Stripe key for org ${orgId}`);
+  }
+
+  // ── Stripe Connect OAuth ──
+
+  async getConnectAuthorizeUrl(orgId: string, returnUrl: string) {
+    this.validateAppUrl(returnUrl);
+
+    const clientId = this.config.get<string>("STRIPE_CONNECT_CLIENT_ID");
+    if (!clientId) {
+      throw new BadRequestException("Stripe Connect is not configured.");
+    }
+
+    const payload = `${orgId}:${Buffer.from(returnUrl).toString("base64url")}`;
+    const state = this.signState(payload);
+
+    const params = new URLSearchParams({
+      response_type: "code",
+      client_id: clientId,
+      scope: "read_write",
+      state,
+    });
+
+    return {
+      url: `https://connect.stripe.com/oauth/authorize?${params.toString()}`,
+    };
+  }
+
+  async handleOAuthCallback(code: string, state: string) {
+    const payload = this.verifyState(state);
+    const colonIdx = payload.indexOf(":");
+    if (colonIdx === -1) throw new BadRequestException("Invalid OAuth state");
+
+    const orgId = payload.slice(0, colonIdx);
+    const returnUrlB64 = payload.slice(colonIdx + 1);
+    const returnUrl = Buffer.from(returnUrlB64, "base64url").toString();
+    this.validateAppUrl(returnUrl);
+
+    try {
+      const response = await this.stripeService.stripe.oauth.token({
+        grant_type: "authorization_code",
+        code,
+      });
+
+      const accountId = response.stripe_user_id;
+      if (!accountId) throw new BadRequestException("No account ID returned from Stripe");
+
+      await this.prisma.systemSettings.upsert({
+        where: { organizationId: orgId },
+        create: {
+          organizationId: orgId,
+          stripeConnectAccountId: accountId,
+          stripeConnectEnabled: true,
+          stripeConnectLivemode: response.livemode ?? false,
+        },
+        update: {
+          stripeConnectAccountId: accountId,
+          stripeConnectEnabled: true,
+          stripeConnectLivemode: response.livemode ?? false,
+          stripeSecretKey: null,
+          stripeWebhookSecret: null,
+        },
+      });
+
+      this.logger.log(`Connected Stripe account ${accountId} for org ${orgId}`);
+      return { returnUrl };
+    } catch (err) {
+      if (err instanceof BadRequestException || err instanceof ForbiddenException) throw err;
+      this.logger.error("Stripe Connect OAuth failed", err);
+      throw new BadRequestException("Failed to connect Stripe account");
+    }
+  }
+
+  async disconnectAccount(orgId: string) {
+    const settings = await this.prisma.systemSettings.findUnique({
+      where: { organizationId: orgId },
+    });
+
+    if (!settings?.stripeConnectAccountId) {
+      throw new BadRequestException("No Stripe account connected");
+    }
+
+    const clientId = this.config.get<string>("STRIPE_CONNECT_CLIENT_ID");
+    if (clientId) {
+      try {
+        await this.stripeService.stripe.oauth.deauthorize({
+          client_id: clientId,
+          stripe_user_id: settings.stripeConnectAccountId,
+        });
+      } catch (err) {
+        this.logger.warn("Failed to deauthorize on Stripe side", err);
+      }
+    }
+
+    await this.prisma.systemSettings.update({
+      where: { organizationId: orgId },
+      data: PaymentsService.PAYMENTS_CLEAR_DATA,
+    });
+
+    this.logger.log(`Disconnected Stripe account for org ${orgId}`);
+  }
+
+  // ── Invoice Checkout (mode-agnostic) ──
+
+  async createCheckoutSession(
+    invoiceId: string,
+    userId: string,
+    orgId: string,
+    successUrl: string,
+    cancelUrl: string,
+  ) {
+    this.validateAppUrl(successUrl);
+    this.validateAppUrl(cancelUrl);
+
+    const [config, invoice] = await Promise.all([
+      this.getStripeConfig(orgId),
+      this.prisma.invoice.findFirst({
+        where: { id: invoiceId, organizationId: orgId },
+        include: { lineItems: true },
+      }),
+    ]);
+
+    if (!invoice) throw new NotFoundException("Invoice not found");
+
+    if (invoice.projectId) {
+      const assignment = await this.prisma.projectClient.findFirst({
+        where: { projectId: invoice.projectId, userId },
+      });
+      if (!assignment) throw new ForbiddenException("Not assigned to this project");
+    } else {
+      throw new ForbiddenException("Invoice has no associated project");
+    }
+
+    if (!["sent", "overdue"].includes(invoice.status)) {
+      throw new BadRequestException(`Invoice is ${invoice.status} and cannot be paid`);
+    }
+
+    // Reuse existing open session
+    if (invoice.stripeCheckoutSessionId) {
+      try {
+        const existingSession = await config.stripe.checkout.sessions.retrieve(
+          invoice.stripeCheckoutSessionId,
+          config.stripeAccount ? { stripeAccount: config.stripeAccount } : undefined,
+        );
+        if (existingSession.status === "open" && existingSession.url) {
+          return { url: existingSession.url };
+        }
+      } catch {
+        // Session expired or invalid, create a new one
+      }
+    }
+
+    const totalCents = calculateInvoiceTotal(invoice);
+    if (totalCents <= 0) {
+      throw new BadRequestException("Invoice total must be greater than zero");
+    }
+
+    const lineItems =
+      invoice.type === "uploaded" || invoice.lineItems.length === 0
+        ? [{
+            price_data: {
+              currency: this.currency,
+              product_data: { name: `Invoice ${invoice.invoiceNumber}` },
+              unit_amount: totalCents,
+            },
+            quantity: 1,
+          }]
+        : invoice.lineItems.map((li) => ({
+            price_data: {
+              currency: this.currency,
+              product_data: { name: li.description },
+              unit_amount: li.unitPrice,
+            },
+            quantity: li.quantity,
+          }));
+
+    const session = await config.stripe.checkout.sessions.create(
+      {
+        mode: "payment",
+        line_items: lineItems,
+        success_url: successUrl,
+        cancel_url: cancelUrl,
+        metadata: {
+          invoiceId: invoice.id,
+          organizationId: orgId,
+        },
+        payment_intent_data: {
+          metadata: {
+            invoiceId: invoice.id,
+            organizationId: orgId,
+          },
+        },
+      },
+      config.stripeAccount ? { stripeAccount: config.stripeAccount } : undefined,
+    );
+
+    await this.prisma.invoice.updateMany({
+      where: {
+        id: invoice.id,
+        stripeCheckoutSessionId: invoice.stripeCheckoutSessionId,
+      },
+      data: { stripeCheckoutSessionId: session.id },
+    });
+
+    return { url: session.url };
+  }
+
+  // ── Webhook handling (mode-agnostic) ──
+
+  getConnectWebhookSecret(): string | undefined {
+    return this.config.get<string>("STRIPE_CONNECT_WEBHOOK_SECRET");
+  }
+
+  async getOrgWebhookSecret(orgId: string): Promise<string | null> {
+    const settings = await this.prisma.systemSettings.findUnique({
+      where: { organizationId: orgId },
+      select: { stripeWebhookSecret: true },
+    });
+    if (!settings?.stripeWebhookSecret) return null;
+    const decrypted = this.settingsService.decrypt(settings.stripeWebhookSecret);
+    if (!decrypted) return null;
+    return decrypted;
+  }
+
+  async handleWebhookEvent(event: Stripe.Event, verifiedOrgId?: string) {
+    switch (event.type) {
+      case "checkout.session.completed":
+        await this.handleCheckoutCompleted(
+          event.data.object as unknown as Record<string, unknown>,
+          event.account,
+          verifiedOrgId,
+        );
+        break;
+      case "account.application.deauthorized":
+        await this.handleAccountDeauthorized(event.account);
+        break;
+      case "checkout.session.expired":
+        await this.handleCheckoutExpired(
+          event.data.object as unknown as Record<string, unknown>,
+        );
+        break;
+    }
+  }
+
+  private async handleAccountDeauthorized(connectedAccountId?: string) {
+    if (!connectedAccountId) return;
+
+    const settings = await this.prisma.systemSettings.findFirst({
+      where: { stripeConnectAccountId: connectedAccountId },
+    });
+    if (!settings) return;
+
+    await this.prisma.systemSettings.update({
+      where: { id: settings.id },
+      data: PaymentsService.PAYMENTS_CLEAR_DATA,
+    });
+
+    this.logger.log(
+      `Stripe account ${connectedAccountId} deauthorized — disabled payments for org ${settings.organizationId}`,
+    );
+    this.notifications.notifyStripeDisconnected(settings.organizationId);
+  }
+
+  private async handleCheckoutExpired(session: Record<string, unknown>) {
+    const metadata = session.metadata as
+      | { invoiceId?: string }
+      | undefined;
+    if (!metadata?.invoiceId) return;
+
+    await this.prisma.invoice.updateMany({
+      where: {
+        id: metadata.invoiceId,
+        stripeCheckoutSessionId: session.id as string,
+      },
+      data: { stripeCheckoutSessionId: null },
+    });
+
+    this.logger.log(`Checkout session expired for invoice ${metadata.invoiceId}`);
+  }
+
+  private async handleCheckoutCompleted(
+    session: Record<string, unknown>,
+    connectedAccountId?: string,
+    verifiedOrgId?: string,
+  ) {
+    const metadata = session.metadata as
+      | { invoiceId?: string; organizationId?: string }
+      | undefined;
+    if (!metadata?.invoiceId || !metadata?.organizationId) return;
+
+    // In direct mode, verify metadata orgId matches the org whose webhook secret verified the signature
+    if (verifiedOrgId && metadata.organizationId !== verifiedOrgId) {
+      this.logger.warn(
+        `Webhook org mismatch: metadata says ${metadata.organizationId} but webhook secret belongs to ${verifiedOrgId}`,
+      );
+      return;
+    }
+
+    // In Connect mode, verify the connected account matches
+    if (connectedAccountId) {
+      const settings = await this.prisma.systemSettings.findUnique({
+        where: { organizationId: metadata.organizationId },
+      });
+      if (settings?.stripeConnectAccountId !== connectedAccountId) {
+        this.logger.warn(
+          `Webhook account ${connectedAccountId} does not match org ${metadata.organizationId}`,
+        );
+        return;
+      }
+    }
+
+    const invoice = await this.prisma.invoice.findFirst({
+      where: {
+        id: metadata.invoiceId,
+        organizationId: metadata.organizationId,
+      },
+      include: { lineItems: true },
+    });
+    if (!invoice) return;
+
+    const totalCents = calculateInvoiceTotal(invoice);
+
+    // Idempotent update: only mark as paid if not already paid
+    const result = await this.prisma.invoice.updateMany({
+      where: { id: invoice.id, status: { not: "paid" } },
+      data: {
+        status: "paid",
+        paidAt: new Date(),
+        paidAmount: (session.amount_total as number) ?? totalCents,
+        stripePaymentIntentId: (session.payment_intent as string) ?? null,
+      },
+    });
+
+    if (result.count === 0) return; // Already processed
+
+    this.logger.log(`Invoice ${invoice.invoiceNumber} marked as paid via Stripe`);
+    this.notifications.notifyInvoicePaid(invoice.id);
+  }
+}

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -24,7 +24,7 @@ export class SettingsService {
     );
   }
 
-  private encrypt(plaintext: string): string {
+  encrypt(plaintext: string): string {
     const iv = randomBytes(16);
     const cipher = createCipheriv(ENCRYPTION_ALGORITHM, this.encryptionKey, iv);
     const encrypted = Buffer.concat([
@@ -36,7 +36,7 @@ export class SettingsService {
     return `${iv.toString("hex")}:${authTag.toString("hex")}:${encrypted.toString("hex")}`;
   }
 
-  private decrypt(encryptedValue: string): string {
+  decrypt(encryptedValue: string): string {
     try {
       const [ivHex, authTagHex, ciphertextHex] = encryptedValue.split(":");
       const iv = Buffer.from(ivHex, "hex");
@@ -67,6 +67,8 @@ export class SettingsService {
       resendApiKey: settings.resendApiKey ? "••••••••" : null,
       smtpPass: settings.smtpPass ? "••••••••" : null,
       paymentDetails: settings.paymentDetails ? "••••••••" : null,
+      stripeSecretKey: settings.stripeSecretKey ? "••••••••" : null,
+      stripeWebhookSecret: settings.stripeWebhookSecret ? "••••••••" : null,
     };
   }
 
@@ -106,6 +108,8 @@ export class SettingsService {
       resendApiKey: settings.resendApiKey ? "••••••••" : null,
       smtpPass: settings.smtpPass ? "••••••••" : null,
       paymentDetails: settings.paymentDetails ? "••••••••" : null,
+      stripeSecretKey: settings.stripeSecretKey ? "••••••••" : null,
+      stripeWebhookSecret: settings.stripeWebhookSecret ? "••••••••" : null,
     };
   }
 
@@ -117,6 +121,7 @@ export class SettingsService {
     return {
       paymentInstructions: settings?.paymentInstructions ?? null,
       paymentMethod: settings?.paymentMethod ?? null,
+      stripeConnectEnabled: settings?.stripeConnectEnabled ?? false,
     };
   }
 

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/invoices-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/invoices-section.tsx
@@ -30,6 +30,9 @@ interface InvoiceListItem {
   uploadedFile?: { id: string; filename: string; sizeBytes: number } | null;
   lineItems: LineItem[];
   createdAt: string;
+  paidAt?: string | null;
+  paidAmount?: number | null;
+  stripePaymentIntentId?: string | null;
 }
 
 interface InvoiceStats {
@@ -616,7 +619,7 @@ export function InvoicesSection({
                           Mark as Sent
                         </button>
                       )}
-                      {(inv.status === "sent" || inv.status === "overdue") && !isArchived && (
+                      {(inv.status === "sent" || inv.status === "overdue") && !isArchived && !inv.stripePaymentIntentId && (
                         <button
                           onClick={() => handleStatusChange(inv.id, "paid")}
                           className="px-3 py-1 bg-green-600 text-white rounded-lg text-xs hover:opacity-90"
@@ -639,7 +642,7 @@ export function InvoicesSection({
                           Edit
                         </button>
                       )}
-                      {!isArchived && (
+                      {!isArchived && !inv.stripePaymentIntentId && (
                         <button
                           onClick={() => handleDelete(inv.id)}
                           className="ml-auto flex items-center gap-1 text-xs text-red-500 hover:underline"
@@ -810,6 +813,23 @@ export function InvoicesSection({
                             <p className="text-sm text-[var(--muted-foreground)] whitespace-pre-wrap">
                               {inv.notes}
                             </p>
+                          </div>
+                        )}
+
+                        {/* Payment details for paid invoices */}
+                        {inv.status === "paid" && inv.paidAt && (
+                          <div className="flex items-center gap-3 p-2 bg-green-50 border border-green-200 rounded-lg text-xs">
+                            <span className="text-green-700 font-medium">
+                              {inv.stripePaymentIntentId ? "Paid via Stripe" : "Marked as paid"}
+                            </span>
+                            <span className="text-green-600">
+                              {new Date(inv.paidAt).toLocaleDateString()}
+                            </span>
+                            {inv.paidAmount != null && inv.paidAmount !== total && (
+                              <span className="text-green-600">
+                                Received: {formatCurrency(inv.paidAmount)}
+                              </span>
+                            )}
                           </div>
                         )}
                       </>

--- a/apps/web/src/app/(dashboard)/dashboard/settings/system/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/system/page.tsx
@@ -4,9 +4,10 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch } from "@/lib/api";
 import { useToast } from "@/components/toast";
-import { Mail, HardDrive, Send, Palette, Tag } from "lucide-react";
+import { Mail, HardDrive, Send, Palette, Tag, CreditCard } from "lucide-react";
 import { BrandingSection } from "./branding-section";
 import { LabelsSection } from "./labels-section";
+import { PaymentsSection } from "./payments-section";
 
 interface SystemSettings {
   emailProvider: string | null;
@@ -413,6 +414,20 @@ export default function SystemSettingsPage() {
           {saving ? "Saving..." : "Save Settings"}
         </button>
       </form>
+
+      {/* Client Payments — outside the form since it's managed via its own OAuth flow */}
+      <div className="max-w-lg space-y-8">
+        <section className="space-y-4">
+          <div className="flex items-center gap-2">
+            <CreditCard size={20} />
+            <h2 className="text-lg font-semibold">Client Payments</h2>
+          </div>
+          <p className="text-sm text-[var(--muted-foreground)]">
+            Accept invoice payments from clients via Stripe.
+          </p>
+          <PaymentsSection />
+        </section>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/settings/system/payments-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/system/payments-section.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { apiFetch } from "@/lib/api";
+import { useToast } from "@/components/toast";
+import { ExternalLink, Unlink, Key } from "lucide-react";
+
+interface PaymentStatus {
+  mode: "direct" | "connect";
+  enabled: boolean;
+  livemode: boolean;
+}
+
+const DISCONNECTED: PaymentStatus = { mode: "direct", enabled: false, livemode: false };
+
+export function PaymentsSection() {
+  const [status, setStatus] = useState<PaymentStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [secretKey, setSecretKey] = useState("");
+  const { success, error: showError, info } = useToast();
+  const connectTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    apiFetch<PaymentStatus>("/payments/status")
+      .then(setStatus)
+      .catch(() => setStatus(DISCONNECTED))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (connectTimeout.current) clearTimeout(connectTimeout.current);
+    };
+  }, []);
+
+  // Handle OAuth redirect results (Connect mode)
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const stripeParam = params.get("stripe");
+    const errorParam = params.get("error");
+
+    if (stripeParam === "connected") {
+      success("Stripe account connected successfully");
+      apiFetch<PaymentStatus>("/payments/status").then(setStatus);
+    } else if (stripeParam === "cancelled" || errorParam === "access_denied") {
+      info("Stripe connection was cancelled. You can try again whenever you're ready.");
+    } else if (stripeParam === "error") {
+      showError("Something went wrong connecting your Stripe account. Please try again.");
+    }
+
+    if (stripeParam || errorParam) {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("stripe");
+      url.searchParams.delete("error");
+      window.history.replaceState({}, "", url.toString());
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Direct Keys handlers ──
+
+  const handleSaveKey = async () => {
+    if (!secretKey.trim()) return;
+    setSaving(true);
+    try {
+      const res = await apiFetch<{ livemode: boolean }>(
+        "/payments/direct/save-key",
+        {
+          method: "POST",
+          body: JSON.stringify({ stripeSecretKey: secretKey.trim() }),
+        },
+      );
+      setSecretKey("");
+      setStatus({ mode: "direct", enabled: true, livemode: res.livemode });
+      success("Stripe key saved. Webhook registered automatically.");
+    } catch (err) {
+      showError(err instanceof Error ? err.message : "Failed to save Stripe key");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRemoveKey = async () => {
+    if (!confirm("Remove your Stripe key? Clients will no longer be able to pay invoices online.")) {
+      return;
+    }
+    setDisconnecting(true);
+    try {
+      await apiFetch("/payments/direct/remove-key", { method: "POST" });
+      setStatus(DISCONNECTED);
+      success("Stripe key removed");
+    } catch (err) {
+      showError(err instanceof Error ? err.message : "Failed to remove key");
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  // ── Connect OAuth handlers ──
+
+  const handleConnect = async () => {
+    setConnecting(true);
+    try {
+      const returnUrl = window.location.href.split("?")[0];
+      const res = await apiFetch<{ url: string }>("/payments/connect/authorize", {
+        method: "POST",
+        body: JSON.stringify({ returnUrl }),
+      });
+      connectTimeout.current = setTimeout(() => {
+        setConnecting(false);
+        showError("Redirect took too long. Please try again.");
+      }, 15000);
+      window.location.href = res.url;
+    } catch (err) {
+      showError(err instanceof Error ? err.message : "Failed to start Stripe Connect");
+      setConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    if (!confirm("Disconnect your Stripe account? Clients will no longer be able to pay invoices online.")) {
+      return;
+    }
+    setDisconnecting(true);
+    try {
+      await apiFetch("/payments/connect/disconnect", { method: "POST" });
+      setStatus({ ...DISCONNECTED, mode: "connect" });
+      success("Stripe account disconnected");
+    } catch (err) {
+      showError(err instanceof Error ? err.message : "Failed to disconnect");
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="h-24 bg-[var(--muted)] rounded-lg animate-pulse" />;
+  }
+
+  // ── Connected state (either mode) ──
+  if (status?.enabled) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 p-3 border border-[var(--border)] rounded-lg bg-[var(--muted)]">
+          <div className="w-2 h-2 rounded-full bg-green-500" />
+          <span className="text-sm font-medium">Connected</span>
+          <span className="text-xs text-[var(--muted-foreground)]">
+            {status.mode === "connect" ? "via Stripe Connect" : "via API key"}
+          </span>
+          <span
+            className={`text-xs px-2 py-0.5 rounded-full ml-auto ${
+              status.livemode
+                ? "bg-green-100 text-green-700"
+                : "bg-yellow-100 text-yellow-700"
+            }`}
+          >
+            {status.livemode ? "Live" : "Test mode"}
+          </span>
+        </div>
+        {!status.livemode && (
+          <p className="text-xs text-yellow-600">
+            Clients cannot submit real payments in test mode. Use a live Stripe key to accept real payments.
+          </p>
+        )}
+        <p className="text-xs text-[var(--muted-foreground)]">
+          Clients can pay invoices directly from the portal. Payments go to your Stripe account.
+        </p>
+        <button
+          type="button"
+          onClick={status.mode === "connect" ? handleDisconnect : handleRemoveKey}
+          disabled={disconnecting}
+          className="flex items-center gap-2 px-3 py-2 text-sm text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors"
+        >
+          <Unlink size={14} />
+          {disconnecting
+            ? "Disconnecting..."
+            : status.mode === "connect"
+              ? "Disconnect Stripe"
+              : "Remove Stripe Key"}
+        </button>
+      </div>
+    );
+  }
+
+  // ── Not connected: Connect mode ──
+  if (status?.mode === "connect") {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-[var(--muted-foreground)]">
+          Connect your Stripe account to let clients pay invoices directly from the portal.
+        </p>
+        <button
+          type="button"
+          onClick={handleConnect}
+          disabled={connecting}
+          className="flex items-center gap-2 px-4 py-2 bg-[#635bff] text-white rounded-lg text-sm font-medium hover:bg-[#5851db] transition-colors"
+        >
+          <ExternalLink size={16} />
+          {connecting ? "Redirecting..." : "Connect with Stripe"}
+        </button>
+      </div>
+    );
+  }
+
+  // ── Not connected: Direct keys mode ──
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-[var(--muted-foreground)]">
+        Enter your Stripe secret key to let clients pay invoices directly from the portal.
+        Your key is stored encrypted and never displayed again.
+      </p>
+      <div className="space-y-2">
+        <input
+          type="password"
+          value={secretKey}
+          onChange={(e) => setSecretKey(e.target.value)}
+          placeholder="sk_test_... or sk_live_..."
+          className="w-full px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm font-mono"
+        />
+        <p className="text-xs text-[var(--muted-foreground)]">
+          Find your key at{" "}
+          <a
+            href="https://dashboard.stripe.com/apikeys"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--primary)] hover:underline"
+          >
+            dashboard.stripe.com/apikeys
+          </a>
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={handleSaveKey}
+        disabled={saving || !secretKey.trim()}
+        className="flex items-center gap-2 px-4 py-2 bg-[var(--primary)] text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+      >
+        <Key size={16} />
+        {saving ? "Connecting..." : "Save & Connect"}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/(portal)/portal/projects/[id]/components/portal-invoices-section.tsx
+++ b/apps/web/src/app/(portal)/portal/projects/[id]/components/portal-invoices-section.tsx
@@ -5,7 +5,7 @@ import { apiFetch } from "@/lib/api";
 import { formatCurrency } from "@/lib/format";
 import { useToast } from "@/components/toast";
 import { Pagination } from "@/components/pagination";
-import { Receipt, Download } from "lucide-react";
+import { Receipt, Download, CreditCard } from "lucide-react";
 import { downloadFile } from "@/lib/download";
 
 interface LineItem {
@@ -36,10 +36,10 @@ interface PaginatedResponse<T> {
 }
 
 const statusColors: Record<string, { bg: string; text: string }> = {
-  draft: { bg: "#e5e7eb", text: "#374151" },
   sent: { bg: "#dbeafe", text: "#1d4ed8" },
   paid: { bg: "#dcfce7", text: "#15803d" },
   overdue: { bg: "#fee2e2", text: "#b91c1c" },
+  cancelled: { bg: "#e5e7eb", text: "#374151" },
 };
 
 export function PortalInvoicesSection({
@@ -53,11 +53,16 @@ export function PortalInvoicesSection({
   const [loading, setLoading] = useState(true);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [paymentInstructions, setPaymentInstructions] = useState<string | null>(null);
-  const { error: showError } = useToast();
+  const [stripeEnabled, setStripeEnabled] = useState(false);
+  const [payingInvoiceId, setPayingInvoiceId] = useState<string | null>(null);
+  const { success, info, error: showError } = useToast();
 
   useEffect(() => {
-    apiFetch<{ paymentInstructions: string | null }>("/settings/payment-instructions")
-      .then((res) => setPaymentInstructions(res.paymentInstructions))
+    apiFetch<{ paymentInstructions: string | null; stripeConnectEnabled: boolean }>("/settings/payment-instructions")
+      .then((res) => {
+        setPaymentInstructions(res.paymentInstructions);
+        setStripeEnabled(res.stripeConnectEnabled);
+      })
       .catch(console.error);
   }, []);
 
@@ -79,6 +84,25 @@ export function PortalInvoicesSection({
   useEffect(() => {
     loadInvoices();
   }, [loadInvoices]);
+
+  // Check for payment redirect results
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const paymentParam = params.get("payment");
+    if (paymentParam === "success") {
+      success("Payment successful! The invoice has been marked as paid.");
+      loadInvoices(); // Refresh to show updated status
+    } else if (paymentParam === "cancelled") {
+      info("Payment was not completed. You can try again below.");
+    }
+
+    if (paymentParam) {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("payment");
+      window.history.replaceState({}, "", url.toString());
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleFileDownload = async (fileId: string, filename: string) => {
     try {
@@ -109,6 +133,32 @@ export function PortalInvoicesSection({
     }
   };
 
+  const handlePayNow = async (e: React.MouseEvent, invoiceId: string) => {
+    e.stopPropagation(); // Prevent row expand/collapse
+    setPayingInvoiceId(invoiceId);
+    try {
+      const currentUrl = window.location.href.split("?")[0];
+      const res = await apiFetch<{ url: string }>(
+        `/payments/checkout/${invoiceId}`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            successUrl: `${currentUrl}?payment=success`,
+            cancelUrl: `${currentUrl}?payment=cancelled`,
+          }),
+        },
+      );
+      if (res.url) {
+        window.location.href = res.url;
+      }
+    } catch (err) {
+      showError(err instanceof Error ? err.message : "Failed to start payment");
+      setPayingInvoiceId(null);
+    }
+  };
+
+  const isPayable = (status: string) => ["sent", "overdue"].includes(status);
+
   if (loading) {
     return (
       <div>
@@ -129,7 +179,7 @@ export function PortalInvoicesSection({
       {invoices.length > 0 ? (
         <div className="space-y-2">
           {invoices.map((inv) => {
-            const colors = statusColors[inv.status] || statusColors.draft;
+            const colors = statusColors[inv.status] || { bg: "#e5e7eb", text: "#374151" };
             const total = inv.type === "uploaded"
               ? (inv.amount || 0)
               : inv.lineItems.reduce(
@@ -137,34 +187,50 @@ export function PortalInvoicesSection({
                   0,
                 );
             const isExpanded = expandedId === inv.id;
+            const expandedPanelId = `invoice-details-${inv.id}`;
 
             return (
               <div key={inv.id} className="border border-[var(--border)] rounded-lg">
-                <button
-                  onClick={() => setExpandedId(isExpanded ? null : inv.id)}
-                  className="flex items-center justify-between w-full p-3 text-left hover:bg-[var(--muted)] transition-colors rounded-lg"
-                >
-                  <span className="text-sm font-medium">{inv.invoiceNumber}</span>
-                  <div className="flex items-center gap-4">
-                    <span className="text-sm font-medium">
-                      {formatCurrency(total)}
-                    </span>
-                    {inv.dueDate && (
-                      <span className="text-xs text-[var(--muted-foreground)]">
-                        Due {new Date(inv.dueDate).toLocaleDateString()}
+                <div className="flex items-center w-full">
+                  <button
+                    onClick={() => setExpandedId(isExpanded ? null : inv.id)}
+                    aria-expanded={isExpanded}
+                    aria-controls={expandedPanelId}
+                    className="flex items-center justify-between flex-1 p-3 text-left hover:bg-[var(--muted)] transition-colors rounded-lg"
+                  >
+                    <span className="text-sm font-medium">{inv.invoiceNumber}</span>
+                    <div className="flex items-center gap-4">
+                      <span className="text-sm font-medium">
+                        {formatCurrency(total)}
                       </span>
-                    )}
-                    <span
-                      className="text-xs px-2 py-1 rounded-full font-medium"
-                      style={{ backgroundColor: colors.bg, color: colors.text }}
+                      {inv.dueDate && (
+                        <span className="text-xs text-[var(--muted-foreground)]">
+                          Due {new Date(inv.dueDate).toLocaleDateString()}
+                        </span>
+                      )}
+                      <span
+                        className="text-xs px-2 py-1 rounded-full font-medium capitalize"
+                        style={{ backgroundColor: colors.bg, color: colors.text }}
+                      >
+                        {inv.status}
+                      </span>
+                    </div>
+                  </button>
+                  {/* Pay Now on row — visible without expanding */}
+                  {stripeEnabled && isPayable(inv.status) && (
+                    <button
+                      onClick={(e) => handlePayNow(e, inv.id)}
+                      disabled={payingInvoiceId === inv.id}
+                      className="flex items-center gap-1.5 text-xs px-3 py-1.5 mr-3 bg-[var(--primary)] text-white rounded-lg font-medium hover:opacity-90 transition-opacity shrink-0"
                     >
-                      {inv.status}
-                    </span>
-                  </div>
-                </button>
+                      <CreditCard size={12} />
+                      {payingInvoiceId === inv.id ? "..." : "Pay"}
+                    </button>
+                  )}
+                </div>
 
                 {isExpanded && (
-                  <div className="px-3 pb-3 space-y-3 border-t border-[var(--border)]">
+                  <div id={expandedPanelId} className="px-3 pb-3 space-y-3 border-t border-[var(--border)]">
                     <div className="flex items-center justify-between pt-3">
                       {inv.dueDate ? (
                         <p className="text-sm text-[var(--muted-foreground)]">
@@ -172,6 +238,16 @@ export function PortalInvoicesSection({
                         </p>
                       ) : <div />}
                       <div className="flex items-center gap-3">
+                        {stripeEnabled && isPayable(inv.status) && (
+                          <button
+                            onClick={(e) => handlePayNow(e, inv.id)}
+                            disabled={payingInvoiceId === inv.id}
+                            className="flex items-center gap-1.5 text-sm px-3 py-1.5 bg-[var(--primary)] text-white rounded-lg font-medium hover:opacity-90 transition-opacity"
+                          >
+                            <CreditCard size={14} />
+                            {payingInvoiceId === inv.id ? "Redirecting..." : "Pay Now"}
+                          </button>
+                        )}
                         {inv.type === "uploaded" && inv.uploadedFile && (
                           <button
                             onClick={() =>
@@ -253,7 +329,8 @@ export function PortalInvoicesSection({
                       </div>
                     )}
 
-                    {paymentInstructions && (
+                    {/* Only show payment instructions for unpaid invoices */}
+                    {paymentInstructions && isPayable(inv.status) && (
                       <div>
                         <p className="text-xs font-medium mb-1">Payment Instructions</p>
                         <p className="text-sm text-[var(--muted-foreground)] whitespace-pre-wrap">

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,7 +40,7 @@ Make the portal the primary channel between agency and client.
 - [ ] **In-portal messaging** -- Dedicated project-scoped chat with email fallback
 - [x] **Team members** -- Invite additional staff to your organization beyond owner/admin
 - [x] **Tags & labels** -- Cross-entity tagging for projects, clients, tasks, and files
-- [ ] **Client-facing invoice payments** -- Pay invoices directly from the portal (Stripe)
+- [x] **Client-facing invoice payments** -- Pay invoices directly from the portal (Stripe Connect)
 - [ ] **Recurring invoices** -- Auto-generate invoices on a schedule for retainer clients
 
 ### v1.4 -- Contracts, Approvals & Scheduling (April 2026)

--- a/docs/testing-stripe-connect.md
+++ b/docs/testing-stripe-connect.md
@@ -1,0 +1,198 @@
+# Testing Stripe Connect Invoice Payments
+
+Step-by-step instructions to manually test the full Stripe Connect payment flow locally.
+
+## Prerequisites
+
+- Atrium running locally (`bun run dev`)
+- A [Stripe account](https://dashboard.stripe.com/register) (free to create)
+- A second Stripe account to act as the "connected agency" (or use the same one in test mode)
+
+## 1. Stripe Dashboard Setup
+
+### Create a Connect Platform
+
+1. Go to [Stripe Dashboard > Connect > Settings](https://dashboard.stripe.com/test/settings/connect)
+2. Complete the platform profile if prompted (select "Other" for platform type)
+3. Under **Integration**, find your **Test mode client ID** — it looks like `ca_xxxxxxxx`
+4. Under **Redirects**, add your callback URL:
+   ```
+   http://localhost:3001/api/payments/connect/callback
+   ```
+
+### Set Up the Connect Webhook
+
+1. Go to [Stripe Dashboard > Developers > Webhooks](https://dashboard.stripe.com/test/webhooks)
+2. Click **Add endpoint**
+3. For local testing, you need to use the Stripe CLI to forward webhooks (see step 2 below)
+4. Select these events:
+   - `checkout.session.completed`
+   - `checkout.session.expired`
+   - `account.application.deauthorized`
+
+### Configure Environment
+
+Add to your `.env` file:
+
+```bash
+STRIPE_CONNECT_CLIENT_ID="ca_xxxxxxxxxxxxx"    # From Connect Settings
+STRIPE_CONNECT_WEBHOOK_SECRET=""               # Will be set in step 2
+# STRIPE_CURRENCY="usd"                        # Optional, defaults to usd
+```
+
+## 2. Forward Webhooks Locally (Stripe CLI)
+
+Install the [Stripe CLI](https://stripe.com/docs/stripe-cli) if you haven't:
+
+```bash
+brew install stripe/stripe-cli/stripe
+stripe login
+```
+
+Forward Connect webhooks to your local server:
+
+```bash
+stripe listen --forward-connect-to localhost:3001/api/payments/webhook
+```
+
+The CLI will print a webhook signing secret like `whsec_xxxxx`. Copy it into your `.env`:
+
+```bash
+STRIPE_CONNECT_WEBHOOK_SECRET="whsec_xxxxxxxxxxxxx"
+```
+
+Restart the API server after updating `.env`.
+
+## 3. Test the Agency Owner Flow
+
+### Connect Stripe Account
+
+1. Log in as the **org owner** at `http://localhost:3000/login`
+2. Go to **Settings > System** (`/dashboard/settings/system`)
+3. Scroll down to **Client Payments** section
+4. Click **Connect with Stripe** (purple button)
+5. You'll be redirected to Stripe's OAuth page
+6. Click **Skip this form** (test mode) or connect a real test account
+7. You should be redirected back to Settings with a green "Connected" badge
+8. The badge should show "Test mode" with a yellow warning
+
+### Verify Connected State
+
+- The status should show "Connected" with a masked account ID
+- A yellow message should say "Clients cannot submit real payments in test mode..."
+- A "Disconnect Stripe" button should be visible
+
+### Test Cancel Flow
+
+1. Click **Disconnect Stripe** to reset
+2. Click **Connect with Stripe** again
+3. On the Stripe OAuth page, click the browser back button or close the tab
+4. Return to Settings — you should see an info toast about cancellation
+
+## 4. Test the Client Payment Flow
+
+### Setup: Create a Payable Invoice
+
+1. As the **owner**, go to a project (`/dashboard/projects/[id]`)
+2. Click the **Invoices** tab
+3. Click **New Invoice** and create one with at least one line item (e.g., "Consulting - 1x $100")
+4. Click **Create Invoice**
+5. Expand the invoice and click **Mark as Sent**
+6. Make sure a client is assigned to this project (Clients tab > Add Client)
+
+### Pay as a Client
+
+1. Log in as the **client user** (or use a separate browser/incognito)
+2. Go to the portal (`/portal/projects/[id]`)
+3. In the Invoices section, you should see:
+   - A compact **Pay** button on the invoice row (right side, next to status badge)
+   - The invoice status should be "sent"
+4. Click **Pay** (or expand and click **Pay Now**)
+5. You'll be redirected to Stripe Checkout
+6. Use test card: `4242 4242 4242 4242`, any future expiry, any CVC
+7. Complete the payment
+8. You should be redirected back to the portal with:
+   - A success toast: "Payment successful!"
+   - The invoice status updated to "paid"
+
+### Verify Payment on Dashboard
+
+1. Log back in as the **owner**
+2. Go to the project's Invoices tab
+3. The invoice should now show "paid" status
+4. Expand it — you should see a green bar: "Paid via Stripe" with the payment date
+5. The **Delete** button should be hidden for this invoice
+6. The **Mark as Paid** button should not appear (it was paid via Stripe)
+
+### Verify Notifications
+
+1. Check the owner's notification bell — should have "Invoice INV-XXXX paid"
+2. Check the Stripe CLI terminal — should show the webhook event was received
+3. If email is configured, check for the "Payment Received" email
+
+## 5. Test Edge Cases
+
+### Cancel Payment Mid-Checkout
+
+1. Create and send another invoice
+2. As the client, click **Pay**
+3. On the Stripe Checkout page, click the back arrow or close the tab
+4. Return to the portal — you should see an info toast: "Payment was not completed..."
+5. The invoice should still show "sent" — click Pay again to verify it works
+
+### Overdue Invoice Payment
+
+1. Create an invoice with a past due date
+2. Wait for the overdue cron to run (hourly), or manually mark it:
+   ```bash
+   # Mark overdue via API
+   curl -X PUT http://localhost:3001/api/invoices/[id] \
+     -H "Content-Type: application/json" \
+     -H "Cookie: [your-session-cookie]" \
+     -d '{"status": "overdue"}'
+   ```
+3. As the client, verify the "Pay" button still appears on overdue invoices
+4. Complete the payment and verify it transitions to "paid"
+
+### Stripe-Paid Invoice Protection
+
+1. Try to delete a Stripe-paid invoice from the dashboard
+2. The Delete button should not be visible
+3. If you hit the API directly, you should get a 400 error:
+   ```
+   "Cannot delete an invoice that was paid via Stripe."
+   ```
+
+### Disconnect Stripe (External)
+
+1. Go to [Stripe Dashboard > Connect > Connected Accounts](https://dashboard.stripe.com/test/connect/accounts/overview)
+2. Find the connected test account and remove/revoke it
+3. The webhook should fire `account.application.deauthorized`
+4. Check the owner's notifications — should see "Stripe account disconnected"
+5. Refresh the Settings page — should show "Connect with Stripe" again
+
+### Payment Instructions Visibility
+
+1. Go to Settings and add manual Payment Instructions (bank transfer info, etc.)
+2. As a client, expand a **sent** invoice — payment instructions should be visible
+3. Expand a **paid** invoice — payment instructions should NOT be visible
+
+## 6. Run Automated Tests
+
+```bash
+# Unit tests
+bun run test
+
+# E2E tests (includes invoice-payments.e2e.ts)
+bun run test:e2e
+```
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| "Stripe Connect is not configured" | Set `STRIPE_CONNECT_CLIENT_ID` in `.env` and restart |
+| Webhook events not received | Make sure `stripe listen` is running and `STRIPE_CONNECT_WEBHOOK_SECRET` matches |
+| OAuth callback returns 403 | Make sure callback URL is added in Stripe Dashboard > Connect > Redirects |
+| "URL must be on the application domain" | Ensure `WEB_URL` in `.env` matches the origin you're testing from |
+| Invoice stays "sent" after payment | Check `stripe listen` output for errors; verify webhook secret |

--- a/e2e/tests/invoice-payments.e2e.ts
+++ b/e2e/tests/invoice-payments.e2e.ts
@@ -1,0 +1,194 @@
+import { test, expect } from "@playwright/test";
+import { getCsrfToken } from "./helpers";
+
+const API = "http://localhost:3001/api";
+
+test.describe("Invoice Payments", () => {
+  // ── Settings UI ──
+
+  test.describe("Settings page", () => {
+    test("system settings shows Client Payments section", async ({ page }) => {
+      await page.goto("/dashboard/settings/system");
+      await expect(
+        page.getByRole("heading", { name: /client payments/i }),
+      ).toBeVisible({ timeout: 5000 });
+    });
+
+    test("shows Stripe key input in direct mode (default)", async ({ page }) => {
+      await page.goto("/dashboard/settings/system");
+      await expect(
+        page.getByPlaceholder(/sk_test_/i),
+      ).toBeVisible({ timeout: 5000 });
+    });
+
+    test("shows Save & Connect button", async ({ page }) => {
+      await page.goto("/dashboard/settings/system");
+      await expect(
+        page.getByRole("button", { name: /save.*connect/i }),
+      ).toBeVisible({ timeout: 5000 });
+    });
+  });
+
+  // ── API: Payment status ──
+
+  test.describe("API — Payment status", () => {
+    test("GET /payments/status returns disabled with mode", async ({
+      request,
+    }) => {
+      const res = await request.get(`${API}/payments/status`);
+      expect(res.ok()).toBeTruthy();
+      const body = await res.json();
+      expect(body.enabled).toBe(false);
+      expect(body.mode).toBe("direct");
+    });
+
+    test("GET /payments/enabled returns enabled: false by default", async ({
+      request,
+    }) => {
+      const res = await request.get(`${API}/payments/enabled`);
+      expect(res.ok()).toBeTruthy();
+      const body = await res.json();
+      expect(body.enabled).toBe(false);
+    });
+
+    test("GET /settings/payment-instructions returns stripeConnectEnabled field", async ({
+      request,
+    }) => {
+      const res = await request.get(`${API}/settings/payment-instructions`);
+      expect(res.ok()).toBeTruthy();
+      const body = await res.json();
+      expect(body).toHaveProperty("stripeConnectEnabled");
+      expect(body.stripeConnectEnabled).toBe(false);
+    });
+  });
+
+  // ── API: Direct keys validation ──
+
+  test.describe("API — Direct keys", () => {
+    test("POST /payments/direct/save-key rejects invalid key format", async ({
+      request,
+    }) => {
+      const csrfToken = getCsrfToken();
+      const res = await request.post(`${API}/payments/direct/save-key`, {
+        data: { stripeSecretKey: "pk_test_invalid_not_a_secret_key" },
+        headers: { "x-csrf-token": csrfToken },
+      });
+      expect(res.status()).toBe(400);
+    });
+
+    test("POST /payments/direct/save-key rejects too-short key", async ({
+      request,
+    }) => {
+      const csrfToken = getCsrfToken();
+      const res = await request.post(`${API}/payments/direct/save-key`, {
+        data: { stripeSecretKey: "sk_test_short" },
+        headers: { "x-csrf-token": csrfToken },
+      });
+      expect(res.status()).toBe(400);
+    });
+
+    test("POST /payments/direct/remove-key returns 400 when no key configured", async ({
+      request,
+    }) => {
+      const csrfToken = getCsrfToken();
+      const res = await request.post(`${API}/payments/direct/remove-key`, {
+        headers: { "x-csrf-token": csrfToken },
+      });
+      expect(res.status()).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("No Stripe key configured");
+    });
+  });
+
+  // ── API: Checkout guard ──
+
+  test.describe("API — Checkout guard", () => {
+    test("POST /payments/checkout/:id returns 400 when payments not configured", async ({
+      request,
+    }) => {
+      const csrfToken = getCsrfToken();
+      const invoiceRes = await request.post(`${API}/invoices`, {
+        data: {
+          lineItems: [
+            { description: "Payment Test Item", quantity: 1, unitPrice: 5000 },
+          ],
+        },
+        headers: { "x-csrf-token": csrfToken },
+      });
+      expect(invoiceRes.status()).toBe(201);
+      const invoice = await invoiceRes.json();
+
+      const res = await request.post(
+        `${API}/payments/checkout/${invoice.id}`,
+        {
+          data: {
+            successUrl: "http://localhost:3000/portal?payment=success",
+            cancelUrl: "http://localhost:3000/portal",
+          },
+          headers: { "x-csrf-token": csrfToken },
+        },
+      );
+      expect(res.status()).toBe(400);
+      const body = await res.json();
+      expect(body.message).toContain("not configured");
+    });
+  });
+
+  // ── API: Webhook endpoints ──
+
+  test.describe("API — Webhook endpoints", () => {
+    test("POST /payments/webhook returns 400 when no connect secret configured", async ({
+      request,
+    }) => {
+      const res = await request.post(`${API}/payments/webhook`, {
+        headers: { "stripe-signature": "t=123,v1=abc" },
+      });
+      expect(res.status()).toBe(400);
+    });
+
+    test("POST /payments/webhook/:orgId returns 400 for unknown org", async ({
+      request,
+    }) => {
+      const res = await request.post(
+        `${API}/payments/webhook/nonexistent-org-id`,
+        { headers: { "stripe-signature": "t=123,v1=abc" } },
+      );
+      expect(res.status()).toBe(400);
+    });
+  });
+
+  // ── API: Delete protection ──
+
+  test.describe("API — Stripe-paid invoice protection", () => {
+    test("settings endpoint masks stripe keys", async ({ request }) => {
+      const res = await request.get(`${API}/settings`);
+      expect(res.ok()).toBeTruthy();
+      const body = await res.json();
+      // stripeSecretKey should be null or masked, never a real value
+      expect(body.stripeSecretKey === null || body.stripeSecretKey === "••••••••").toBeTruthy();
+      expect(body.stripeWebhookSecret === null || body.stripeWebhookSecret === "••••••••").toBeTruthy();
+    });
+  });
+
+  // ── Portal: Pay Now visibility ──
+
+  test.describe("Portal — Pay Now visibility", () => {
+    test("portal does not show Pay Now when payments disabled", async ({
+      page,
+    }) => {
+      await page.goto("/portal/projects");
+      const projectLink = page
+        .locator("a[href*='/portal/projects/']")
+        .first();
+      if (
+        await projectLink.isVisible({ timeout: 5000 }).catch(() => false)
+      ) {
+        await projectLink.click();
+        await page.waitForTimeout(2000);
+        await expect(
+          page.getByRole("button", { name: /pay now/i }),
+        ).not.toBeVisible();
+      }
+    });
+  });
+});

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -299,6 +299,12 @@ model Invoice {
   createdAt      DateTime          @default(now())
   updatedAt      DateTime          @updatedAt
 
+  // Stripe Connect payment tracking
+  stripeCheckoutSessionId String?
+  stripePaymentIntentId   String?
+  paidAt                  DateTime?
+  paidAmount              Int?      // Amount actually paid (cents)
+
   project      Project?          @relation(fields: [projectId], references: [id], onDelete: SetNull)
   uploadedFile File?             @relation("UploadedInvoiceFile", fields: [uploadedFileId], references: [id])
   lineItems    InvoiceLineItem[]
@@ -385,6 +391,13 @@ model SystemSettings {
   paymentInstructions String?  // Displayed on invoices in the portal
   paymentMethod       String?  // "bank_transfer", "paypal", "stripe_link", "other"
   paymentDetails      String?  // Encrypted — bank account, PayPal email, etc.
+
+  // Stripe payments (direct keys or Connect)
+  stripeSecretKey        String?   // encrypted — agency's own Stripe secret key (direct mode)
+  stripeWebhookSecret    String?   // encrypted — auto-registered webhook signing secret
+  stripeConnectAccountId String?   // Connected Stripe account ID (Connect mode)
+  stripeConnectEnabled   Boolean   @default(false) // true when payments are configured (either mode)
+  stripeConnectLivemode  Boolean   @default(false)
 
   // File settings
   maxFileSizeMb  Int      @default(50)

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -11,3 +11,4 @@ export { DocumentUploadedEmail } from "./templates/document-uploaded";
 export { DocumentRespondedEmail } from "./templates/document-responded";
 export { DocumentReminderEmail } from "./templates/document-reminder";
 export { DocumentSigningTurnEmail } from "./templates/document-signing-turn";
+export { InvoicePaidEmail } from "./templates/invoice-paid";

--- a/packages/email/src/templates/invoice-paid.tsx
+++ b/packages/email/src/templates/invoice-paid.tsx
@@ -1,0 +1,65 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Preview,
+  Text,
+} from "@react-email/components";
+import * as React from "react";
+
+interface InvoicePaidEmailProps {
+  recipientName: string;
+  invoiceNumber: string;
+  amount: string;
+  projectName: string;
+  dashboardUrl: string;
+}
+
+export function InvoicePaidEmail({
+  recipientName,
+  invoiceNumber,
+  amount,
+  projectName,
+  dashboardUrl,
+}: InvoicePaidEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Invoice {invoiceNumber} paid — {amount}</Preview>
+      <Body style={{ fontFamily: "sans-serif", padding: "40px 0" }}>
+        <Container style={{ maxWidth: "480px", margin: "0 auto" }}>
+          <Heading style={{ fontSize: "24px", marginBottom: "24px" }}>
+            Payment Received
+          </Heading>
+          <Text style={{ fontSize: "16px", lineHeight: "24px" }}>
+            {recipientName}, invoice {invoiceNumber} for {amount} on project{" "}
+            {projectName} has been paid.
+          </Text>
+          <Link
+            href={dashboardUrl}
+            style={{
+              display: "inline-block",
+              padding: "12px 24px",
+              backgroundColor: "#006b68",
+              color: "#ffffff",
+              borderRadius: "6px",
+              textDecoration: "none",
+              fontSize: "16px",
+              marginTop: "16px",
+            }}
+          >
+            View Invoice
+          </Link>
+          <Text
+            style={{ fontSize: "14px", color: "#6b7280", marginTop: "24px" }}
+          >
+            This payment was processed via Stripe.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds Stripe invoice payments with dual-mode support: **direct API keys** (self-hosted) and **Stripe Connect OAuth** (hosted product)
- Clients see a "Pay Now" button on sent/overdue invoices in the portal, which redirects to Stripe Checkout
- Webhooks auto-mark invoices as paid with notifications to admins
- Dashboard shows payment source ("Paid via Stripe" vs "Marked as paid") and protects Stripe-paid invoices from deletion

## How it works

| Mode | For | How agencies connect | Env vars needed |
|------|-----|---------------------|-----------------|
| Direct keys | Self-hosted | Paste Stripe secret key in Settings | None |
| Connect OAuth | Hosted product | Click "Connect with Stripe" | `STRIPE_CONNECT_CLIENT_ID` |

Both modes use the same checkout flow, webhook handling, and portal UI. Mode is auto-detected based on whether `STRIPE_CONNECT_CLIENT_ID` is set.

## New files

- `apps/api/src/payments/` — NestJS module (service, controller, webhook controller, DTOs)
- `apps/web/.../payments-section.tsx` — Settings UI for both modes
- `packages/email/src/templates/invoice-paid.tsx` — Payment received email template
- `e2e/tests/invoice-payments.e2e.ts` — 13 e2e tests
- `docs/testing-stripe-connect.md` — Manual testing guide

## Schema changes

- `SystemSettings`: `stripeSecretKey`, `stripeWebhookSecret`, `stripeConnectAccountId`, `stripeConnectEnabled`, `stripeConnectLivemode`
- `Invoice`: `stripeCheckoutSessionId`, `stripePaymentIntentId`, `paidAt`, `paidAmount`

## Security

- HMAC-signed OAuth state with timing-safe comparison
- Org-scoped webhook URLs (`/webhook/:orgId`) prevent cross-org injection
- URL origin validation prevents open redirects
- AES-256-GCM encrypted key storage
- Idempotent webhook processing (prevents double-charge notifications)
- Stripe-paid invoices protected from deletion
- Sensitive fields masked in all API responses

## Test plan

- [x] TypeScript compiles clean (API + Web + Email)
- [x] Full production build passes
- [x] 440 unit tests pass
- [x] 13 new e2e tests for payments feature
- [x] Manual: paste test Stripe key in Settings, verify webhook auto-registers
- [x] Manual: client clicks Pay Now → Stripe Checkout → invoice marked as paid
- [x] Manual: Stripe Connect OAuth flow (requires `STRIPE_CONNECT_CLIENT_ID`)