### PR TITLE
feat: billing upsell prompts, page redesign & invoice delete fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Atrium will be documented in this file.
 
+## [1.4.3] — 2026-04-07
+
+### Added
+
+- **Plan limit upsell prompts** — Free-plan users now see contextual upgrade prompts at the point of friction: a usage counter and upgrade card on the Projects page, member/client limit banners on the People page, and a locked input with inline `PRO` badge on the Custom Domain setting.
+- **Billing page redesign** — Plans section is now the primary focus (moved above current plan details). Pro card is visually highlighted with a teal border and "Most Popular" badge. Lifetime card includes a founding member spots meter and a "Become a Founding Member" CTA. Usage meters are compact (2-column, small text).
+- **Contextual upgrade banner** — Arriving at the billing page via an upsell prompt now shows a banner explaining why you're there (projects limit, clients limit, or custom domain).
+- **Founder Discord access** — Added as a feature bullet on the Lifetime plan.
+
+### Fixed
+
+- Invoice delete button was hidden for `overdue` and `cancelled` invoices — now any non-`paid` invoice without a Stripe payment intent can be deleted.
+- Upsell components were reading `sub.plan` directly but the billing API wraps it as `sub.subscription.plan`, causing plan limits to never apply.
+- Billing tab not opening when navigating to `/dashboard/settings/account?tab=billing` — `billingEnabled` wasn't in the sync effect's dependency array, so the tab stayed on Profile until a second interaction.
+- Upgrade links redirected through `/dashboard/settings/billing` (which itself redirected) — all links now point directly to `?tab=billing`.
+
 ## [1.4.2] — 2026-04-05
 
 ### Added

--- a/apps/api/src/invoices/invoices.service.ts
+++ b/apps/api/src/invoices/invoices.service.ts
@@ -325,7 +325,7 @@ export class InvoicesService {
       );
     }
 
-    await this.prisma.invoice.delete({ where: { id } });
+    await this.prisma.invoice.delete({ where: { id, organizationId: orgId } });
   }
 
   async getStats(orgId: string, projectId?: string) {

--- a/apps/api/src/invoices/invoices.service.ts
+++ b/apps/api/src/invoices/invoices.service.ts
@@ -325,7 +325,7 @@ export class InvoicesService {
       );
     }
 
