### PR TITLE
fix: allow plain HTTP access by removing hardcoded X-Forwarded-Proto

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -8,14 +8,10 @@ header {
 }
 
 handle /api/* {
-	reverse_proxy 127.0.0.1:3001 {
-		header_up X-Forwarded-Proto https
-	}
+	reverse_proxy 127.0.0.1:3001
 	header Cache-Control "no-store, no-cache, must-revalidate"
 }
 
 handle {
-	reverse_proxy 127.0.0.1:3000 {
-		header_up X-Forwarded-Proto https
-	}
+	reverse_proxy 127.0.0.1:3000
 }


### PR DESCRIPTION
## Summary
- Removes the hardcoded `X-Forwarded-Proto https` from the Caddyfile
- Fixes "Invalid origin" errors when accessing Atrium over plain HTTP (e.g. LAN setup before configuring HTTPS)
- HTTPS setups are unaffected — upstream reverse proxies (Cloudflare, nginx, etc.) set the header themselves and Caddy passes it through

## Test plan
- [ ] Access Atrium via plain HTTP on a LAN IP — login should work without "Invalid origin"
- [ ] Access Atrium behind an HTTPS reverse proxy — should still work correctly