-    await this.prisma.invoice.delete({ where: { id, organizationId: orgId } });
+    await this.prisma.invoice.delete({ where: { id } });
   }
 
   async getStats(orgId: string, projectId?: string) {

--- a/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
@@ -170,6 +170,11 @@ export default function PeoplePage() {
       await apiFetch(`/clients/${memberId}`, { method: "DELETE" });
       success(`${memberName} removed`);
       loadMembers();
+      if (isTeam) {
+        setPlanLimits((prev) => prev ? { ...prev, membersUsed: Math.max(0, prev.membersUsed - 1) } : prev);
+      } else {
+        setPlanLimits((prev) => prev ? { ...prev, clientsUsed: Math.max(0, prev.clientsUsed - 1) } : prev);
+      }
     } catch (err) {
       showError(err instanceof Error ? err.message : "Failed to remove");
     }
@@ -203,6 +208,7 @@ export default function PeoplePage() {
       const submittedEmail = teamEmail;
       setTeamEmail("");
       success("Invitation sent");
+      setPlanLimits((prev) => prev ? { ...prev, membersUsed: prev.membersUsed + 1 } : prev);
 
       const updated = await apiFetch<Invitation[]>("/clients/invitations");
       setInvitations(updated);
@@ -233,6 +239,7 @@ export default function PeoplePage() {
       const submittedEmail = clientEmail;
       setClientEmail("");
       success("Invitation sent");
+      setPlanLimits((prev) => prev ? { ...prev, clientsUsed: prev.clientsUsed + 1 } : prev);
 
       const updated = await apiFetch<Invitation[]>("/clients/invitations");
       setInvitations(updated);
@@ -371,7 +378,7 @@ export default function PeoplePage() {
                     </p>
                   </div>
                   <Link
-                    href="/dashboard/settings/account?tab=billing&reason=clients"
+                    href="/dashboard/settings/account?tab=billing&reason=members"
                     className="shrink-0 flex items-center gap-1.5 px-4 py-2 bg-[var(--primary)] text-white rounded-lg text-xs font-semibold hover:opacity-90 transition-opacity whitespace-nowrap"
                   >
                     Upgrade

--- a/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
@@ -5,10 +5,12 @@ import { apiFetch } from "@/lib/api";
 import { useConfirm } from "@/components/confirm-modal";
 import { useToast } from "@/components/toast";
 import { ClientItemSkeleton } from "@/components/skeletons";
-import { UserPlus, Copy, Check, Trash2, ChevronDown, ChevronRight, UsersRound, Download } from "lucide-react";
+import { UserPlus, Copy, Check, Trash2, ChevronDown, ChevronRight, UsersRound, Download, Sparkles, ExternalLink } from "lucide-react";
 import { track } from "@/lib/track";
 import { LabelBadge } from "@/components/label-badge";
 import { downloadCsv } from "@/lib/download";
+import Link from "next/link";
+import { useAppConfig } from "@/lib/app-config";
 
 interface Invitation {
   id: string;
@@ -60,9 +62,14 @@ const roleColor = (role: string) => {
 type TabId = "team" | "clients";
 
 export default function PeoplePage() {
+  const config = useAppConfig();
   const confirm = useConfirm();
   const { success, error: showError } = useToast();
   const [activeTab, setActiveTab] = useState<TabId>("team");
+  const [planLimits, setPlanLimits] = useState<{
+    maxMembers: number; membersUsed: number;
+    maxClients: number; clientsUsed: number;
+  } | null>(null);
 
   // Shared state
   const [members, setMembers] = useState<MemberRecord[]>([]);
@@ -124,6 +131,26 @@ export default function PeoplePage() {
     loadMembers();
     loadInvitations();
   }, [loadMembers, loadInvitations]);
+
+  useEffect(() => {
+    if (!config?.billingEnabled) return;
+    Promise.all([
+      apiFetch<{ subscription: { plan: { maxMembers: number; maxClients: number } } | null }>("/billing/subscription").catch(() => null),
+      apiFetch<{ members: number; clients: number }>("/billing/usage").catch(() => null),
+    ]).then(([sub, usage]) => {
+      if (sub?.subscription?.plan && usage != null) {
+        setPlanLimits({
+          maxMembers: sub.subscription.plan.maxMembers,
+          membersUsed: usage.members,
+          maxClients: sub.subscription.plan.maxClients,
+          clientsUsed: usage.clients,
+        });
+      }
+    });
+  }, [config?.billingEnabled]);
+
+  const atMemberLimit = planLimits !== null && planLimits.maxMembers !== -1 && planLimits.membersUsed >= planLimits.maxMembers;
+  const atClientLimit = planLimits !== null && planLimits.maxClients !== -1 && planLimits.clientsUsed >= planLimits.maxClients;
 
   const copyLink = (link: string) => {
     navigator.clipboard.writeText(link);
@@ -322,7 +349,36 @@ export default function PeoplePage() {
           )}
           {isOwner && (
             <div className="max-w-lg">
-              <h2 className="text-sm font-medium mb-3">Invite a Team Member</h2>
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-sm font-medium">Invite a Team Member</h2>
+                {planLimits && planLimits.maxMembers !== -1 && (
+                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                    atMemberLimit ? "bg-red-100 text-red-700" : "bg-[var(--muted)] text-[var(--muted-foreground)]"
+                  }`}>
+                    {planLimits.membersUsed}/{planLimits.maxMembers} members
+                  </span>
+                )}
+              </div>
+              {atMemberLimit ? (
+                <div className="flex items-center gap-3 rounded-xl border border-[var(--border)] bg-[var(--muted)] px-4 py-3.5">
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[var(--background)] border border-[var(--border)] shadow-sm">
+                    <Sparkles size={15} className="text-amber-500" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold">Team member limit reached</p>
+                    <p className="text-xs text-[var(--muted-foreground)] mt-0.5">
+                      Upgrade to Pro for up to 5 team members, or Lifetime for 100.
+                    </p>
+                  </div>
+                  <Link
+                    href="/dashboard/settings/account?tab=billing&reason=clients"
+                    className="shrink-0 flex items-center gap-1.5 px-4 py-2 bg-[var(--primary)] text-white rounded-lg text-xs font-semibold hover:opacity-90 transition-opacity whitespace-nowrap"
+                  >
+                    Upgrade
+                    <ExternalLink size={11} />
+                  </Link>
+                </div>
+              ) : (
               <form onSubmit={handleTeamInvite} className="space-y-3">
                 {teamError && (
                   <div className="p-3 text-sm text-red-600 bg-red-50 rounded-lg">{teamError}</div>
@@ -354,6 +410,7 @@ export default function PeoplePage() {
                   </button>
                 </div>
               </form>
+              )}
 
               {teamInviteLink && (
                 <div className="mt-3 p-3 bg-green-50 border border-green-200 rounded-lg">
@@ -487,7 +544,36 @@ export default function PeoplePage() {
         <div className="space-y-6">
           {/* Client Invite */}
           <div className="max-w-lg">
-            <h2 className="text-sm font-medium mb-3">Invite a Client</h2>
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-sm font-medium">Invite a Client</h2>
+              {planLimits && planLimits.maxClients !== -1 && (
+                <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                  atClientLimit ? "bg-red-100 text-red-700" : "bg-[var(--muted)] text-[var(--muted-foreground)]"
+                }`}>
+                  {planLimits.clientsUsed}/{planLimits.maxClients} clients
+                </span>
+              )}
+            </div>
+            {atClientLimit ? (
+              <div className="flex items-center gap-3 rounded-xl border border-[var(--border)] bg-[var(--muted)] px-4 py-3.5">
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[var(--background)] border border-[var(--border)] shadow-sm">
+                  <Sparkles size={15} className="text-amber-500" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold">Client limit reached</p>
+                  <p className="text-xs text-[var(--muted-foreground)] mt-0.5">
+                    Upgrade to Pro for unlimited clients.
+                  </p>
+                </div>
+                <Link
+                  href="/dashboard/settings/account?tab=billing&reason=clients"
+                  className="shrink-0 flex items-center gap-1.5 px-4 py-2 bg-[var(--primary)] text-white rounded-lg text-xs font-semibold hover:opacity-90 transition-opacity whitespace-nowrap"
+                >
+                  Upgrade
+                  <ExternalLink size={11} />
+                </Link>
+              </div>
+            ) : (
             <form onSubmit={handleClientInvite} className="space-y-3">
               {clientError && (
                 <div className="p-3 text-sm text-red-600 bg-red-50 rounded-lg">{clientError}</div>
@@ -511,6 +597,7 @@ export default function PeoplePage() {
                 </button>
               </div>
             </form>
+            )}
 
             {clientInviteLink && (
               <div className="mt-3 p-3 bg-green-50 border border-green-200 rounded-lg">

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/invoices-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/invoices-section.tsx
@@ -736,7 +736,7 @@ export function InvoicesSection({
                           Edit
                         </button>
                       )}
-                      {!isArchived && ["draft", "sent"].includes(inv.status) && !inv.stripePaymentIntentId && (
+                      {!isArchived && inv.status !== "paid" && !inv.stripePaymentIntentId && (
                         <button
                           onClick={() => handleDelete(inv.id)}
                           className="ml-auto flex items-center gap-1 text-xs text-red-500 hover:underline"

--- a/apps/web/src/app/(dashboard)/dashboard/projects/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/page.tsx
@@ -6,10 +6,11 @@ import { apiFetch } from "@/lib/api";
 import { useDebounce } from "@/hooks/use-debounce";
 import { Pagination } from "@/components/pagination";
 import { ProjectCardSkeleton } from "@/components/skeletons";
-import { Plus, Search, FolderOpen, Archive, Tag, Download } from "lucide-react";
+import { Plus, Search, FolderOpen, Archive, Tag, Download, Sparkles, ExternalLink } from "lucide-react";
 import { track } from "@/lib/track";
 import { LabelBadge } from "@/components/label-badge";
 import { downloadCsv } from "@/lib/download";
+import { useAppConfig } from "@/lib/app-config";
 
 interface LabelRecord {
   id: string;
@@ -40,12 +41,14 @@ interface PaginatedResponse<T> {
 }
 
 export default function ProjectsPage() {
+  const config = useAppConfig();
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [error, setError] = useState("");
+  const [planLimits, setPlanLimits] = useState<{ maxProjects: number; projectsUsed: number } | null>(null);
 
   // Pagination & filters
   const [page, setPage] = useState(1);
@@ -109,7 +112,22 @@ export default function ProjectsPage() {
     setPage(1);
   }, [debouncedSearch, statusFilter, showArchived, labelFilter]);
 
+  useEffect(() => {
+    if (!config?.billingEnabled) return;
+    Promise.all([
+      apiFetch<{ subscription: { plan: { maxProjects: number } } | null }>("/billing/subscription").catch(() => null),
+      apiFetch<{ projects: number }>("/billing/usage").catch(() => null),
+    ]).then(([sub, usage]) => {
+      if (sub?.subscription?.plan && usage != null) {
+        setPlanLimits({ maxProjects: sub.subscription.plan.maxProjects, projectsUsed: usage.projects });
+      }
+    });
+  }, [config?.billingEnabled]);
+
   const [creating, setCreating] = useState(false);
+
+  const atProjectLimit = planLimits !== null && planLimits.maxProjects !== -1 && planLimits.projectsUsed >= planLimits.maxProjects;
+  const oneProjectLeft = planLimits !== null && planLimits.maxProjects !== -1 && !atProjectLimit && planLimits.maxProjects - planLimits.projectsUsed === 1;
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -125,8 +143,11 @@ export default function ProjectsPage() {
       setDescription("");
       setShowCreate(false);
       loadProjects();
+      if (planLimits) {
+        setPlanLimits((prev) => prev ? { ...prev, projectsUsed: prev.projectsUsed + 1 } : prev);
+      }
     } catch (err) {
-      console.error(err);
+      setError(err instanceof Error ? err.message : "Failed to create project");
     } finally {
       setCreating(false);
     }
@@ -137,6 +158,17 @@ export default function ProjectsPage() {
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Projects</h1>
         <div className="flex items-center gap-2">
+          {planLimits && planLimits.maxProjects !== -1 && (
+            <span className={`hidden sm:inline text-xs px-2 py-1 rounded-full font-medium ${
+              atProjectLimit
+                ? "bg-red-100 text-red-700"
+                : oneProjectLeft
+                  ? "bg-amber-100 text-amber-700"
+                  : "bg-[var(--muted)] text-[var(--muted-foreground)]"
+            }`}>
+              {planLimits.projectsUsed}/{planLimits.maxProjects} projects
+            </span>
+          )}
           <button
             onClick={() => downloadCsv("/projects/export")}
             className="flex items-center gap-1.5 px-3 py-2 border border-[var(--border)] rounded-lg text-sm text-[var(--muted-foreground)] hover:bg-[var(--muted)] transition-colors"
@@ -147,9 +179,13 @@ export default function ProjectsPage() {
           </button>
           <button
             onClick={() => setShowCreate(!showCreate)}
-            className="flex items-center gap-2 px-4 py-2 bg-[var(--primary)] text-white rounded-lg text-sm font-medium hover:opacity-90"
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium hover:opacity-90 transition-colors ${
+              atProjectLimit
+                ? "bg-amber-500 text-white"
+                : "bg-[var(--primary)] text-white"
+            }`}
           >
-            <Plus size={16} />
+            {atProjectLimit ? <Sparkles size={16} /> : <Plus size={16} />}
             New Project
           </button>
         </div>
@@ -159,11 +195,55 @@ export default function ProjectsPage() {
         <div className="mb-6 p-4 text-sm text-red-600 bg-red-50 rounded-lg">{error}</div>
       )}
 
-      {showCreate && (
+      {showCreate && atProjectLimit && (
+        <div className="mb-6 flex items-center gap-3 rounded-xl border border-[var(--border)] bg-[var(--muted)] px-4 py-4">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[var(--background)] border border-[var(--border)] shadow-sm">
+            <Sparkles size={16} className="text-amber-500" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold">
+              You&apos;ve used all {planLimits?.maxProjects} free projects
+            </p>
+            <p className="text-xs text-[var(--muted-foreground)] mt-0.5">
+              Upgrade to Pro for unlimited projects, 10 GB storage, custom domain, and more.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <Link
+              href="/dashboard/settings/account?tab=billing&reason=projects"
+              className="flex items-center gap-1.5 px-4 py-2 bg-[var(--primary)] text-white rounded-lg text-sm font-semibold hover:opacity-90 transition-opacity whitespace-nowrap"
+            >
+              Upgrade to Pro
+              <ExternalLink size={12} />
+            </Link>
+            <button
+              onClick={() => setShowCreate(false)}
+              className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] whitespace-nowrap"
+            >
+              Maybe later
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showCreate && !atProjectLimit && (
         <form
           onSubmit={handleCreate}
           className="mb-6 p-4 border border-[var(--border)] rounded-lg space-y-3"
         >
+          {oneProjectLeft && (
+            <div className="flex items-center justify-between rounded-lg bg-[var(--muted)] border border-[var(--border)] px-3 py-2">
+              <p className="text-xs text-[var(--muted-foreground)]">
+                <span className="font-medium text-[var(--foreground)]">Last free project.</span> Upgrade to Pro for unlimited.
+              </p>
+              <Link
+                href="/dashboard/settings/account?tab=billing&reason=projects"
+                className="text-xs font-medium text-[var(--primary)] hover:opacity-80 whitespace-nowrap ml-3"
+              >
+                Upgrade →
+              </Link>
+            </div>
+          )}
           <input
             value={name}
             onChange={(e) => setName(e.target.value)}

--- a/apps/web/src/app/(dashboard)/dashboard/settings/account/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/account/page.tsx
@@ -44,13 +44,13 @@ export default function AccountSettingsPage() {
       .catch(() => {});
   }, []);
 
-  // Sync tab with URL param changes
+  // Sync tab with URL param changes (also re-runs when billingEnabled loads)
   useEffect(() => {
     const tab = searchParams.get("tab");
     if (tab === "billing" && billingEnabled) {
       setActiveTab("billing");
     }
-  }, [searchParams]);
+  }, [searchParams, billingEnabled]);
 
   const switchTab = (tab: Tab) => {
     setActiveTab(tab);

--- a/apps/web/src/app/(dashboard)/dashboard/settings/billing/billing-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/billing/billing-section.tsx
@@ -10,6 +10,9 @@ import {
   Crown,
   ExternalLink,
   Loader2,
+  Folder,
+  Users,
+  Globe,
 } from "lucide-react";
 
 interface Plan {
@@ -68,144 +71,173 @@ function UsageMeter({
 }) {
   const isUnlimited = max === -1;
   const pct = isUnlimited ? 0 : Math.min(100, (current / max) * 100);
-  const displayMax =
-    format === "storage" ? formatStorage(max) : formatLimit(max);
-  const displayCurrent =
-    format === "storage" ? formatStorage(current) : String(current);
+  const displayMax = format === "storage" ? formatStorage(max) : formatLimit(max);
+  const displayCurrent = format === "storage" ? formatStorage(current) : String(current);
+  const color = pct >= 90 ? "var(--destructive, #ef4444)" : pct >= 70 ? "#f59e0b" : "var(--primary)";
 
   return (
-    <div className="space-y-1.5">
-      <div className="flex justify-between text-sm">
-        <span className="font-medium">{label}</span>
-        <span className="text-[var(--muted-foreground)]">
-          {displayCurrent} / {displayMax}
+    <div className="space-y-1">
+      <div className="flex justify-between text-xs">
+        <span className="text-[var(--muted-foreground)]">{label}</span>
+        <span className={`font-medium ${pct >= 90 ? "text-red-500" : pct >= 70 ? "text-amber-500" : "text-[var(--foreground)]"}`}>
+          {isUnlimited ? "Unlimited" : `${displayCurrent} / ${displayMax}`}
         </span>
       </div>
-      <div className="h-2 bg-[var(--muted)] rounded-full overflow-hidden">
-        <div
-          className="h-full rounded-full transition-all"
-          style={{
-            width: isUnlimited ? "0%" : `${pct}%`,
-            backgroundColor:
-              pct >= 90
-                ? "var(--destructive, #ef4444)"
-                : pct >= 70
-                  ? "#f59e0b"
-                  : "var(--primary)",
-          }}
-        />
-      </div>
+      {!isUnlimited && (
+        <div className="h-1 bg-[var(--muted)] rounded-full overflow-hidden">
+          <div className="h-full rounded-full transition-all" style={{ width: `${pct}%`, backgroundColor: color }} />
+        </div>
+      )}
     </div>
   );
 }
 
+const REASON_BANNER: Record<string, { icon: React.ElementType; text: string; sub: string }> = {
+  projects: {
+    icon: Folder,
+    text: "You've reached your project limit on the Free plan.",
+    sub: "Upgrade to Pro for unlimited projects.",
+  },
+  clients: {
+    icon: Users,
+    text: "Free plan is limited to 3 clients and 1 team member.",
+    sub: "Pro gives you unlimited clients and up to 5 team members.",
+  },
+  "custom-domain": {
+    icon: Globe,
+    text: "Custom domains are a Pro feature.",
+    sub: "Upgrade to host your client portal at your own domain.",
+  },
+};
+
 function PlanCard({
   plan,
   isCurrentPlan,
+  isFree,
   lifetimeSeatsRemaining,
   onSelect,
   loadingSlug,
 }: {
   plan: Plan;
   isCurrentPlan: boolean;
+  isFree: boolean;
   lifetimeSeatsRemaining: number | null;
   onSelect: (slug: string) => void;
   loadingSlug: string | null;
 }) {
+  const isPro = plan.slug === "pro";
+  const isLifetime = plan.slug === "lifetime";
+
   const price = plan.isRecurring
-    ? `$${(plan.priceMonthly / 100).toFixed(0)}/mo`
+    ? `$${(plan.priceMonthly / 100).toFixed(0)}`
     : plan.priceLifetime > 0
       ? `$${(plan.priceLifetime / 100).toFixed(0)}`
       : "Free";
 
-  const icon =
-    plan.slug === "free" ? null : plan.slug === "pro" ? (
-      <Zap size={20} />
-    ) : (
-      <Crown size={20} />
-    );
+  const seatsLeft = isLifetime && lifetimeSeatsRemaining !== null ? lifetimeSeatsRemaining : null;
+  const soldOut = seatsLeft !== null && seatsLeft <= 0;
 
   return (
     <div
-      className={`rounded-xl border p-6 space-y-4 ${
-        isCurrentPlan
-          ? "border-[var(--primary)] ring-2 ring-[var(--primary)] ring-opacity-20"
-          : "border-[var(--border)]"
+      className={`relative rounded-xl border p-6 flex flex-col gap-4 transition-all ${
+        isPro && isFree
+          ? "border-2 border-[var(--primary)] shadow-lg shadow-[var(--primary)]/10 bg-[var(--card,var(--background))]"
+          : isCurrentPlan
+            ? "border-[var(--primary)] ring-1 ring-[var(--primary)]/20"
+            : "border-[var(--border)] opacity-90"
       }`}
     >
+      {/* Top accent bar */}
+      {isPro && isFree && (
+        <div className="absolute top-0 inset-x-0 h-[3px] bg-[var(--primary)] rounded-t-xl" />
+      )}
+
+      {/* Header */}
       <div className="space-y-1">
         <div className="flex items-center gap-2">
-          {icon}
-          <h3 className="text-lg font-semibold">{plan.name}</h3>
+          {plan.slug === "pro" && <Zap size={16} className="text-[var(--primary)]" />}
+          {plan.slug === "lifetime" && <Crown size={16} className="text-amber-500" />}
+          <h3 className="font-semibold">{plan.name}</h3>
           {isCurrentPlan && (
-            <span className="text-xs bg-[var(--primary)] text-white px-2 py-0.5 rounded-full">
+            <span className="text-[10px] bg-[var(--primary)] text-white px-1.5 py-0.5 rounded-full font-medium">
               Current
             </span>
           )}
+          {isPro && isFree && (
+            <span className="text-[10px] bg-[var(--primary)]/15 text-[var(--primary)] px-1.5 py-0.5 rounded-full font-semibold">
+              Most Popular
+            </span>
+          )}
         </div>
-        <p className="text-sm text-[var(--muted-foreground)]">
-          {plan.description}
-        </p>
+        <p className="text-xs text-[var(--muted-foreground)]">{plan.description}</p>
       </div>
 
-      <div className="text-3xl font-bold">
-        {price}
+      {/* Price */}
+      <div className="flex items-end gap-1">
+        <span className="text-3xl font-bold tracking-tight">{price}</span>
         {plan.isRecurring && (
-          <span className="text-sm font-normal text-[var(--muted-foreground)]">
-            {" "}
-            /month
-          </span>
+          <span className="text-sm text-[var(--muted-foreground)] mb-0.5">/mo</span>
         )}
         {!plan.isRecurring && plan.priceLifetime > 0 && (
-          <span className="text-sm font-normal text-[var(--muted-foreground)]">
-            {" "}
-            one-time
-          </span>
+          <span className="text-sm text-[var(--muted-foreground)] mb-0.5">one-time</span>
         )}
       </div>
 
-      {plan.slug === "lifetime" && lifetimeSeatsRemaining !== null && (
-        <div className="text-sm bg-amber-50 dark:bg-amber-950 text-amber-700 dark:text-amber-300 px-3 py-1.5 rounded-lg">
-          {lifetimeSeatsRemaining} of {plan.maxSeats} seats remaining
+      {/* Lifetime scarcity meter */}
+      {isLifetime && seatsLeft !== null && (
+        <div className="space-y-1.5">
+          <div className="flex justify-between text-xs">
+            <span className="text-[var(--muted-foreground)]">Founding member spots</span>
+            <span className={`font-medium ${seatsLeft < 20 ? "text-amber-500" : "text-[var(--foreground)]"}`}>
+              {seatsLeft} of {plan.maxSeats} left
+            </span>
+          </div>
+          <div className="h-1 bg-[var(--muted)] rounded-full overflow-hidden">
+            <div
+              className="h-full rounded-full bg-amber-500 transition-all"
+              style={{ width: `${Math.min(100, (seatsLeft / plan.maxSeats) * 100)}%` }}
+            />
+          </div>
         </div>
       )}
 
-      <ul className="space-y-2">
+      {/* Features */}
+      <ul className="space-y-1.5 flex-1">
         {plan.features.map((feature) => (
-          <li key={feature} className="flex items-center gap-2 text-sm">
-            <Check size={16} className="text-green-500 shrink-0" />
+          <li key={feature} className="flex items-center gap-2 text-xs text-[var(--muted-foreground)]">
+            <Check size={12} className="text-green-500 shrink-0" />
             {feature}
           </li>
         ))}
       </ul>
 
+      {/* CTA */}
       {!isCurrentPlan && plan.slug !== "free" && (
         <button
           onClick={() => onSelect(plan.slug)}
-          disabled={
-            loadingSlug !== null ||
-            (plan.slug === "lifetime" &&
-              lifetimeSeatsRemaining !== null &&
-              lifetimeSeatsRemaining <= 0)
-          }
-          className="w-full py-2 px-4 bg-[var(--primary)] text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+          disabled={loadingSlug !== null || soldOut}
+          className={`w-full py-2.5 px-4 rounded-lg text-sm font-semibold transition-opacity disabled:opacity-50 ${
+            isPro
+              ? "bg-[var(--primary)] text-white hover:opacity-90"
+              : isLifetime
+                ? "bg-amber-500 text-white hover:opacity-90"
+                : "bg-[var(--muted)] text-[var(--foreground)] hover:opacity-80"
+          }`}
         >
           {loadingSlug === plan.slug ? (
-            <Loader2 size={16} className="animate-spin mx-auto" />
-          ) : plan.slug === "lifetime" &&
-            lifetimeSeatsRemaining !== null &&
-            lifetimeSeatsRemaining <= 0 ? (
+            <Loader2 size={15} className="animate-spin mx-auto" />
+          ) : soldOut ? (
             "Sold Out"
+          ) : isLifetime ? (
+            "Become a Founding Member"
           ) : (
-            `Upgrade to ${plan.name}`
+            `Upgrade to ${plan.name} — $${(plan.priceMonthly / 100).toFixed(0)}/mo`
           )}
         </button>
       )}
 
       {isCurrentPlan && plan.slug !== "free" && (
-        <div className="text-center text-sm text-[var(--muted-foreground)]">
-          This is your current plan
-        </div>
+        <p className="text-center text-xs text-[var(--muted-foreground)]">Your current plan</p>
       )}
     </div>
   );
@@ -215,18 +247,15 @@ export function BillingSection() {
   const [plans, setPlans] = useState<Plan[]>([]);
   const [subscription, setSubscription] = useState<Subscription | null>(null);
   const [usage, setUsage] = useState<Usage | null>(null);
-  const [lifetimeSeatsRemaining, setLifetimeSeatsRemaining] = useState<
-    number | null
-  >(null);
+  const [lifetimeSeatsRemaining, setLifetimeSeatsRemaining] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [checkoutLoadingSlug, setCheckoutLoadingSlug] = useState<string | null>(null);
   const { success, error: showError } = useToast();
 
-  const searchParams =
-    typeof window !== "undefined"
-      ? new URLSearchParams(window.location.search)
-      : null;
+  const searchParams = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
   const checkoutSuccess = searchParams?.get("success") === "true";
+  const reason = searchParams?.get("reason") ?? null;
+  const reasonBanner = reason ? REASON_BANNER[reason] ?? null : null;
 
   useEffect(() => {
     if (checkoutSuccess) {
@@ -238,12 +267,8 @@ export function BillingSection() {
 
   useEffect(() => {
     Promise.all([
-      apiFetch<{ plans: Plan[]; lifetimeSeatsRemaining: number | null }>(
-        "/billing/plans",
-      ),
-      apiFetch<{ subscription: Subscription; usage: Usage }>(
-        "/billing/subscription",
-      ),
+      apiFetch<{ plans: Plan[]; lifetimeSeatsRemaining: number | null }>("/billing/plans"),
+      apiFetch<{ subscription: Subscription; usage: Usage }>("/billing/subscription"),
     ])
       .then(([plansData, subData]) => {
         setPlans(plansData.plans);
@@ -253,9 +278,7 @@ export function BillingSection() {
         setLoading(false);
       })
       .catch((err) => {
-        showError(
-          err instanceof Error ? err.message : "Failed to load billing data",
-        );
+        showError(err instanceof Error ? err.message : "Failed to load billing data");
         setLoading(false);
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -272,13 +295,9 @@ export function BillingSection() {
           cancelUrl: `${window.location.origin}/dashboard/settings/account?tab=billing`,
         }),
       });
-      if (result.url) {
-        window.location.href = result.url;
-      }
+      if (result.url) window.location.href = result.url;
     } catch (err) {
-      showError(
-        err instanceof Error ? err.message : "Failed to create checkout session",
-      );
+      showError(err instanceof Error ? err.message : "Failed to create checkout session");
       setCheckoutLoadingSlug(null);
     }
   };
@@ -291,115 +310,41 @@ export function BillingSection() {
           returnUrl: `${window.location.origin}/dashboard/settings/account?tab=billing`,
         }),
       });
-      if (result.url) {
-        window.location.href = result.url;
-      }
+      if (result.url) window.location.href = result.url;
     } catch (err) {
-      showError(
-        err instanceof Error
-          ? err.message
-          : "Failed to open payment portal",
-      );
+      showError(err instanceof Error ? err.message : "Failed to open payment portal");
     }
   };
 
   if (loading) return <div>Loading...</div>;
 
   const currentPlan = subscription?.plan;
+  const isFree = !currentPlan || currentPlan.slug === "free";
 
   return (
-    <div className="space-y-8">
-      {/* Current Plan & Status */}
-      {subscription && currentPlan && (
-        <section className="space-y-4">
-          <div className="flex items-center gap-2">
-            <CreditCard size={20} />
-            <h2 className="text-lg font-semibold">Current Plan</h2>
+    <div className="space-y-6">
+      {/* Contextual reason banner */}
+      {reasonBanner && isFree && (
+        <div className="flex items-center gap-3 p-3.5 rounded-lg border border-[var(--border)] bg-[var(--muted)]">
+          <reasonBanner.icon size={15} className="text-[var(--primary)] shrink-0" />
+          <div className="flex-1 min-w-0">
+            <span className="text-sm font-medium">{reasonBanner.text}</span>
+            {" "}
+            <span className="text-sm text-[var(--muted-foreground)]">{reasonBanner.sub}</span>
           </div>
-          <div className="p-4 border border-[var(--border)] rounded-lg space-y-2">
-            <div className="flex items-center justify-between">
-              <div>
-                <span className="font-semibold text-lg">
-                  {currentPlan.name}
-                </span>
-                <span
-                  className={`ml-2 text-xs px-2 py-0.5 rounded-full ${
-                    subscription.status === "active"
-                      ? "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300"
-                      : subscription.status === "past_due"
-                        ? "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300"
-                        : "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300"
-                  }`}
-                >
-                  {subscription.status}
-                </span>
-              </div>
-              {subscription.stripeSubscriptionId && (
-                <button
-                  onClick={handleManagePayment}
-                  className="flex items-center gap-1 text-sm text-[var(--primary)] hover:underline"
-                >
-                  Manage Payment <ExternalLink size={14} />
-                </button>
-              )}
-            </div>
-            {subscription.currentPeriodEnd && (
-              <p className="text-sm text-[var(--muted-foreground)]">
-                {subscription.cancelAtPeriodEnd
-                  ? "Cancels"
-                  : "Renews"}{" "}
-                on{" "}
-                {new Date(subscription.currentPeriodEnd).toLocaleDateString()}
-              </p>
-            )}
-            {!currentPlan.isRecurring && currentPlan.slug === "lifetime" && (
-              <p className="text-sm text-[var(--muted-foreground)]">
-                Lifetime access — no renewal needed
-              </p>
-            )}
-          </div>
-        </section>
+        </div>
       )}
 
-      {/* Usage Meters */}
-      {usage && currentPlan && (
-        <section className="space-y-4">
-          <h2 className="text-lg font-semibold">Usage</h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <UsageMeter
-              label="Projects"
-              current={usage.projects}
-              max={currentPlan.maxProjects}
-            />
-            <UsageMeter
-              label="Storage"
-              current={usage.storageMb}
-              max={currentPlan.maxStorageMb}
-              format="storage"
-            />
-            <UsageMeter
-              label="Team Members"
-              current={usage.members}
-              max={currentPlan.maxMembers}
-            />
-            <UsageMeter
-              label="Clients"
-              current={usage.clients}
-              max={currentPlan.maxClients}
-            />
-          </div>
-        </section>
-      )}
-
-      {/* Plan Cards */}
-      <section className="space-y-4">
-        <h2 className="text-lg font-semibold">Plans</h2>
-        <div className="grid gap-4 md:grid-cols-3">
+      {/* Plans — primary focus */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wide">Plans</h2>
+        <div className="grid gap-4 md:grid-cols-3 pt-4">
           {plans.map((plan) => (
             <PlanCard
               key={plan.id}
               plan={plan}
               isCurrentPlan={currentPlan?.slug === plan.slug}
+              isFree={isFree}
               lifetimeSeatsRemaining={lifetimeSeatsRemaining}
               onSelect={handleUpgrade}
               loadingSlug={checkoutLoadingSlug}
@@ -407,6 +352,51 @@ export function BillingSection() {
           ))}
         </div>
       </section>
+
+      {/* Current plan + usage — compact, secondary */}
+      {subscription && currentPlan && usage && (
+        <section className="rounded-lg border border-[var(--border)] p-4 space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <CreditCard size={14} className="text-[var(--muted-foreground)]" />
+              <span className="text-sm font-medium">{currentPlan.name}</span>
+              <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${
+                subscription.status === "active"
+                  ? "bg-green-500/15 text-green-600"
+                  : subscription.status === "past_due"
+                    ? "bg-amber-500/15 text-amber-600"
+                    : "bg-red-500/15 text-red-600"
+              }`}>
+                {subscription.status}
+              </span>
+              {subscription.currentPeriodEnd && (
+                <span className="text-xs text-[var(--muted-foreground)]">
+                  · {subscription.cancelAtPeriodEnd ? "Cancels" : "Renews"}{" "}
+                  {new Date(subscription.currentPeriodEnd).toLocaleDateString()}
+                </span>
+              )}
+              {!currentPlan.isRecurring && currentPlan.slug === "lifetime" && (
+                <span className="text-xs text-[var(--muted-foreground)]">· Lifetime access</span>
+              )}
+            </div>
+            {subscription.stripeSubscriptionId && (
+              <button
+                onClick={handleManagePayment}
+                className="flex items-center gap-1 text-xs text-[var(--primary)] hover:underline"
+              >
+                Manage <ExternalLink size={11} />
+              </button>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-x-6 gap-y-3">
+            <UsageMeter label="Projects" current={usage.projects} max={currentPlan.maxProjects} />
+            <UsageMeter label="Storage" current={usage.storageMb} max={currentPlan.maxStorageMb} format="storage" />
+            <UsageMeter label="Team Members" current={usage.members} max={currentPlan.maxMembers} />
+            <UsageMeter label="Clients" current={usage.clients} max={currentPlan.maxClients} />
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/settings/billing/billing-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/billing/billing-section.tsx
@@ -70,7 +70,7 @@ function UsageMeter({
   format?: "number" | "storage";
 }) {
   const isUnlimited = max === -1;
-  const pct = isUnlimited ? 0 : Math.min(100, (current / max) * 100);
+  const pct = (isUnlimited || max === 0) ? 0 : Math.min(100, (current / max) * 100);
   const displayMax = format === "storage" ? formatStorage(max) : formatLimit(max);
   const displayCurrent = format === "storage" ? formatStorage(current) : String(current);
   const color = pct >= 90 ? "var(--destructive, #ef4444)" : pct >= 70 ? "#f59e0b" : "var(--primary)";
@@ -102,6 +102,11 @@ const REASON_BANNER: Record<string, { icon: React.ElementType; text: string; sub
     icon: Users,
     text: "Free plan is limited to 3 clients and 1 team member.",
     sub: "Pro gives you unlimited clients and up to 5 team members.",
+  },
+  members: {
+    icon: Users,
+    text: "You've reached your team member limit on the Free plan.",
+    sub: "Upgrade to Pro for up to 5 team members, or Lifetime for 100.",
   },
   "custom-domain": {
     icon: Globe,
@@ -195,7 +200,7 @@ function PlanCard({
           <div className="h-1 bg-[var(--muted)] rounded-full overflow-hidden">
             <div
               className="h-full rounded-full bg-amber-500 transition-all"
-              style={{ width: `${Math.min(100, (seatsLeft / plan.maxSeats) * 100)}%` }}
+              style={{ width: `${Math.min(100, ((plan.maxSeats - seatsLeft) / plan.maxSeats) * 100)}%` }}
             />
           </div>
         </div>
@@ -252,9 +257,14 @@ export function BillingSection() {
   const [checkoutLoadingSlug, setCheckoutLoadingSlug] = useState<string | null>(null);
   const { success, error: showError } = useToast();
 
-  const searchParams = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
-  const checkoutSuccess = searchParams?.get("success") === "true";
-  const reason = searchParams?.get("reason") ?? null;
+  // Capture URL params once at mount — replaceState later clears them from the URL
+  // so we must not re-derive these on every render.
+  const [checkoutSuccess] = useState(() =>
+    typeof window !== "undefined" ? new URLSearchParams(window.location.search).get("success") === "true" : false,
+  );
+  const [reason] = useState(() =>
+    typeof window !== "undefined" ? new URLSearchParams(window.location.search).get("reason") ?? null : null,
+  );
   const reasonBanner = reason ? REASON_BANNER[reason] ?? null : null;
 
   useEffect(() => {

--- a/apps/web/src/app/(dashboard)/dashboard/settings/system/custom-domain-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/system/custom-domain-section.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Check, Copy, ExternalLink, Lock, RefreshCw, Sparkles, X } from "lucide-react";
+import { Check, Copy, ExternalLink, RefreshCw, Sparkles, X } from "lucide-react";
 import { apiFetch } from "@/lib/api";
 import { useToast } from "@/components/toast";
 
 interface Subscription {
-  plan: { slug: string };
+  subscription: { plan: { slug: string } } | null;
 }
 
 interface CustomDomainData {
@@ -177,7 +177,7 @@ export function CustomDomainSection() {
       apiFetch<Subscription>("/billing/subscription").catch(() => null),
       apiFetch<CustomDomainData>("/settings/custom-domain").catch(() => null),
     ]).then(([sub, domainData]) => {
-      setIsPaid(!sub || sub.plan?.slug !== "free");
+      setIsPaid(!sub || sub.subscription?.plan?.slug !== "free");
       if (domainData?.customDomain) {
         setSavedDomain(domainData.customDomain);
         setDomain(domainData.customDomain);
@@ -242,33 +242,25 @@ export function CustomDomainSection() {
   // Free plan — premium feature gate
   if (!isPaid) {
     return (
-      <div className="relative overflow-hidden rounded-lg border border-[var(--border)] p-5">
-        <div className="flex items-start gap-3">
-          <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--muted)]">
-            <Lock size={15} className="text-[var(--muted-foreground)]" />
-          </div>
-          <div className="space-y-1">
-            <p className="text-sm font-semibold">Custom Domain</p>
-            <p className="text-xs text-[var(--muted-foreground)] leading-relaxed">
-              Point your own domain (e.g. <span className="font-mono">portal.yourcompany.com</span>) to
-              your client portal so clients never see our URL.
-            </p>
-          </div>
-          <div className="ml-auto flex shrink-0 items-center gap-1 rounded-full bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-700 border border-amber-200">
-            <Sparkles size={11} />
-            Pro
-          </div>
+      <div className="flex gap-2">
+        <div className="relative flex-1">
+          <input
+            type="text"
+            placeholder="portal.yourcompany.com"
+            disabled
+            className="w-full px-3 py-2 pr-16 border border-[var(--border)] rounded-lg bg-[var(--muted)] text-sm text-[var(--muted-foreground)] cursor-not-allowed select-none"
+          />
+          <span className="absolute right-2.5 top-1/2 -translate-y-1/2 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-amber-500/15 text-amber-600 text-[10px] font-semibold tracking-wide">
+            <Sparkles size={9} />
+            PRO
+          </span>
         </div>
-        <div className="mt-4 pt-4 border-t border-[var(--border)] flex items-center justify-between">
-          <p className="text-xs text-[var(--muted-foreground)]">Includes automatic SSL — no extra setup.</p>
-          <a
-            href="/dashboard/settings/billing"
-            className="flex items-center gap-1 text-xs font-medium text-[var(--primary)] hover:underline"
-          >
-            Upgrade to Pro
-            <ExternalLink size={11} />
-          </a>
-        </div>
+        <a
+          href="/dashboard/settings/account?tab=billing&reason=custom-domain"
+          className="shrink-0 flex items-center gap-1.5 px-4 py-2 bg-[var(--primary)] text-white rounded-lg text-sm font-semibold hover:opacity-90 transition-opacity whitespace-nowrap"
+        >
+          Upgrade to Pro
+        </a>
       </div>
     );
   }

--- a/apps/web/src/app/(dashboard)/dashboard/settings/system/custom-domain-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/system/custom-domain-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Check, Copy, ExternalLink, RefreshCw, Sparkles, X } from "lucide-react";
+import { Check, Copy, RefreshCw, Sparkles, X } from "lucide-react";
 import { apiFetch } from "@/lib/api";
 import { useToast } from "@/components/toast";
 

--- a/e2e/tests/activity-feed.e2e.ts
+++ b/e2e/tests/activity-feed.e2e.ts
@@ -233,8 +233,8 @@ test.describe("Activity Feed", () => {
       // Wait for timeline to load - check for either update content or activity entries
       await page.waitForTimeout(1000);
 
-      // The page should load without errors
-      await expect(page.locator("body")).not.toContainText("error", {
+      // The page should load without an error state (project failed to load)
+      await expect(page.locator(".bg-red-50")).not.toBeVisible({
         timeout: 3000,
       });
     });

--- a/e2e/tests/invoices.e2e.ts
+++ b/e2e/tests/invoices.e2e.ts
@@ -191,6 +191,45 @@ test.describe("Invoices", () => {
       expect(body).toHaveProperty("totalInvoices");
       expect(body).toHaveProperty("paidAmount");
     });
+
+    test("delete draft invoice via API", async ({ request }) => {
+      const csrfToken = getCsrfToken();
+      const invoiceId = await createTestInvoice(request);
+
+      const res = await request.delete(`${API}/invoices/${invoiceId}`, {
+        headers: { "x-csrf-token": csrfToken },
+      });
+      expect(res.ok()).toBeTruthy();
+
+      // Verify the invoice is gone
+      const getRes = await request.get(`${API}/invoices/${invoiceId}`);
+      expect(getRes.status()).toBe(404);
+    });
+
+    test("delete sent invoice via API", async ({ request }) => {
+      const csrfToken = getCsrfToken();
+      const invoiceId = await createTestInvoice(request);
+
+      // Transition to sent
+      await request.put(`${API}/invoices/${invoiceId}`, {
+        data: { status: "sent" },
+        headers: { "x-csrf-token": csrfToken },
+      });
+
+      const res = await request.delete(`${API}/invoices/${invoiceId}`, {
+        headers: { "x-csrf-token": csrfToken },
+      });
+      expect(res.ok()).toBeTruthy();
+    });
+
+    test("cannot delete nonexistent invoice", async ({ request }) => {
+      const csrfToken = getCsrfToken();
+      const res = await request.delete(
+        `${API}/invoices/00000000-0000-0000-0000-000000000000`,
+        { headers: { "x-csrf-token": csrfToken } },
+      );
+      expect(res.status()).toBe(404);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/e2e/tests/system-settings.e2e.ts
+++ b/e2e/tests/system-settings.e2e.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { getCsrfToken } from "./helpers";
 
 test.describe("System Settings", () => {
   test("system settings page loads", async ({ page }) => {
@@ -131,7 +132,9 @@ test.describe("System Settings", () => {
     await expect(page.getByText("Loading...")).not.toBeVisible({ timeout: 5000 });
 
     await expect(page.getByRole("heading", { name: /error reporting/i })).toBeVisible();
-    await expect(page.getByText(/share anonymous crash reports/i)).toBeVisible();
+    await expect(
+      page.locator("section").filter({ hasText: /error reporting/i }).getByText(/share anonymous crash reports/i)
+    ).toBeVisible();
   });
 
   test("can toggle error reporting on and off", async ({ page }) => {
@@ -154,8 +157,10 @@ test.describe("System Settings", () => {
 
   test("telemetry consent banner appears when preference not yet set", async ({ page, request }) => {
     // Reset telemetryEnabled to null via the settings API
+    const csrfToken = getCsrfToken();
     await request.patch("http://localhost:3001/api/settings", {
       data: { telemetryEnabled: null },
+      headers: { "x-csrf-token": csrfToken },
     });
 
     await page.goto("/dashboard");
@@ -165,8 +170,10 @@ test.describe("System Settings", () => {
   });
 
   test("accepting telemetry consent banner dismisses it", async ({ page, request }) => {
+    const csrfToken = getCsrfToken();
     await request.patch("http://localhost:3001/api/settings", {
       data: { telemetryEnabled: null },
+      headers: { "x-csrf-token": csrfToken },
     });
 
     await page.goto("/dashboard");
@@ -175,8 +182,10 @@ test.describe("System Settings", () => {
   });
 
   test("declining telemetry consent banner dismisses it", async ({ page, request }) => {
+    const csrfToken = getCsrfToken();
     await request.patch("http://localhost:3001/api/settings", {
       data: { telemetryEnabled: null },
+      headers: { "x-csrf-token": csrfToken },
     });
 
     await page.goto("/dashboard");
@@ -185,8 +194,10 @@ test.describe("System Settings", () => {
   });
 
   test("consent banner does not appear when preference already set", async ({ page, request }) => {
+    const csrfToken = getCsrfToken();
     await request.patch("http://localhost:3001/api/settings", {
       data: { telemetryEnabled: false },
+      headers: { "x-csrf-token": csrfToken },
     });
 
     await page.goto("/dashboard");

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -67,6 +67,7 @@ const plans = [
       "25 GB storage",
       "100 team members",
       "Unlimited clients",
+      "Founder Discord access",
       "Limited to 100 total seats",
     ],
     description: "One-time payment, lifetime access",

--- a/scripts/upgrade-to-pro.ts
+++ b/scripts/upgrade-to-pro.ts
@@ -1,0 +1,43 @@
+/**
+ * Upgrades your organization's subscription to Pro directly in the DB.
+ * Run with: bun scripts/upgrade-to-pro.ts
+ */
+import { PrismaClient } from "../packages/database/src/index";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const proPlan = await prisma.subscriptionPlan.findUnique({ where: { slug: "pro" } });
+  if (!proPlan) {
+    console.error("Pro plan not found — run `bun run db:seed` first.");
+    process.exit(1);
+  }
+
+  // Find all orgs (usually just one in local dev)
+  const orgs = await prisma.organization.findMany({ select: { id: true, name: true } });
+  if (orgs.length === 0) {
+    console.error("No organizations found.");
+    process.exit(1);
+  }
+
+  for (const org of orgs) {
+    await prisma.subscription.upsert({
+      where: { organizationId: org.id },
+      create: {
+        organizationId: org.id,
+        planId: proPlan.id,
+        status: "active",
+      },
+      update: {
+        planId: proPlan.id,
+        status: "active",
+        cancelAtPeriodEnd: false,
+      },
+    });
+    console.log(`✓ Upgraded "${org.name}" to Pro`);
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

- **Upsell prompts** — Free-plan users see contextual upgrade CTAs at the point of friction: usage counter + upgrade card on Projects, member/client limit banners on People, locked input with `PRO` badge on Custom Domain
- **Billing page redesign** — Plans section first, Pro card highlighted with teal border + "Most Popular" badge, Lifetime card with founding member spots meter and "Become a Founding Member" CTA, compact usage meters
- **Contextual upgrade banner** — Billing page shows a relevant message when arriving from a upsell link (`?reason=projects/clients/custom-domain`)
- **Invoice delete fix** — Delete button was hidden for `overdue`/`cancelled` invoices; now any non-`paid` invoice without a Stripe payment intent can be deleted

## Bug Fixes

- Billing API response shape mismatch (`sub.plan` → `sub.subscription.plan`) causing plan limits to never apply
- Billing tab not opening when navigating via `?tab=billing` link due to missing `billingEnabled` dependency
- Upgrade links bouncing through `/dashboard/settings/billing` redirect — now point directly to `?tab=billing`

## Test plan

- [x] Free plan: verify upsell prompts appear on Projects, People, and Custom Domain pages
- [x] Free plan: verify "Upgrade to Pro" links land on billing tab with correct context banner
- [x] Billing page: Pro card has teal border and Most Popular badge, all cards same height
- [x] Billing page: Lifetime card shows founding member spots meter
- [ ] Create an invoice, let it go overdue, verify delete button appears
- [ ] E2e: `bun run test:e2e` invoice delete tests pass