### PR TITLE
feat: link files, oembed/OG previews, inline edits, and project duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Atrium will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Link-type file entries** — The Files section now supports adding external links (Nextcloud, Canva, Notion, Google Drive, etc.) alongside hard-uploaded files. A single "+ Add" menu on the project files header replaces the previous upload button with two clearly labeled options (Upload file / Add link). Link entries open in a new tab and do not count against the plan storage quota. Visible read-only in the client portal.
+- **oEmbed discovery for project updates** — Project update URLs are now resolved via a server-side oEmbed registry covering Canva, Spotify, SoundCloud, CodePen, and Vimeo. Existing regex providers (YouTube, Loom, Figma, Google Docs) remain a zero-network fast path. Provider HTML is sanitized to an iframe-only allowlist with per-provider host pinning; failed resolutions silently degrade to plain links. Embed cards are capped to `max-w-xl` so they don't dominate the timeline. Twitter/X is intentionally deferred — its oEmbed response is a `<blockquote>` + widgets.js script, which our iframe-only sanitizer rejects.
+
+### Changed
+
+- `POST /files/link` endpoint added (owner/admin only). `download`/`remove` paths branch on file `type` so link entries are never fetched from storage. CSP `frame-src` extended for the new providers' embed hosts.
+
+### Database
+
+- `File.type` (`UPLOAD | LINK`, default `UPLOAD`), `File.url`, `File.description` added. `storageKey`/`mimeType`/`sizeBytes` are now nullable to accommodate link entries; all existing readers filter to `type = UPLOAD` or tolerate nulls.
+
 ## [1.4.4] — 2026-04-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,3 +115,4 @@ See `.env.example` for all variables.
 ## Git
 
 - Never add `Co-Authored-By` lines to commit messages. All commits should show only the user as author.
+- **Releases mean tagging, not PRs.** When asked to "create a release", create a git tag on `main` (e.g. `git tag v1.4.3 && git push origin v1.4.3`). Do not open a PR for a release. PRs are for feature branches merging into main.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -41,6 +41,7 @@
     "reflect-metadata": "^0.2.2",
     "resend": "^4.1.0",
     "rxjs": "^7.8.1",
+    "sanitize-html": "^2.17.3",
     "stripe": "^20.4.0",
     "web-push": "^3.6.7"
   },
@@ -53,6 +54,7 @@
     "@types/multer": "^2.1.0",
     "@types/nodemailer": "^7.0.11",
     "@types/pdfkit": "^0.17.5",
+    "@types/sanitize-html": "^2.16.1",
     "@types/web-push": "^3.6.4",
     "bun-types": "^1.3.9",
     "pino-pretty": "^13.1.3",

--- a/apps/api/src/account/account.service.spec.ts
+++ b/apps/api/src/account/account.service.spec.ts
@@ -407,9 +407,15 @@ describe("AccountService", () => {
 
       await service.deleteAccount("user-1", "correct-password");
 
-      // Storage keys should be queried for the org being deleted
+      // Storage keys should be queried for the org being deleted, scoped to
+      // UPLOAD-type files with a non-null storageKey (link-type files have no
+      // storage to purge).
       expect(mockPrisma.file.findMany).toHaveBeenCalledWith({
-        where: { organizationId: { in: ["org-1"] } },
+        where: {
+          organizationId: { in: ["org-1"] },
+          type: "UPLOAD",
+          storageKey: { not: null },
+        },
         select: { storageKey: true },
       });
 

--- a/apps/api/src/account/account.service.ts
+++ b/apps/api/src/account/account.service.ts
@@ -97,10 +97,10 @@ export class AccountService {
     let storageKeys: string[] = [];
     if (orgsToDelete.length > 0) {
       const files = await this.prisma.file.findMany({
-        where: { organizationId: { in: orgsToDelete } },
+        where: { organizationId: { in: orgsToDelete }, type: "UPLOAD", storageKey: { not: null } },
         select: { storageKey: true },
       });
-      storageKeys = files.map((f) => f.storageKey);
+      storageKeys = files.map((f) => f.storageKey).filter((k): k is string => k !== null);
     }
 
     await this.prisma.$transaction(async (tx) => {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -26,6 +26,7 @@ import { ActivityModule } from "./activity/activity.module";
 import { CommentsModule } from "./comments/comments.module";
 import { LabelsModule } from "./labels/labels.module";
 import { PaymentsModule } from "./payments/payments.module";
+import { EmbedsModule } from "./embeds/embeds.module";
 import { HealthController } from "./health.controller";
 import { SessionMiddleware } from "./auth/session.middleware";
 import { AllExceptionsFilter } from "./common";
@@ -79,6 +80,7 @@ import { PlanGuard } from "./common/guards/plan.guard";
     CommentsModule,
     LabelsModule,
     PaymentsModule,
+    EmbedsModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -438,6 +438,7 @@ export class DocumentsService {
     await assertProjectAccess(this.prisma, doc.projectId, userId, role);
 
     const fileToView = doc.signedFile ?? doc.file;
+    if (!fileToView.storageKey) throw new NotFoundException("Document file has no storage object");
     const { body, contentType } = await this.storage.download(fileToView.storageKey);
 
     this.auditService.log(id, "downloaded", { userId });
@@ -619,6 +620,7 @@ export class DocumentsService {
 
       // Download the latest signed PDF (or original)
       const sourceFile = doc.signedFileId ? doc.signedFile! : doc.file;
+      if (!sourceFile.storageKey) throw new BadRequestException("Document source file has no storage object");
       const { body: pdfStream } = await this.storage.download(sourceFile.storageKey);
 
       const pdfChunks: Buffer[] = [];
@@ -752,8 +754,8 @@ export class DocumentsService {
       title: string;
       projectId: string;
       signedFileId: string | null;
-      signedFile: { storageKey: string } | null;
-      file: { storageKey: string };
+      signedFile: { storageKey: string | null } | null;
+      file: { storageKey: string | null };
     },
     field: { pageNumber: number; x: number; y: number; width: number; height: number },
     text: string,
@@ -770,6 +772,7 @@ export class DocumentsService {
     },
   ) {
     const sourceFile = doc.signedFileId ? doc.signedFile! : doc.file;
+    if (!sourceFile.storageKey) throw new BadRequestException("Document source file has no storage object");
     const { body: pdfStream } = await this.storage.download(sourceFile.storageKey);
 
     const pdfChunks: Buffer[] = [];
@@ -918,9 +921,11 @@ export class DocumentsService {
     });
     if (!doc) throw new NotFoundException("Document not found");
 
-    // Collect all storage keys to delete
-    const keysToDelete: string[] = [doc.file.storageKey];
-    if (doc.signedFile) {
+    // Collect all storage keys to delete (documents always back onto uploads, so storageKey should be non-null,
+    // but we filter defensively in case of data drift)
+    const keysToDelete: string[] = [];
+    if (doc.file.storageKey) keysToDelete.push(doc.file.storageKey);
+    if (doc.signedFile?.storageKey) {
       keysToDelete.push(doc.signedFile.storageKey);
     }
 
@@ -932,7 +937,7 @@ export class DocumentsService {
     // Version file storage keys
     const versionFileIds: string[] = [];
     for (const v of doc.versions) {
-      keysToDelete.push(v.file.storageKey);
+      if (v.file.storageKey) keysToDelete.push(v.file.storageKey);
       versionFileIds.push(v.fileId);
     }
 
@@ -1038,7 +1043,7 @@ export class DocumentsService {
 
       // Clean up old signed file record + blob
       if (doc.signedFileId && doc.signedFile) {
-        keysToDelete.push(doc.signedFile.storageKey);
+        if (doc.signedFile.storageKey) keysToDelete.push(doc.signedFile.storageKey);
         await tx.file.deleteMany({ where: { id: doc.signedFileId } });
       }
 
@@ -1169,7 +1174,7 @@ export class DocumentsService {
         await tx.documentResponse.deleteMany({ where: { documentId: id } });
       }
       if (doc.signedFileId && doc.signedFile) {
-        keysToDelete.push(doc.signedFile.storageKey);
+        if (doc.signedFile.storageKey) keysToDelete.push(doc.signedFile.storageKey);
         await tx.file.deleteMany({ where: { id: doc.signedFileId } });
       }
 

--- a/apps/api/src/embeds/embeds.controller.ts
+++ b/apps/api/src/embeds/embeds.controller.ts
@@ -1,0 +1,60 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  NotFoundException,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { AuthGuard } from "../common";
+import { EmbedsService, OEmbedResult } from "./embeds.service";
+import { findProvider } from "./providers";
+import { UnfurlCard, UnfurlService } from "./unfurl.service";
+
+@Controller("embeds")
+@UseGuards(AuthGuard)
+export class EmbedsController {
+  constructor(
+    private readonly embedsService: EmbedsService,
+    private readonly unfurlService: UnfurlService,
+  ) {}
+
+  @Get("resolve")
+  async resolve(@Query("url") url: string): Promise<OEmbedResult> {
+    if (!url || typeof url !== "string") {
+      throw new BadRequestException("Missing url query parameter");
+    }
+
+    if (!findProvider(url)) {
+      throw new NotFoundException("No oEmbed provider for this URL");
+    }
+
+    const result = await this.embedsService.resolve(url);
+    if (!result) {
+      throw new NotFoundException("Unable to resolve embed for this URL");
+    }
+    return result;
+  }
+
+  @Get("unfurl")
+  async unfurl(@Query("url") url: string): Promise<UnfurlCard> {
+    if (!url || typeof url !== "string") {
+      throw new BadRequestException("Missing url query parameter");
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new BadRequestException("Invalid URL");
+    }
+    if (parsed.protocol !== "https:") {
+      throw new BadRequestException("Only https URLs are supported");
+    }
+
+    const card = await this.unfurlService.unfurl(url);
+    if (!card) {
+      throw new NotFoundException("Could not unfurl this URL");
+    }
+    return card;
+  }
+}

--- a/apps/api/src/embeds/embeds.module.ts
+++ b/apps/api/src/embeds/embeds.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { EmbedsController } from "./embeds.controller";
+import { EmbedsService } from "./embeds.service";
+import { UnfurlService } from "./unfurl.service";
+
+@Module({
+  controllers: [EmbedsController],
+  providers: [EmbedsService, UnfurlService],
+  exports: [EmbedsService, UnfurlService],
+})
+export class EmbedsModule {}

--- a/apps/api/src/embeds/embeds.service.spec.ts
+++ b/apps/api/src/embeds/embeds.service.spec.ts
@@ -1,0 +1,203 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { EmbedsService } from "./embeds.service";
+import { findProvider, OEMBED_PROVIDERS } from "./providers";
+
+describe("findProvider", () => {
+  test("matches a direct hostname", () => {
+    expect(findProvider("https://codepen.io/foo/pen/abc")?.name).toBe("CodePen");
+  });
+
+  test("matches after stripping leading www.", () => {
+    expect(findProvider("https://www.canva.com/design/xyz")?.name).toBe("Canva");
+  });
+
+  test("matches subdomains declared in the registry (open.spotify.com)", () => {
+    expect(
+      findProvider("https://open.spotify.com/track/abc")?.name,
+    ).toBe("Spotify");
+  });
+
+  test("returns null for Twitter/X URLs (not in v1 registry)", () => {
+    expect(findProvider("https://x.com/user/status/1")).toBeNull();
+    expect(findProvider("https://twitter.com/user/status/1")).toBeNull();
+  });
+
+  test("returns null for an unknown host", () => {
+    expect(findProvider("https://example.com/whatever")).toBeNull();
+  });
+
+  test("returns null for a suffix-style attacker host (canva.com.evil.com)", () => {
+    expect(findProvider("https://canva.com.evil.com/foo")).toBeNull();
+  });
+
+  test("returns null for a malformed URL", () => {
+    expect(findProvider("not a url")).toBeNull();
+  });
+
+  test("returns null for non-http(s) schemes", () => {
+    expect(findProvider("javascript:alert(1)")).toBeNull();
+    expect(findProvider("ftp://canva.com/x")).toBeNull();
+  });
+});
+
+describe("EmbedsService.resolve", () => {
+  let service: EmbedsService;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    service = new EmbedsService();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("returns null when no provider matches", async () => {
+    const result = await service.resolve("https://example.com/whatever");
+    expect(result).toBeNull();
+  });
+
+  test("returns sanitized iframe HTML for a valid provider response", async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          html:
+            '<iframe src="https://codepen.io/anon/embed/abc" width="800" height="400"></iframe>',
+          width: 800,
+          height: 400,
+          title: "A pen",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    ) as unknown as typeof fetch;
+
+    const result = await service.resolve("https://codepen.io/anon/pen/abc");
+    expect(result).not.toBeNull();
+    expect(result!.providerName).toBe("CodePen");
+    expect(result!.html).toContain("<iframe");
+    expect(result!.html).toContain("https://codepen.io/anon/embed/abc");
+    expect(result!.width).toBe(800);
+    expect(result!.height).toBe(400);
+    expect(result!.title).toBe("A pen");
+  });
+
+  test("strips <script> tags from the provider response", async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          html:
+            '<script>alert("xss")</script><iframe src="https://codepen.io/anon/embed/abc"></iframe>',
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    ) as unknown as typeof fetch;
+
+    const result = await service.resolve("https://codepen.io/anon/pen/abc");
+    expect(result).not.toBeNull();
+    expect(result!.html).not.toContain("<script");
+    expect(result!.html).not.toContain("alert(");
+    expect(result!.html).toContain("<iframe");
+  });
+
+  test("rejects iframes whose src is not on the provider's allowlist", async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          html: '<iframe src="https://attacker.example.com/pwn"></iframe>',
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    ) as unknown as typeof fetch;
+
+    const result = await service.resolve("https://codepen.io/anon/pen/abc");
+    // sanitize-html drops the iframe whose host isn't in iframeHostnames,
+    // leaving no iframe in the output → service returns null.
+    expect(result).toBeNull();
+  });
+
+  test("strips dangerous attributes like onload and srcdoc", async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          html:
+            '<iframe src="https://codepen.io/anon/embed/abc" onload="alert(1)" srcdoc="<p>x</p>"></iframe>',
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    ) as unknown as typeof fetch;
+
+    const result = await service.resolve("https://codepen.io/anon/pen/abc");
+    expect(result).not.toBeNull();
+    expect(result!.html).not.toContain("onload");
+    expect(result!.html).not.toContain("srcdoc");
+  });
+
+  test("returns null when the provider response has no html", async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(JSON.stringify({ type: "video" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ) as unknown as typeof fetch;
+
+    const result = await service.resolve("https://codepen.io/anon/pen/abc");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when the provider returns a non-2xx status", async () => {
+    globalThis.fetch = mock(async () =>
+      new Response("not found", { status: 404 }),
+    ) as unknown as typeof fetch;
+
+    const result = await service.resolve("https://codepen.io/anon/pen/abc");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when the fetch throws", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("network");
+    }) as unknown as typeof fetch;
+
+    const result = await service.resolve("https://codepen.io/anon/pen/abc");
+    expect(result).toBeNull();
+  });
+
+  test("caches successful lookups (second call does not hit fetch)", async () => {
+    let calls = 0;
+    globalThis.fetch = mock(async () => {
+      calls++;
+      return new Response(
+        JSON.stringify({
+          html: '<iframe src="https://codepen.io/anon/embed/abc"></iframe>',
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    await service.resolve("https://codepen.io/anon/pen/abc");
+    await service.resolve("https://codepen.io/anon/pen/abc");
+    expect(calls).toBe(1);
+  });
+});
+
+describe("OEMBED_PROVIDERS registry", () => {
+  test("includes Canva, Spotify, SoundCloud, CodePen, Vimeo", () => {
+    const names = OEMBED_PROVIDERS.map((p) => p.name);
+    expect(names).toContain("Canva");
+    expect(names).toContain("Spotify");
+    expect(names).toContain("SoundCloud");
+    expect(names).toContain("CodePen");
+    expect(names).toContain("Vimeo");
+  });
+
+  test("does not include Twitter (requires blockquote+script support)", () => {
+    const names = OEMBED_PROVIDERS.map((p) => p.name);
+    expect(names).not.toContain("Twitter");
+  });
+
+  test("every provider uses an https endpoint", () => {
+    for (const p of OEMBED_PROVIDERS) {
+      expect(p.endpoint.startsWith("https://")).toBe(true);
+    }
+  });
+});

--- a/apps/api/src/embeds/embeds.service.ts
+++ b/apps/api/src/embeds/embeds.service.ts
@@ -1,0 +1,152 @@
+import { Injectable, Logger } from "@nestjs/common";
+import sanitizeHtml from "sanitize-html";
+import { findProvider, OEmbedProvider } from "./providers";
+
+export interface OEmbedResult {
+  html: string;
+  width?: number;
+  height?: number;
+  providerName: string;
+  thumbnailUrl?: string;
+  title?: string;
+}
+
+interface CacheEntry {
+  value: OEmbedResult | null;
+  expiresAt: number;
+}
+
+const CACHE_MAX = 500;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const FETCH_TIMEOUT_MS = 5000;
+
+@Injectable()
+export class EmbedsService {
+  private readonly logger = new Logger(EmbedsService.name);
+  private readonly cache = new Map<string, CacheEntry>();
+
+  async resolve(url: string): Promise<OEmbedResult | null> {
+    const provider = findProvider(url);
+    if (!provider) return null;
+
+    const cacheKey = `${provider.name}:${url}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    let result: OEmbedResult | null = null;
+    try {
+      result = await this.fetchAndSanitize(provider, url);
+    } catch (err) {
+      this.logger.warn(`oEmbed fetch failed for ${url}: ${(err as Error).message}`);
+      result = null;
+    }
+
+    this.storeInCache(cacheKey, result);
+    return result;
+  }
+
+  private async fetchAndSanitize(
+    provider: OEmbedProvider,
+    url: string,
+  ): Promise<OEmbedResult | null> {
+    const endpoint = `${provider.endpoint}?url=${encodeURIComponent(url)}&format=json`;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetch(endpoint, {
+        signal: controller.signal,
+        headers: { Accept: "application/json" },
+        redirect: "follow",
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      this.logger.debug(
+        `oEmbed provider ${provider.name} returned ${response.status} for ${url}`,
+      );
+      return null;
+    }
+
+    const data = (await response.json()) as Record<string, unknown>;
+    const rawHtml = typeof data.html === "string" ? data.html : null;
+    if (!rawHtml) return null;
+
+    const sanitized = this.sanitizeIframeHtml(rawHtml, provider);
+    if (!sanitized) return null;
+
+    return {
+      html: sanitized,
+      width: typeof data.width === "number" ? data.width : undefined,
+      height: typeof data.height === "number" ? data.height : undefined,
+      providerName: provider.name,
+      thumbnailUrl:
+        typeof data.thumbnail_url === "string" ? data.thumbnail_url : undefined,
+      title: typeof data.title === "string" ? data.title : undefined,
+    };
+  }
+
+  /**
+   * Strip everything except a single `<iframe>` element with a narrowly
+   * allowed attribute set. Returns `null` if the result would be empty.
+   *
+   * The `src` attribute is additionally constrained to the provider's
+   * expected iframe hostnames (when declared) to limit what a compromised
+   * or misbehaving provider can get us to frame.
+   */
+  private sanitizeIframeHtml(
+    rawHtml: string,
+    provider: OEmbedProvider,
+  ): string | null {
+    const allowedIframeHosts = provider.iframeHostnames?.map((h) =>
+      h.toLowerCase(),
+    );
+
+    const clean = sanitizeHtml(rawHtml, {
+      allowedTags: ["iframe"],
+      allowedAttributes: {
+        iframe: [
+          "src",
+          "width",
+          "height",
+          "frameborder",
+          "allow",
+          "allowfullscreen",
+          "allowtransparency",
+          "scrolling",
+          "title",
+          "loading",
+          "referrerpolicy",
+        ],
+      },
+      allowedSchemesByTag: { iframe: ["https"] },
+      allowedIframeHostnames: allowedIframeHosts,
+      // Reject any attribute not explicitly listed.
+      disallowedTagsMode: "discard",
+      // Drop comments and scripts.
+      allowedSchemes: ["https"],
+    });
+
+    const trimmed = clean.trim();
+    // Require an iframe with a valid src — sanitize-html keeps the <iframe>
+    // tag even when it strips a disallowed src, so we must reject that case
+    // explicitly.
+    if (!trimmed || !/<iframe[^>]+src=/i.test(trimmed)) return null;
+    return trimmed;
+  }
+
+  private storeInCache(key: string, value: OEmbedResult | null) {
+    if (this.cache.size >= CACHE_MAX) {
+      // Evict the oldest entry (Maps preserve insertion order).
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey !== undefined) this.cache.delete(oldestKey);
+    }
+    this.cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+  }
+}

--- a/apps/api/src/embeds/providers.ts
+++ b/apps/api/src/embeds/providers.ts
@@ -1,0 +1,79 @@
+/**
+ * Curated oEmbed provider registry.
+ *
+ * Maps a request URL's hostname to the provider's oEmbed endpoint. We only
+ * resolve URLs whose hostname appears here — link-rel autodiscovery is not
+ * performed as it would expand the SSRF surface.
+ */
+
+export interface OEmbedProvider {
+  name: string;
+  /** Hostnames (exact match, lowercased, no leading `www.`) served by this provider. */
+  hostnames: string[];
+  /** oEmbed endpoint returning JSON. Appended with `?url=<encoded>&format=json`. */
+  endpoint: string;
+  /**
+   * Optional allowed iframe `src` hostnames returned by the provider's HTML.
+   * When set, the sanitizer will reject iframes whose src host isn't in this list.
+   */
+  iframeHostnames?: string[];
+}
+
+export const OEMBED_PROVIDERS: OEmbedProvider[] = [
+  {
+    name: "Canva",
+    hostnames: ["canva.com"],
+    endpoint: "https://www.canva.com/_oembed",
+    iframeHostnames: ["canva.com", "www.canva.com"],
+  },
+  {
+    name: "Spotify",
+    hostnames: ["spotify.com", "open.spotify.com"],
+    endpoint: "https://open.spotify.com/oembed",
+    iframeHostnames: ["open.spotify.com"],
+  },
+  {
+    name: "SoundCloud",
+    hostnames: ["soundcloud.com"],
+    endpoint: "https://soundcloud.com/oembed",
+    iframeHostnames: ["w.soundcloud.com", "soundcloud.com"],
+  },
+  {
+    name: "CodePen",
+    hostnames: ["codepen.io"],
+    endpoint: "https://codepen.io/api/oembed",
+    iframeHostnames: ["codepen.io"],
+  },
+  {
+    name: "Vimeo",
+    hostnames: ["vimeo.com"],
+    endpoint: "https://vimeo.com/api/oembed.json",
+    iframeHostnames: ["player.vimeo.com"],
+  },
+  // Twitter/X is intentionally NOT in this registry. Its oEmbed response is a
+  // <blockquote> plus <script src="https://platform.twitter.com/widgets.js">,
+  // which our iframe-only sanitizer correctly rejects. Supporting it requires
+  // a separate code path (allowing a pinned Twitter widgets script) or using
+  // an unofficial platform.twitter.com embed URL. Tracked as a follow-up.
+];
+
+/**
+ * Find the provider whose hostname list matches the given URL, if any.
+ * Matches on exact host (after stripping leading `www.`) so that
+ * `open.spotify.com` matches but `evil-spotify.com.attacker.com` does not.
+ */
+export function findProvider(rawUrl: string): OEmbedProvider | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+
+  const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+  for (const provider of OEMBED_PROVIDERS) {
+    if (provider.hostnames.includes(host)) return provider;
+  }
+  return null;
+}

--- a/apps/api/src/embeds/safe-fetch.spec.ts
+++ b/apps/api/src/embeds/safe-fetch.spec.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from "bun:test";
+import { isPrivateAddress, safeFetch, SsrfError } from "./safe-fetch";
+
+describe("isPrivateAddress — IPv4", () => {
+  test("flags 0.0.0.0", () => {
+    expect(isPrivateAddress("0.0.0.0")).toBe(true);
+  });
+
+  test("flags loopback (127.x.x.x)", () => {
+    expect(isPrivateAddress("127.0.0.1")).toBe(true);
+    expect(isPrivateAddress("127.1.2.3")).toBe(true);
+  });
+
+  test("flags the classic private ranges", () => {
+    expect(isPrivateAddress("10.0.0.1")).toBe(true);
+    expect(isPrivateAddress("172.16.5.5")).toBe(true);
+    expect(isPrivateAddress("172.31.255.254")).toBe(true);
+    expect(isPrivateAddress("192.168.1.1")).toBe(true);
+  });
+
+  test("flags link-local incl. the AWS metadata address 169.254.169.254", () => {
+    expect(isPrivateAddress("169.254.169.254")).toBe(true);
+    expect(isPrivateAddress("169.254.0.1")).toBe(true);
+  });
+
+  test("flags carrier-grade NAT (100.64.0.0/10)", () => {
+    expect(isPrivateAddress("100.64.0.1")).toBe(true);
+    expect(isPrivateAddress("100.127.255.254")).toBe(true);
+    // Just outside CGNAT is public.
+    expect(isPrivateAddress("100.128.0.1")).toBe(false);
+  });
+
+  test("flags multicast and reserved", () => {
+    expect(isPrivateAddress("224.0.0.1")).toBe(true);
+    expect(isPrivateAddress("255.255.255.255")).toBe(true);
+  });
+
+  test("allows typical public addresses", () => {
+    expect(isPrivateAddress("1.1.1.1")).toBe(false);
+    expect(isPrivateAddress("8.8.8.8")).toBe(false);
+    expect(isPrivateAddress("172.15.0.1")).toBe(false); // just outside 172.16/12
+    expect(isPrivateAddress("172.32.0.1")).toBe(false); // just outside 172.16/12
+  });
+
+  test("malformed input is treated as unsafe", () => {
+    expect(isPrivateAddress("not-an-ip")).toBe(true);
+    expect(isPrivateAddress("")).toBe(true);
+  });
+});
+
+describe("isPrivateAddress — IPv6", () => {
+  test("flags loopback ::1 and unspecified ::", () => {
+    expect(isPrivateAddress("::1")).toBe(true);
+    expect(isPrivateAddress("::")).toBe(true);
+  });
+
+  test("flags link-local (fe80::)", () => {
+    expect(isPrivateAddress("fe80::1")).toBe(true);
+  });
+
+  test("flags ULA (fc00::/7)", () => {
+    expect(isPrivateAddress("fc00::1")).toBe(true);
+    expect(isPrivateAddress("fd12:3456::1")).toBe(true);
+  });
+
+  test("flags multicast (ff00::/8)", () => {
+    expect(isPrivateAddress("ff02::1")).toBe(true);
+  });
+
+  test("flags IPv4-mapped private addresses (::ffff:127.0.0.1)", () => {
+    expect(isPrivateAddress("::ffff:127.0.0.1")).toBe(true);
+    expect(isPrivateAddress("::ffff:192.168.1.1")).toBe(true);
+    // IPv4-mapped public address is fine.
+    expect(isPrivateAddress("::ffff:1.1.1.1")).toBe(false);
+  });
+
+  test("allows typical public IPv6", () => {
+    expect(isPrivateAddress("2606:4700:4700::1111")).toBe(false);
+    expect(isPrivateAddress("2001:4860:4860::8888")).toBe(false);
+  });
+});
+
+describe("safeFetch — pre-flight guards", () => {
+  test("rejects non-https schemes before any I/O", async () => {
+    await expect(safeFetch("http://example.com/")).rejects.toBeInstanceOf(
+      SsrfError,
+    );
+    await expect(safeFetch("ftp://example.com/")).rejects.toBeInstanceOf(
+      SsrfError,
+    );
+  });
+
+  test("rejects IP literals in the private range", async () => {
+    await expect(safeFetch("https://127.0.0.1/")).rejects.toBeInstanceOf(
+      SsrfError,
+    );
+    await expect(safeFetch("https://169.254.169.254/")).rejects.toBeInstanceOf(
+      SsrfError,
+    );
+  });
+
+  test("rejects malformed URLs", async () => {
+    await expect(safeFetch("not a url")).rejects.toBeInstanceOf(SsrfError);
+  });
+});

--- a/apps/api/src/embeds/safe-fetch.ts
+++ b/apps/api/src/embeds/safe-fetch.ts
@@ -1,0 +1,240 @@
+import { lookup } from "dns/promises";
+import { isIP } from "net";
+
+/**
+ * SSRF guard. Rejects requests whose hostname resolves to a private,
+ * loopback, link-local, multicast, or broadcast address. Used by the link
+ * unfurler to fetch arbitrary URLs safely.
+ */
+
+// IPv4 CIDR ranges we refuse to connect to.
+const PRIVATE_V4: [number, number][] = [
+  // [network, mask-bit-count]
+  ipv4ToInt("0.0.0.0") >>> 0 as unknown as [number, number][][0] as any, // placeholder, filled below
+];
+
+function ipv4ToInt(ip: string): number {
+  const parts = ip.split(".").map((p) => parseInt(p, 10));
+  if (parts.length !== 4 || parts.some((n) => isNaN(n) || n < 0 || n > 255)) {
+    return -1;
+  }
+  return (
+    ((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0
+  );
+}
+
+interface CidrV4 {
+  network: number;
+  maskBits: number;
+}
+
+function cidr(ip: string, bits: number): CidrV4 {
+  return { network: ipv4ToInt(ip), maskBits: bits };
+}
+
+// Reset PRIVATE_V4 with real data now that helpers exist.
+(PRIVATE_V4 as unknown as CidrV4[]).length = 0;
+(PRIVATE_V4 as unknown as CidrV4[]).push(
+  cidr("0.0.0.0", 8), // "this network"
+  cidr("10.0.0.0", 8), // private
+  cidr("100.64.0.0", 10), // carrier-grade NAT
+  cidr("127.0.0.0", 8), // loopback
+  cidr("169.254.0.0", 16), // link-local (incl. 169.254.169.254 AWS metadata)
+  cidr("172.16.0.0", 12), // private
+  cidr("192.0.0.0", 24), // IETF protocol assignments
+  cidr("192.0.2.0", 24), // TEST-NET-1
+  cidr("192.168.0.0", 16), // private
+  cidr("198.18.0.0", 15), // network interconnect benchmarks
+  cidr("198.51.100.0", 24), // TEST-NET-2
+  cidr("203.0.113.0", 24), // TEST-NET-3
+  cidr("224.0.0.0", 4), // multicast
+  cidr("240.0.0.0", 4), // reserved + broadcast (255.255.255.255)
+);
+
+function isPrivateIPv4(ip: string): boolean {
+  const n = ipv4ToInt(ip);
+  if (n === -1) return true; // malformed → treat as unsafe
+  for (const range of PRIVATE_V4 as unknown as CidrV4[]) {
+    const mask = range.maskBits === 0 ? 0 : (~0 << (32 - range.maskBits)) >>> 0;
+    if ((n & mask) === (range.network & mask)) return true;
+  }
+  return false;
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  if (lower === "::1") return true; // loopback
+  if (lower === "::") return true; // unspecified
+  if (lower.startsWith("fe80:") || lower.startsWith("fe80::")) return true; // link-local
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // ULA fc00::/7
+  if (lower.startsWith("ff")) return true; // multicast ff00::/8
+  // IPv4-mapped: ::ffff:a.b.c.d
+  const mapped = lower.match(/^::ffff:(.+)$/);
+  if (mapped) {
+    return isPrivateIPv4(mapped[1]);
+  }
+  return false;
+}
+
+export function isPrivateAddress(ip: string): boolean {
+  const family = isIP(ip);
+  if (family === 4) return isPrivateIPv4(ip);
+  if (family === 6) return isPrivateIPv6(ip);
+  return true; // not a valid IP
+}
+
+export class SsrfError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SsrfError";
+  }
+}
+
+/**
+ * Check that `hostname` resolves to a public IP. Throws `SsrfError` otherwise.
+ * If the hostname IS an IP literal, validates that directly.
+ */
+async function assertHostnameIsPublic(hostname: string): Promise<void> {
+  if (isIP(hostname)) {
+    if (isPrivateAddress(hostname)) {
+      throw new SsrfError(`Refusing to fetch private address: ${hostname}`);
+    }
+    return;
+  }
+  const results = await lookup(hostname, { all: true });
+  if (!results.length) {
+    throw new SsrfError(`Could not resolve hostname: ${hostname}`);
+  }
+  for (const r of results) {
+    if (isPrivateAddress(r.address)) {
+      throw new SsrfError(
+        `Hostname ${hostname} resolves to private address ${r.address}`,
+      );
+    }
+  }
+}
+
+export interface SafeFetchOptions {
+  timeoutMs?: number;
+  maxBytes?: number;
+  maxRedirects?: number;
+  /** Accept header to send (default: text/html). */
+  accept?: string;
+}
+
+export interface SafeFetchResult {
+  finalUrl: string;
+  status: number;
+  contentType: string | null;
+  body: string;
+}
+
+const DEFAULTS = {
+  timeoutMs: 5000,
+  maxBytes: 1_000_000, // 1 MB
+  maxRedirects: 3,
+};
+
+/**
+ * Fetch a URL with SSRF protection and hard limits on timeout, size, and
+ * redirects. Follows redirects manually so the IP can be re-checked per hop.
+ *
+ * - https only (prevents plaintext MITM + cleartext metadata leakage)
+ * - DNS-level private-address check on every hop
+ * - Aborts after timeoutMs or when body exceeds maxBytes
+ */
+export async function safeFetch(
+  urlString: string,
+  options: SafeFetchOptions = {},
+): Promise<SafeFetchResult> {
+  const opts = { ...DEFAULTS, ...options };
+  const accept = options.accept ?? "text/html,application/xhtml+xml";
+
+  let current: URL;
+  try {
+    current = new URL(urlString);
+  } catch {
+    throw new SsrfError("Invalid URL");
+  }
+
+  for (let hop = 0; hop <= opts.maxRedirects; hop++) {
+    if (current.protocol !== "https:") {
+      throw new SsrfError(
+        `Refusing non-https URL: ${current.protocol}//${current.hostname}`,
+      );
+    }
+    await assertHostnameIsPublic(current.hostname);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetch(current.toString(), {
+        signal: controller.signal,
+        redirect: "manual",
+        headers: {
+          Accept: accept,
+          "User-Agent": "AtriumLinkPreview/1.0 (+https://atrium.app)",
+        },
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    // Redirects: re-check the next hop.
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (!location) {
+        throw new SsrfError(`Redirect ${response.status} without Location`);
+      }
+      current = new URL(location, current);
+      continue;
+    }
+
+    // Terminal response. Read body with a size cap.
+    const contentType = response.headers.get("content-type");
+    const body = await readCapped(response, opts.maxBytes);
+    return {
+      finalUrl: current.toString(),
+      status: response.status,
+      contentType,
+      body,
+    };
+  }
+
+  throw new SsrfError("Too many redirects");
+}
+
+async function readCapped(response: Response, maxBytes: number): Promise<string> {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      try {
+        await reader.cancel();
+      } catch {
+        /* ignore */
+      }
+      break;
+    }
+    chunks.push(value);
+  }
+  const combined = new Uint8Array(total > maxBytes ? maxBytes : total);
+  let offset = 0;
+  for (const c of chunks) {
+    if (offset + c.byteLength > combined.byteLength) {
+      combined.set(c.subarray(0, combined.byteLength - offset), offset);
+      break;
+    }
+    combined.set(c, offset);
+    offset += c.byteLength;
+  }
+  return new TextDecoder("utf-8", { fatal: false }).decode(combined);
+}

--- a/apps/api/src/embeds/unfurl.service.spec.ts
+++ b/apps/api/src/embeds/unfurl.service.spec.ts
@@ -1,0 +1,144 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { UnfurlService, parseMeta } from "./unfurl.service";
+
+describe("parseMeta", () => {
+  test("extracts Open Graph tags", () => {
+    const html = `
+      <html><head>
+        <meta property="og:title" content="The Title">
+        <meta property="og:description" content="A description">
+        <meta property="og:image" content="https://example.com/img.png">
+        <meta property="og:site_name" content="Example Site">
+      </head></html>
+    `;
+    const meta = parseMeta(html, "https://example.com/page");
+    expect(meta.title).toBe("The Title");
+    expect(meta.description).toBe("A description");
+    expect(meta.image).toBe("https://example.com/img.png");
+    expect(meta.siteName).toBe("Example Site");
+  });
+
+  test("falls back to Twitter Card tags when OG is missing", () => {
+    const html = `
+      <head>
+        <meta name="twitter:title" content="Twitter Title">
+        <meta name="twitter:description" content="Twitter desc">
+        <meta name="twitter:image" content="https://example.com/tw.png">
+      </head>
+    `;
+    const meta = parseMeta(html, "https://example.com/");
+    expect(meta.title).toBe("Twitter Title");
+    expect(meta.description).toBe("Twitter desc");
+    expect(meta.image).toBe("https://example.com/tw.png");
+  });
+
+  test("falls back to <title> tag when no meta tags are present", () => {
+    const html = `<head><title>Page Title</title></head>`;
+    const meta = parseMeta(html, "https://example.com/");
+    expect(meta.title).toBe("Page Title");
+  });
+
+  test("prefers og:description over meta name=description", () => {
+    const html = `
+      <head>
+        <meta name="description" content="plain">
+        <meta property="og:description" content="og">
+      </head>
+    `;
+    expect(parseMeta(html, "https://x.com/").description).toBe("og");
+  });
+
+  test("absolutizes relative image URLs against the final URL", () => {
+    const html = `<head><meta property="og:image" content="/img/pic.jpg"></head>`;
+    const meta = parseMeta(html, "https://example.com/posts/1");
+    expect(meta.image).toBe("https://example.com/img/pic.jpg");
+  });
+
+  test("absolutizes favicon from <link rel=icon>", () => {
+    const html = `<head><link rel="icon" href="/favicon.ico"></head>`;
+    const meta = parseMeta(html, "https://example.com/page");
+    expect(meta.favicon).toBe("https://example.com/favicon.ico");
+  });
+
+  test("absolutizes favicon from <link rel=\"shortcut icon\">", () => {
+    const html = `<head><link rel="shortcut icon" href="fav.png"></head>`;
+    const meta = parseMeta(html, "https://example.com/a/b");
+    expect(meta.favicon).toBe("https://example.com/a/fav.png");
+  });
+
+  test("decodes HTML entities in meta content", () => {
+    const html = `<meta property="og:title" content="A &amp; B &lt;C&gt;">`;
+    expect(parseMeta(html, "https://x.com/").title).toBe("A & B <C>");
+  });
+
+  test("returns undefined fields when nothing is present", () => {
+    const meta = parseMeta("<html><body>no head</body></html>", "https://x.com/");
+    expect(meta.title).toBeUndefined();
+    expect(meta.description).toBeUndefined();
+    expect(meta.image).toBeUndefined();
+  });
+
+  test("tolerates swapped attribute order (content before property)", () => {
+    const html = `<meta content="Swapped" property="og:title">`;
+    expect(parseMeta(html, "https://x.com/").title).toBe("Swapped");
+  });
+
+  test("caps head scan at 256KB so huge docs don't blow up CPU", () => {
+    // Pad with non-meta content, then place the meta tag beyond the cap.
+    const padding = "x".repeat(260 * 1024);
+    const html = `<head>${padding}<meta property="og:title" content="Hidden"></head>`;
+    expect(parseMeta(html, "https://x.com/").title).toBeUndefined();
+  });
+});
+
+describe("UnfurlService.unfurl", () => {
+  let service: UnfurlService;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    service = new UnfurlService();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("returns null when the response has no meta at all", async () => {
+    globalThis.fetch = mock(async () =>
+      new Response("<html><body>nothing here</body></html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      }),
+    ) as unknown as typeof fetch;
+
+    // Point at a public-looking hostname that still resolves (example.com does).
+    const result = await service.unfurl("https://example.com/empty");
+    expect(result).toBeNull();
+  });
+
+  test("returns null on SSRF-blocked hosts (localhost)", async () => {
+    // safeFetch rejects loopback before any network I/O.
+    const result = await service.unfurl("https://127.0.0.1/");
+    expect(result).toBeNull();
+  });
+
+  test("returns null for non-https URLs", async () => {
+    const result = await service.unfurl("http://example.com/");
+    expect(result).toBeNull();
+  });
+
+  test("caches null results (second call does not re-fetch)", async () => {
+    let calls = 0;
+    globalThis.fetch = mock(async () => {
+      calls++;
+      return new Response("<html></html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      });
+    }) as unknown as typeof fetch;
+
+    await service.unfurl("https://example.com/a");
+    await service.unfurl("https://example.com/a");
+    expect(calls).toBe(1);
+  });
+});

--- a/apps/api/src/embeds/unfurl.service.ts
+++ b/apps/api/src/embeds/unfurl.service.ts
@@ -1,0 +1,187 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { safeFetch, SsrfError } from "./safe-fetch";
+
+export interface UnfurlCard {
+  url: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+  favicon?: string;
+}
+
+interface CacheEntry {
+  value: UnfurlCard | null;
+  expiresAt: number;
+}
+
+const CACHE_MAX = 500;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+@Injectable()
+export class UnfurlService {
+  private readonly logger = new Logger(UnfurlService.name);
+  private readonly cache = new Map<string, CacheEntry>();
+
+  async unfurl(url: string): Promise<UnfurlCard | null> {
+    const cached = this.cache.get(url);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    let value: UnfurlCard | null = null;
+    try {
+      value = await this.fetchAndParse(url);
+    } catch (err) {
+      if (err instanceof SsrfError) {
+        this.logger.warn(`unfurl blocked by SSRF guard: ${err.message}`);
+      } else {
+        this.logger.warn(
+          `unfurl failed for ${url}: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    this.storeInCache(url, value);
+    return value;
+  }
+
+  private async fetchAndParse(url: string): Promise<UnfurlCard | null> {
+    const response = await safeFetch(url);
+    if (response.status < 200 || response.status >= 300) return null;
+
+    // Only parse HTML-ish responses.
+    const contentType = (response.contentType || "").toLowerCase();
+    if (contentType && !contentType.includes("html")) return null;
+
+    const parsed = parseMeta(response.body, response.finalUrl);
+    if (!parsed.title && !parsed.description && !parsed.image) return null;
+
+    return { url: response.finalUrl, ...parsed };
+  }
+
+  private storeInCache(key: string, value: UnfurlCard | null) {
+    if (this.cache.size >= CACHE_MAX) {
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey !== undefined) this.cache.delete(oldestKey);
+    }
+    this.cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTML parsing (regex-based, no JS execution, no external fetches)
+// ---------------------------------------------------------------------------
+
+interface ParsedMeta {
+  title?: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+  favicon?: string;
+}
+
+/**
+ * Extract Open Graph / Twitter Card / plain `<title>` and favicon from raw
+ * HTML. We truncate to the first 256KB of the document — meta tags always
+ * live in `<head>`, and refusing to scan arbitrarily large bodies bounds CPU.
+ */
+export function parseMeta(html: string, baseUrl: string): ParsedMeta {
+  const head = html.slice(0, 256 * 1024);
+
+  const og = (prop: string) => matchMetaProperty(head, prop);
+  const name = (n: string) => matchMetaName(head, n);
+
+  const title =
+    og("og:title") ||
+    name("twitter:title") ||
+    matchTitleTag(head) ||
+    undefined;
+
+  const description =
+    og("og:description") || name("twitter:description") || name("description");
+
+  const image = og("og:image") || name("twitter:image");
+
+  const siteName = og("og:site_name");
+
+  const faviconRel = matchFavicon(head);
+  const favicon = faviconRel ? absolutize(faviconRel, baseUrl) : undefined;
+
+  return {
+    title: title?.trim() || undefined,
+    description: description?.trim() || undefined,
+    image: image ? absolutize(image, baseUrl) : undefined,
+    siteName: siteName?.trim() || undefined,
+    favicon,
+  };
+}
+
+function absolutize(href: string, base: string): string | undefined {
+  try {
+    return new URL(href, base).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function matchMetaProperty(head: string, prop: string): string | undefined {
+  // <meta property="og:title" content="..."> — also tolerate swapped order.
+  const pattern = new RegExp(
+    `<meta[^>]+property=["']${escapeRegex(prop)}["'][^>]*>`,
+    "i",
+  );
+  const tag = head.match(pattern)?.[0];
+  if (!tag) return undefined;
+  return extractContent(tag);
+}
+
+function matchMetaName(head: string, name: string): string | undefined {
+  const pattern = new RegExp(
+    `<meta[^>]+name=["']${escapeRegex(name)}["'][^>]*>`,
+    "i",
+  );
+  const tag = head.match(pattern)?.[0];
+  if (!tag) return undefined;
+  return extractContent(tag);
+}
+
+function extractContent(tag: string): string | undefined {
+  const match = tag.match(/\bcontent=["']([^"']*)["']/i);
+  if (!match) return undefined;
+  return decodeHtmlEntities(match[1]);
+}
+
+function matchTitleTag(head: string): string | undefined {
+  const match = head.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (!match) return undefined;
+  return decodeHtmlEntities(match[1]).trim();
+}
+
+function matchFavicon(head: string): string | undefined {
+  // Prefer icon / shortcut icon links.
+  const linkTags = head.match(/<link[^>]+>/gi) || [];
+  for (const tag of linkTags) {
+    const rel = tag.match(/\brel=["']([^"']*)["']/i)?.[1]?.toLowerCase();
+    if (!rel) continue;
+    if (rel.includes("icon")) {
+      const href = tag.match(/\bhref=["']([^"']*)["']/i)?.[1];
+      if (href) return href;
+    }
+  }
+  return undefined;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/apps/api/src/files/files.controller.ts
+++ b/apps/api/src/files/files.controller.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  Body,
   Controller,
   Get,
   Post,
@@ -14,6 +15,7 @@ import {
 import { FileInterceptor } from "@nestjs/platform-express";
 import { Response } from "express";
 import { FilesService, UploadedFile as UploadedFileType } from "./files.service";
+import { CreateFileLinkDto } from "./files.dto";
 import { AuthGuard, RolesGuard, Roles, PlanLimit, CurrentUser, CurrentOrg, CurrentMember, PaginationQueryDto, contentDisposition } from "../common";
 
 @Controller("files")
@@ -33,6 +35,20 @@ export class FilesController {
   ) {
     if (!file) throw new BadRequestException("No file provided");
     return this.filesService.upload(file, projectId, orgId, userId);
+  }
+
+  @Post("link")
+  @Roles("owner", "admin")
+  createLink(
+    @Body() dto: CreateFileLinkDto,
+    @CurrentOrg("id") orgId: string,
+    @CurrentUser("id") userId: string,
+  ) {
+    return this.filesService.createLink(dto.projectId, orgId, userId, {
+      url: dto.url,
+      title: dto.title,
+      description: dto.description,
+    });
   }
 
   @Post("upload/mine")

--- a/apps/api/src/files/files.controller.ts
+++ b/apps/api/src/files/files.controller.ts
@@ -4,6 +4,7 @@ import {
   Controller,
   Get,
   Post,
+  Patch,
   Delete,
   Param,
   Query,
@@ -14,8 +15,9 @@ import {
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { Response } from "express";
+import type { File } from "@atrium/database";
 import { FilesService, UploadedFile as UploadedFileType } from "./files.service";
-import { CreateFileLinkDto } from "./files.dto";
+import { CreateFileLinkDto, UpdateFileDto } from "./files.dto";
 import { AuthGuard, RolesGuard, Roles, PlanLimit, CurrentUser, CurrentOrg, CurrentMember, PaginationQueryDto, contentDisposition } from "../common";
 
 @Controller("files")
@@ -108,6 +110,18 @@ export class FilesController {
     @CurrentMember("role") role: string,
   ) {
     return this.filesService.getDownloadUrl(id, orgId, userId, role);
+  }
+
+  @Patch(":id")
+  @Roles("owner", "admin")
+  update(
+    @Param("id") id: string,
+    @Body() dto: UpdateFileDto,
+    @CurrentOrg("id") orgId: string,
+    @CurrentUser("id") userId: string,
+    @CurrentMember("role") role: string,
+  ): Promise<File> {
+    return this.filesService.update(id, dto, orgId, userId, role);
   }
 
   @Delete(":id")

--- a/apps/api/src/files/files.dto.ts
+++ b/apps/api/src/files/files.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsUrl, MaxLength, MinLength } from "class-validator";
+import { IsOptional, IsString, IsUrl, Matches, MaxLength, MinLength } from "class-validator";
 
 export class CreateFileLinkDto {
   @IsString()
@@ -17,4 +17,23 @@ export class CreateFileLinkDto {
   @IsString()
   @MaxLength(1000)
   description?: string;
+}
+
+export class UpdateFileDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(255)
+  filename?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  @Matches(/^https?:\/\//i, { message: "url must start with http:// or https://" })
+  url?: string;
 }

--- a/apps/api/src/files/files.dto.ts
+++ b/apps/api/src/files/files.dto.ts
@@ -1,0 +1,20 @@
+import { IsOptional, IsString, IsUrl, MaxLength, MinLength } from "class-validator";
+
+export class CreateFileLinkDto {
+  @IsString()
+  projectId!: string;
+
+  @IsUrl({ protocols: ["http", "https"], require_protocol: true })
+  @MaxLength(2048)
+  url!: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(255)
+  title!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  description?: string;
+}

--- a/apps/api/src/files/files.service.spec.ts
+++ b/apps/api/src/files/files.service.spec.ts
@@ -48,6 +48,9 @@ const mockPrisma = {
     ),
     findMany: mock(() => Promise.resolve([])),
     findFirst: mock(() => Promise.resolve(null)),
+    update: mock((args: PrismaArgs) =>
+      Promise.resolve({ id: (args.where as Record<string, string>)?.id ?? "file-1", ...args.data }),
+    ),
     delete: mock(() => Promise.resolve()),
     deleteMany: mock(() => Promise.resolve({ count: 1 })),
     count: mock(() => Promise.resolve(0)),
@@ -612,6 +615,185 @@ describe("FilesService", () => {
         expect(true).toBe(false);
       } catch (e) {
         expect(e).toBeInstanceOf(PayloadTooLargeException);
+      }
+    });
+  });
+
+  // --- update ---
+
+  describe("update", () => {
+    it("updates filename on an UPLOAD-type file", async () => {
+      mockPrisma.file.findFirst.mockReturnValue(
+        Promise.resolve({
+          id: "file-1",
+          type: "UPLOAD",
+          filename: "old.pdf",
+          storageKey: "org/proj/old.pdf",
+          projectId: "proj-1",
+          organizationId: "org-1",
+        }),
+      );
+
+      const result = await service.update(
+        "file-1",
+        { filename: "new.pdf" },
+        "org-1",
+        "user-1",
+        "owner",
+      );
+
+      expect(mockPrisma.file.update).toHaveBeenCalledWith({
+        where: { id: "file-1" },
+        data: { filename: "new.pdf" },
+      });
+      expect(result).toBeDefined();
+    });
+
+    it("updates filename, description, and url on a LINK-type file", async () => {
+      mockPrisma.file.findFirst.mockReturnValue(
+        Promise.resolve({
+          id: "file-link-1",
+          type: "LINK",
+          filename: "Old title",
+          url: "https://example.com/old",
+          description: "Old desc",
+          projectId: "proj-1",
+          organizationId: "org-1",
+        }),
+      );
+
+      await service.update(
+        "file-link-1",
+        {
+          filename: "New title",
+          description: "New desc",
+          url: "https://example.com/new",
+        },
+        "org-1",
+        "user-1",
+        "owner",
+      );
+
+      expect(mockPrisma.file.update).toHaveBeenCalledWith({
+        where: { id: "file-link-1" },
+        data: {
+          filename: "New title",
+          description: "New desc",
+          url: "https://example.com/new",
+        },
+      });
+    });
+
+    it("rejects url edits on UPLOAD-type files with BadRequestException", async () => {
+      mockPrisma.file.findFirst.mockReturnValue(
+        Promise.resolve({
+          id: "file-1",
+          type: "UPLOAD",
+          filename: "doc.pdf",
+          storageKey: "org/proj/doc.pdf",
+          projectId: "proj-1",
+          organizationId: "org-1",
+        }),
+      );
+      const callsBefore = mockPrisma.file.update.mock.calls.length;
+
+      try {
+        await service.update(
+          "file-1",
+          { url: "https://example.com/bad" },
+          "org-1",
+          "user-1",
+          "owner",
+        );
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toBeInstanceOf(BadRequestException);
+      }
+
+      // Should not have invoked prisma.file.update during this test
+      expect(mockPrisma.file.update.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("throws NotFoundException when file does not exist", async () => {
+      mockPrisma.file.findFirst.mockReturnValue(Promise.resolve(null));
+
+      try {
+        await service.update("missing", { filename: "x" }, "org-1", "user-1", "owner");
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toBeInstanceOf(NotFoundException);
+      }
+    });
+
+    it("rejects updates with no fields provided", async () => {
+      mockPrisma.file.findFirst.mockReturnValue(
+        Promise.resolve({
+          id: "file-1",
+          type: "UPLOAD",
+          filename: "doc.pdf",
+          storageKey: "org/proj/doc.pdf",
+          projectId: "proj-1",
+          organizationId: "org-1",
+        }),
+      );
+
+      try {
+        await service.update("file-1", {}, "org-1", "user-1", "owner");
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toBeInstanceOf(BadRequestException);
+      }
+    });
+
+    it("rejects non-http(s) URLs on LINK-type files", async () => {
+      mockPrisma.file.findFirst.mockReturnValue(
+        Promise.resolve({
+          id: "file-link-1",
+          type: "LINK",
+          filename: "Old",
+          url: "https://example.com/old",
+          projectId: "proj-1",
+          organizationId: "org-1",
+        }),
+      );
+
+      try {
+        await service.update(
+          "file-link-1",
+          { url: "ftp://example.com/bad" },
+          "org-1",
+          "user-1",
+          "owner",
+        );
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toBeInstanceOf(BadRequestException);
+      }
+    });
+
+    it("rejects malformed URL strings on LINK-type files", async () => {
+      mockPrisma.file.findFirst.mockReturnValue(
+        Promise.resolve({
+          id: "file-link-1",
+          type: "LINK",
+          filename: "Old",
+          url: "https://example.com/old",
+          projectId: "proj-1",
+          organizationId: "org-1",
+        }),
+      );
+
+      try {
+        await service.update(
+          "file-link-1",
+          { url: "not a url" },
+          "org-1",
+          "user-1",
+          "owner",
+        );
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toBeInstanceOf(BadRequestException);
       }
     });
   });

--- a/apps/api/src/files/files.service.spec.ts
+++ b/apps/api/src/files/files.service.spec.ts
@@ -304,6 +304,7 @@ describe("FilesService", () => {
   it("remove deletes from storage and db", async () => {
     const file = {
       id: "file-1",
+      type: "UPLOAD",
       storageKey: "org/proj/file.pdf",
       organizationId: "org-1",
     };
@@ -313,6 +314,112 @@ describe("FilesService", () => {
     await service.remove("file-1", "org-1");
     expect(mockPrisma.file.delete).toHaveBeenCalled();
     expect(mockStorage.delete).toHaveBeenCalled();
+  });
+
+  // --- createLink ---
+
+  describe("createLink", () => {
+    it("rejects an invalid URL", async () => {
+      await expect(
+        service.createLink("proj-1", "org-1", "user-1", {
+          url: "not a url",
+          title: "Notes",
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("rejects non-http(s) URLs", async () => {
+      await expect(
+        service.createLink("proj-1", "org-1", "user-1", {
+          url: "ftp://example.com/x",
+          title: "Notes",
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("throws NotFoundException when project is not in the org", async () => {
+      mockPrisma.project.findFirst.mockReturnValue(Promise.resolve(null));
+      await expect(
+        service.createLink("proj-1", "org-1", "user-1", {
+          url: "https://nextcloud.example.com/s/abc",
+          title: "Design brief",
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("persists a LINK-type file entry", async () => {
+      mockPrisma.project.findFirst.mockReturnValue(
+        Promise.resolve({ id: "proj-1", organizationId: "org-1" }),
+      );
+      const result = await service.createLink("proj-1", "org-1", "user-1", {
+        url: "https://nextcloud.example.com/s/abc",
+        title: "  Design brief  ",
+        description: "  A doc  ",
+      });
+
+      expect(result).toBeDefined();
+      expect(mockPrisma.file.create).toHaveBeenCalledWith({
+        data: {
+          filename: "Design brief",
+          type: "LINK",
+          url: "https://nextcloud.example.com/s/abc",
+          description: "A doc",
+          projectId: "proj-1",
+          organizationId: "org-1",
+          uploadedById: "user-1",
+        },
+      });
+    });
+  });
+
+  // --- LINK-type guards in download/remove ---
+
+  it("download rejects LINK-type files", async () => {
+    mockPrisma.file.findFirst.mockReturnValue(
+      Promise.resolve({
+        id: "file-1",
+        type: "LINK",
+        storageKey: null,
+        url: "https://example.com",
+        projectId: "proj-1",
+        organizationId: "org-1",
+      }),
+    );
+    await expect(
+      service.download("file-1", "org-1", "user-1", "admin"),
+    ).rejects.toThrow();
+  });
+
+  it("getDownloadUrl rejects LINK-type files", async () => {
+    mockPrisma.file.findFirst.mockReturnValue(
+      Promise.resolve({
+        id: "file-1",
+        type: "LINK",
+        storageKey: null,
+        projectId: "proj-1",
+        organizationId: "org-1",
+      }),
+    );
+    await expect(
+      service.getDownloadUrl("file-1", "org-1", "user-1", "admin"),
+    ).rejects.toThrow();
+  });
+
+  it("remove succeeds for LINK-type files without touching storage keys", async () => {
+    const deleteCountBefore = mockStorage.delete.mock.calls.length;
+    mockPrisma.file.findFirst.mockReturnValue(
+      Promise.resolve({
+        id: "file-link-remove",
+        type: "LINK",
+        storageKey: null,
+        organizationId: "org-1",
+      }),
+    );
+    mockPrisma.invoice.findFirst.mockReturnValue(Promise.resolve(null));
+
+    await service.remove("file-link-remove", "org-1");
+    expect(mockPrisma.file.delete).toHaveBeenCalled();
+    expect(mockStorage.delete.mock.calls.length).toBe(deleteCountBefore);
   });
 
   // --- uploadAsClient ---

--- a/apps/api/src/files/files.service.ts
+++ b/apps/api/src/files/files.service.ts
@@ -143,13 +143,53 @@ export class FilesService {
     return paginatedResponse(data, total, page, limit);
   }
 
+  async createLink(
+    projectId: string,
+    organizationId: string,
+    uploadedById: string,
+    params: { url: string; title: string; description?: string },
+  ) {
+    let parsed: URL;
+    try {
+      parsed = new URL(params.url);
+    } catch {
+      throw new BadRequestException("Invalid URL");
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new BadRequestException("Only http(s) URLs are allowed");
+    }
+
+    const project = await this.prisma.project.findFirst({
+      where: { id: projectId, organizationId },
+    });
+    if (!project) throw new NotFoundException("Project not found");
+
+    return this.prisma.file.create({
+      data: {
+        filename: params.title.trim(),
+        type: "LINK",
+        url: parsed.toString(),
+        description: params.description?.trim() || null,
+        projectId,
+        organizationId,
+        uploadedById,
+      },
+    });
+  }
+
   async download(id: string, organizationId: string, userId: string, role: string) {
     const file = await this.prisma.file.findFirst({
       where: { id, organizationId },
     });
     if (!file) throw new NotFoundException("File not found");
+    if (file.type === "LINK") {
+      throw new BadRequestException("Cannot download a link entry");
+    }
+    if (!file.storageKey) {
+      throw new NotFoundException("File has no storage object");
+    }
 
-    await assertProjectAccess(this.prisma,file.projectId, userId, role);
+    await assertProjectAccess(this.prisma, file.projectId, userId, role);
 
     const { body, contentType } = await this.storage.download(file.storageKey);
     return { body, contentType, filename: file.filename };
@@ -160,8 +200,11 @@ export class FilesService {
       where: { id, organizationId },
     });
     if (!file) throw new NotFoundException("File not found");
+    if (file.type === "LINK") {
+      throw new BadRequestException("Cannot download a link entry");
+    }
 
-    await assertProjectAccess(this.prisma,file.projectId, userId, role);
+    await assertProjectAccess(this.prisma, file.projectId, userId, role);
 
     return { url: `/api/files/${id}/download` };
   }
@@ -185,11 +228,13 @@ export class FilesService {
 
     await this.prisma.file.delete({ where: { id } });
 
-    try {
-      await this.storage.delete(file.storageKey);
-    } catch {
-      // DB record already deleted — orphaned blob is acceptable;
-      // a future cleanup job can sweep orphans by comparing storage keys.
+    if (file.type === "UPLOAD" && file.storageKey) {
+      try {
+        await this.storage.delete(file.storageKey);
+      } catch {
+        // DB record already deleted — orphaned blob is acceptable;
+        // a future cleanup job can sweep orphans by comparing storage keys.
+      }
     }
   }
 }

--- a/apps/api/src/files/files.service.ts
+++ b/apps/api/src/files/files.service.ts
@@ -209,6 +209,50 @@ export class FilesService {
     return { url: `/api/files/${id}/download` };
   }
 
+  async update(
+    id: string,
+    dto: { filename?: string; description?: string; url?: string },
+    organizationId: string,
+    userId: string,
+    role: string,
+  ) {
+    const file = await this.prisma.file.findFirst({
+      where: { id, organizationId },
+    });
+    if (!file) throw new NotFoundException("File not found");
+
+    if (dto.url !== undefined && file.type !== "LINK") {
+      throw new BadRequestException("url can only be updated on link-type files");
+    }
+
+    await assertProjectAccess(this.prisma, file.projectId, userId, role, organizationId);
+
+    const data: { filename?: string; description?: string; url?: string } = {};
+    if (dto.filename !== undefined) data.filename = dto.filename;
+    if (dto.description !== undefined) data.description = dto.description;
+    if (dto.url !== undefined) {
+      let parsed: URL;
+      try {
+        parsed = new URL(dto.url);
+      } catch {
+        throw new BadRequestException("Invalid URL");
+      }
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new BadRequestException("Only http(s) URLs are allowed");
+      }
+      data.url = parsed.toString();
+    }
+
+    if (Object.keys(data).length === 0) {
+      throw new BadRequestException("No fields provided to update");
+    }
+
+    return this.prisma.file.update({
+      where: { id },
+      data,
+    });
+  }
+
   async remove(id: string, organizationId: string) {
     const file = await this.prisma.file.findFirst({
       where: { id, organizationId },

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -15,6 +15,7 @@ import { ProjectsService } from "./projects.service";
 import {
   CreateProjectDto,
   UpdateProjectDto,
+  DuplicateProjectDto,
   ProjectListQueryDto,
   ClientProjectListQueryDto,
 } from "./projects.dto";
@@ -110,6 +111,17 @@ export class ProjectsController {
   @Roles("owner", "admin")
   archive(@Param("id") id: string, @CurrentOrg("id") orgId: string) {
     return this.projectsService.archive(id, orgId);
+  }
+
+  @Post(":id/duplicate")
+  @Roles("owner", "admin")
+  @PlanLimit("projects")
+  duplicate(
+    @Param("id") id: string,
+    @Body() dto: DuplicateProjectDto,
+    @CurrentOrg("id") orgId: string,
+  ) {
+    return this.projectsService.duplicate(id, dto, orgId);
   }
 
   @Post(":id/unarchive")

--- a/apps/api/src/projects/projects.dto.ts
+++ b/apps/api/src/projects/projects.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsArray, IsDateString, MaxLength } from "class-validator";
+import { IsString, IsOptional, IsArray, IsBoolean, IsDateString, MaxLength } from "class-validator";
 import { PaginationQueryDto } from "../common";
 
 export class CreateProjectDto {
@@ -51,6 +51,20 @@ export class ProjectListQueryDto extends ClientProjectListQueryDto {
   @IsOptional()
   @MaxLength(2000)
   labels?: string;
+}
+
+export class DuplicateProjectDto {
+  @IsString()
+  @MaxLength(255)
+  name!: string;
+
+  @IsBoolean()
+  @IsOptional()
+  includeTasks?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  includeClients?: boolean;
 }
 
 export class UpdateProjectDto {

--- a/apps/api/src/projects/projects.service.spec.ts
+++ b/apps/api/src/projects/projects.service.spec.ts
@@ -28,6 +28,21 @@ const mockPrisma = {
   },
   projectClient: {
     deleteMany: mock(() => Promise.resolve({ count: 0 })),
+    createMany: mock(() => Promise.resolve({ count: 0 })),
+  },
+  projectLabel: {
+    createMany: mock(() => Promise.resolve({ count: 0 })),
+  },
+  task: {
+    create: mock((args: PrismaArgs) =>
+      Promise.resolve({ id: `task-${Math.random().toString(36).slice(2, 8)}`, ...args.data }),
+    ),
+  },
+  taskLabel: {
+    createMany: mock(() => Promise.resolve({ count: 0 })),
+  },
+  decisionOption: {
+    createMany: mock(() => Promise.resolve({ count: 0 })),
   },
   projectStatus: {
     findMany: mock(() => Promise.resolve([])),
@@ -36,7 +51,12 @@ const mockPrisma = {
   member: {
     count: mock(() => Promise.resolve(2)),
   },
-  $transaction: mock((args: Promise<unknown>[]) => Promise.all(args)),
+  $transaction: mock((arg: unknown) => {
+    if (typeof arg === "function") {
+      return (arg as (tx: typeof mockPrisma) => Promise<unknown>)(mockPrisma);
+    }
+    return Promise.all(arg as Promise<unknown>[]);
+  }),
 };
 
 describe("ProjectsService", () => {
@@ -51,6 +71,11 @@ describe("ProjectsService", () => {
       }
     });
     mockPrisma.projectClient.deleteMany.mockClear();
+    mockPrisma.projectClient.createMany.mockClear();
+    mockPrisma.projectLabel.createMany.mockClear();
+    mockPrisma.task.create.mockClear();
+    mockPrisma.taskLabel.createMany.mockClear();
+    mockPrisma.decisionOption.createMany.mockClear();
     mockPrisma.$transaction.mockClear();
   });
 
@@ -160,5 +185,172 @@ describe("ProjectsService", () => {
         }),
       }),
     );
+  });
+
+  describe("duplicate", () => {
+    const sourceProject = {
+      id: "src-1",
+      name: "Source",
+      description: "Original",
+      status: "in_progress",
+      startDate: null,
+      endDate: null,
+      organizationId: "org-1",
+      clients: [{ userId: "u-1" }, { userId: "u-2" }],
+      labels: [{ labelId: "lab-1" }],
+      tasks: [
+        {
+          id: "t-1",
+          title: "Kickoff",
+          description: "Initial task",
+          dueDate: null,
+          status: "done",
+          closedAt: new Date(),
+          requestedById: null,
+          assigneeId: "u-1",
+          order: 0,
+          type: "checkbox",
+          question: null,
+          options: [],
+          labels: [{ labelId: "lab-1" }],
+        },
+        {
+          id: "t-2",
+          title: "Pick a direction",
+          description: null,
+          dueDate: null,
+          status: "open",
+          closedAt: null,
+          requestedById: null,
+          assigneeId: null,
+          order: 1,
+          type: "decision",
+          question: "Which way?",
+          options: [
+            { label: "Option A", order: 0 },
+            { label: "Option B", order: 1 },
+          ],
+          labels: [],
+        },
+      ],
+    };
+
+    it("throws NotFoundException when source project is not in the org", async () => {
+      mockPrisma.project.findFirst.mockReturnValue(Promise.resolve(null));
+      try {
+        await service.duplicate("missing", { name: "Copy" }, "org-1");
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toBeInstanceOf(NotFoundException);
+      }
+    });
+
+    it("copies project core fields, labels, tasks, options, and task labels (no clients by default)", async () => {
+      mockPrisma.project.findFirst.mockReturnValue(Promise.resolve(sourceProject));
+      mockPrisma.project.create.mockReturnValue(
+        Promise.resolve({ id: "new-1", name: "Copy", organizationId: "org-1" }),
+      );
+      mockPrisma.project.findUnique.mockReturnValue(
+        Promise.resolve({ id: "new-1", name: "Copy", organizationId: "org-1", clients: [] }),
+      );
+
+      const result = await service.duplicate("src-1", { name: "Copy" }, "org-1");
+
+      // New project created with source's core fields
+      expect(mockPrisma.project.create).toHaveBeenCalledWith({
+        data: {
+          name: "Copy",
+          description: "Original",
+          status: "in_progress",
+          startDate: null,
+          endDate: null,
+          organizationId: "org-1",
+        },
+      });
+
+      // Project labels cloned
+      expect(mockPrisma.projectLabel.createMany).toHaveBeenCalledWith({
+        data: [{ projectId: "new-1", labelId: "lab-1" }],
+      });
+
+      // Clients NOT copied by default
+      expect(mockPrisma.projectClient.createMany).not.toHaveBeenCalled();
+
+      // Tasks copied with status reset
+      expect(mockPrisma.task.create).toHaveBeenCalledTimes(2);
+      const taskCalls = mockPrisma.task.create.mock.calls;
+      const firstTaskData = (taskCalls[0][0] as PrismaArgs).data as Record<string, unknown>;
+      expect(firstTaskData.status).toBe("open");
+      expect(firstTaskData.closedAt).toBe(null);
+      expect(firstTaskData.title).toBe("Kickoff");
+      expect(firstTaskData.projectId).toBe("new-1");
+      expect(firstTaskData.organizationId).toBe("org-1");
+
+      // Decision options copied for the second task
+      expect(mockPrisma.decisionOption.createMany).toHaveBeenCalledTimes(1);
+      const optCall = mockPrisma.decisionOption.createMany.mock.calls[0][0] as PrismaArgs;
+      const optData = optCall.data as Array<Record<string, unknown>>;
+      expect(optData.map((o) => o.label)).toEqual(["Option A", "Option B"]);
+
+      // Task label copied for the first task only
+      expect(mockPrisma.taskLabel.createMany).toHaveBeenCalledTimes(1);
+
+      expect(result).toEqual({ id: "new-1", name: "Copy", organizationId: "org-1", clients: [] });
+    });
+
+    it("skips tasks when includeTasks is false", async () => {
+      mockPrisma.project.findFirst.mockReturnValue(Promise.resolve(sourceProject));
+      mockPrisma.project.create.mockReturnValue(
+        Promise.resolve({ id: "new-2", name: "NoTasks", organizationId: "org-1" }),
+      );
+      mockPrisma.project.findUnique.mockReturnValue(
+        Promise.resolve({ id: "new-2", name: "NoTasks", organizationId: "org-1", clients: [] }),
+      );
+
+      await service.duplicate("src-1", { name: "NoTasks", includeTasks: false }, "org-1");
+
+      expect(mockPrisma.task.create).not.toHaveBeenCalled();
+      expect(mockPrisma.decisionOption.createMany).not.toHaveBeenCalled();
+      expect(mockPrisma.taskLabel.createMany).not.toHaveBeenCalled();
+      // Labels on the project are still copied
+      expect(mockPrisma.projectLabel.createMany).toHaveBeenCalled();
+    });
+
+    it("copies clients when includeClients is true", async () => {
+      mockPrisma.project.findFirst.mockReturnValue(Promise.resolve(sourceProject));
+      mockPrisma.project.create.mockReturnValue(
+        Promise.resolve({ id: "new-3", name: "WithClients", organizationId: "org-1" }),
+      );
+      mockPrisma.project.findUnique.mockReturnValue(
+        Promise.resolve({ id: "new-3", name: "WithClients", organizationId: "org-1", clients: [] }),
+      );
+
+      await service.duplicate(
+        "src-1",
+        { name: "WithClients", includeTasks: false, includeClients: true },
+        "org-1",
+      );
+
+      expect(mockPrisma.projectClient.createMany).toHaveBeenCalledWith({
+        data: [
+          { projectId: "new-3", userId: "u-1" },
+          { projectId: "new-3", userId: "u-2" },
+        ],
+      });
+    });
+
+    it("scopes the source lookup to the provided organizationId", async () => {
+      mockPrisma.project.findFirst.mockReturnValue(Promise.resolve(null));
+      try {
+        await service.duplicate("src-1", { name: "X" }, "org-other");
+      } catch {
+        // expected
+      }
+      expect(mockPrisma.project.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: "src-1", organizationId: "org-other" }),
+        }),
+      );
+    });
   });
 });

--- a/apps/api/src/projects/projects.service.spec.ts
+++ b/apps/api/src/projects/projects.service.spec.ts
@@ -256,12 +256,12 @@ describe("ProjectsService", () => {
 
       const result = await service.duplicate("src-1", { name: "Copy" }, "org-1");
 
-      // New project created with source's core fields
+      // New project created with source's core fields; status is NOT copied —
+      // the schema default ("not_started") applies instead.
       expect(mockPrisma.project.create).toHaveBeenCalledWith({
         data: {
           name: "Copy",
           description: "Original",
-          status: "in_progress",
           startDate: null,
           endDate: null,
           organizationId: "org-1",
@@ -276,12 +276,15 @@ describe("ProjectsService", () => {
       // Clients NOT copied by default
       expect(mockPrisma.projectClient.createMany).not.toHaveBeenCalled();
 
-      // Tasks copied with status reset
+      // Tasks copied with status/assignment state reset
       expect(mockPrisma.task.create).toHaveBeenCalledTimes(2);
       const taskCalls = mockPrisma.task.create.mock.calls;
       const firstTaskData = (taskCalls[0][0] as PrismaArgs).data as Record<string, unknown>;
       expect(firstTaskData.status).toBe("open");
       expect(firstTaskData.closedAt).toBe(null);
+      expect(firstTaskData.dueDate).toBe(null);
+      expect(firstTaskData.requestedById).toBe(null);
+      expect(firstTaskData.assigneeId).toBe(null);
       expect(firstTaskData.title).toBe("Kickoff");
       expect(firstTaskData.projectId).toBe("new-1");
       expect(firstTaskData.organizationId).toBe("org-1");

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -243,11 +243,13 @@ export class ProjectsService {
     const includeClients = dto.includeClients ?? false;
 
     return this.prisma.$transaction(async (tx) => {
+      // Duplicate = fresh copy semantics:
+      // - project status uses the schema default (not_started), not the source's
+      // - startDate/endDate are copied but future/past relevance is the user's call
       const newProject = await tx.project.create({
         data: {
           name: dto.name,
           description: source.description,
-          status: source.status,
           startDate: source.startDate,
           endDate: source.endDate,
           organizationId,
@@ -274,15 +276,18 @@ export class ProjectsService {
 
       if (includeTasks && source.tasks.length) {
         for (const task of source.tasks) {
+          // Template-clone semantics: shape is copied, state is not.
+          // Status is reset, dueDate is dropped (source dates don't apply to new work),
+          // and assignees/requesters are cleared so the new project starts unowned.
           const newTask = await tx.task.create({
             data: {
               title: task.title,
               description: task.description,
-              dueDate: task.dueDate,
+              dueDate: null,
               status: "open",
               closedAt: null,
-              requestedById: task.requestedById,
-              assigneeId: task.assigneeId,
+              requestedById: null,
+              assigneeId: null,
               order: task.order,
               type: task.type,
               question: task.question,
@@ -316,6 +321,10 @@ export class ProjectsService {
         where: { id: newProject.id },
         include: { clients: { select: { userId: true } } },
       });
+    }, {
+      // Raise above Prisma's 5s default: cloning a project with many tasks
+      // + options + labels is sequential and can exceed 5s on larger templates.
+      timeout: 15000,
     });
   }
 

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service";
-import { CreateProjectDto, UpdateProjectDto } from "./projects.dto";
+import { CreateProjectDto, UpdateProjectDto, DuplicateProjectDto } from "./projects.dto";
 import { paginationArgs, paginatedResponse } from "../common";
 
 interface ProjectWhereInput {
@@ -216,6 +216,106 @@ export class ProjectsService {
     return this.prisma.project.findUnique({
       where: { id },
       include: { clients: { select: { userId: true } } },
+    });
+  }
+
+  async duplicate(
+    id: string,
+    dto: DuplicateProjectDto,
+    organizationId: string,
+  ) {
+    const source = await this.prisma.project.findFirst({
+      where: { id, organizationId },
+      include: {
+        clients: { select: { userId: true } },
+        labels: { select: { labelId: true } },
+        tasks: {
+          include: {
+            options: { select: { label: true, order: true } },
+            labels: { select: { labelId: true } },
+          },
+        },
+      },
+    });
+    if (!source) throw new NotFoundException("Project not found");
+
+    const includeTasks = dto.includeTasks ?? true;
+    const includeClients = dto.includeClients ?? false;
+
+    return this.prisma.$transaction(async (tx) => {
+      const newProject = await tx.project.create({
+        data: {
+          name: dto.name,
+          description: source.description,
+          status: source.status,
+          startDate: source.startDate,
+          endDate: source.endDate,
+          organizationId,
+        },
+      });
+
+      if (source.labels.length) {
+        await tx.projectLabel.createMany({
+          data: source.labels.map((l) => ({
+            projectId: newProject.id,
+            labelId: l.labelId,
+          })),
+        });
+      }
+
+      if (includeClients && source.clients.length) {
+        await tx.projectClient.createMany({
+          data: source.clients.map((c) => ({
+            projectId: newProject.id,
+            userId: c.userId,
+          })),
+        });
+      }
+
+      if (includeTasks && source.tasks.length) {
+        for (const task of source.tasks) {
+          const newTask = await tx.task.create({
+            data: {
+              title: task.title,
+              description: task.description,
+              dueDate: task.dueDate,
+              status: "open",
+              closedAt: null,
+              requestedById: task.requestedById,
+              assigneeId: task.assigneeId,
+              order: task.order,
+              type: task.type,
+              question: task.question,
+              projectId: newProject.id,
+              organizationId,
+            },
+          });
+
+          if (task.options.length) {
+            await tx.decisionOption.createMany({
+              data: task.options.map((o) => ({
+                taskId: newTask.id,
+                label: o.label,
+                order: o.order,
+              })),
+            });
+          }
+
+          if (task.labels.length) {
+            await tx.taskLabel.createMany({
+              data: task.labels.map((l) => ({
+                taskId: newTask.id,
+                labelId: l.labelId,
+              })),
+            });
+          }
+        }
+      }
+
+      return tx.project.findUnique({
+        where: { id: newProject.id },
+        include: { clients: { select: { userId: true } } },
+      });
     });
   }
 

--- a/apps/api/src/updates/updates.controller.ts
+++ b/apps/api/src/updates/updates.controller.ts
@@ -17,7 +17,7 @@ import { FileInterceptor } from "@nestjs/platform-express";
 import { Response } from "express";
 import type { ProjectUpdate } from "@atrium/database";
 import { UpdatesService } from "./updates.service";
-import { CreateUpdateDto, UpdatePreviewPrefsDto } from "./updates.dto";
+import { CreateUpdateDto, UpdateContentDto, UpdatePreviewPrefsDto } from "./updates.dto";
 import { AuthGuard, RolesGuard, Roles, CurrentUser, CurrentOrg, CurrentMember, PaginationQueryDto } from "../common";
 import type { UploadedFile as UploadedFileType } from "../files/files.service";
 
@@ -42,6 +42,17 @@ export class UpdatesController {
   ): Promise<ProjectUpdate> {
     if (!projectId) throw new BadRequestException("projectId is required");
     return this.updatesService.create(dto, projectId, orgId, userId, role, attachment);
+  }
+
+  @Patch(":id")
+  update(
+    @Param("id") id: string,
+    @Body() dto: UpdateContentDto,
+    @CurrentOrg("id") orgId: string,
+    @CurrentUser("id") userId: string,
+    @CurrentMember("role") role: string,
+  ): Promise<ProjectUpdate> {
+    return this.updatesService.update(id, dto, orgId, userId, role);
   }
 
   @Patch(":id/preview-prefs")

--- a/apps/api/src/updates/updates.controller.ts
+++ b/apps/api/src/updates/updates.controller.ts
@@ -5,6 +5,7 @@ import {
   Delete,
   Get,
   Param,
+  Patch,
   Post,
   Query,
   Res,
@@ -14,8 +15,9 @@ import {
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { Response } from "express";
+import type { ProjectUpdate } from "@atrium/database";
 import { UpdatesService } from "./updates.service";
-import { CreateUpdateDto } from "./updates.dto";
+import { CreateUpdateDto, UpdatePreviewPrefsDto } from "./updates.dto";
 import { AuthGuard, RolesGuard, Roles, CurrentUser, CurrentOrg, CurrentMember, PaginationQueryDto } from "../common";
 import type { UploadedFile as UploadedFileType } from "../files/files.service";
 
@@ -37,9 +39,26 @@ export class UpdatesController {
     @CurrentOrg("id") orgId: string,
     @CurrentUser("id") userId: string,
     @CurrentMember("role") role: string,
-  ) {
+  ): Promise<ProjectUpdate> {
     if (!projectId) throw new BadRequestException("projectId is required");
     return this.updatesService.create(dto, projectId, orgId, userId, role, attachment);
+  }
+
+  @Patch(":id/preview-prefs")
+  updatePreviewPrefs(
+    @Param("id") id: string,
+    @Body() dto: UpdatePreviewPrefsDto,
+    @CurrentOrg("id") orgId: string,
+    @CurrentUser("id") userId: string,
+    @CurrentMember("role") role: string,
+  ): Promise<ProjectUpdate> {
+    return this.updatesService.updatePreviewPrefs(
+      id,
+      orgId,
+      userId,
+      role,
+      dto.previewPrefs,
+    );
   }
 
   @Get("project/:projectId")

--- a/apps/api/src/updates/updates.dto.ts
+++ b/apps/api/src/updates/updates.dto.ts
@@ -5,12 +5,20 @@ import {
   IsOptional,
   IsString,
   MaxLength,
+  MinLength,
   ValidateNested,
 } from "class-validator";
 import { Type } from "class-transformer";
 
 export class CreateUpdateDto {
   @IsString()
+  @MaxLength(5000)
+  content: string;
+}
+
+export class UpdateContentDto {
+  @IsString()
+  @MinLength(1)
   @MaxLength(5000)
   content: string;
 }

--- a/apps/api/src/updates/updates.dto.ts
+++ b/apps/api/src/updates/updates.dto.ts
@@ -1,7 +1,38 @@
-import { IsString, MaxLength } from "class-validator";
+import {
+  IsBoolean,
+  IsIn,
+  IsObject,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from "class-validator";
+import { Type } from "class-transformer";
 
 export class CreateUpdateDto {
   @IsString()
   @MaxLength(5000)
   content: string;
+}
+
+export class PreviewPrefDto {
+  @IsOptional()
+  @IsIn(["compact", "full"])
+  size?: "compact" | "full";
+
+  @IsOptional()
+  @IsBoolean()
+  hidden?: boolean;
+}
+
+export class UpdatePreviewPrefsDto {
+  /**
+   * Map of URL → { size?, hidden? }. We validate with `IsObject` only and
+   * trust the service to key-by-URL — the shape is narrow enough that
+   * per-URL nested validation isn't worth the class-validator gymnastics.
+   */
+  @IsObject()
+  @ValidateNested({ each: true })
+  @Type(() => PreviewPrefDto)
+  previewPrefs: Record<string, PreviewPrefDto>;
 }

--- a/apps/api/src/updates/updates.service.spec.ts
+++ b/apps/api/src/updates/updates.service.spec.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { UpdatesService } from "./updates.service";
+import {
+  NotFoundException,
+  ForbiddenException,
+} from "@nestjs/common";
+import type { PrismaService } from "../prisma/prisma.service";
+import type { NotificationsService } from "../notifications/notifications.service";
+import type { ActivityService } from "../activity/activity.service";
+import type { StorageProvider } from "./../files/storage/storage.interface";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ORG = "org-1";
+const AUTHOR = "user-author";
+const ADMIN = "user-admin";
+const OTHER = "user-other";
+const PROJECT_ID = "project-1";
+const UPDATE_ID = "update-1";
+
+interface PrismaArgs {
+  where?: Record<string, unknown>;
+  data?: Record<string, unknown>;
+}
+
+function makeUpdate(overrides: Record<string, unknown> = {}) {
+  return {
+    id: UPDATE_ID,
+    content: "Original content",
+    authorId: AUTHOR,
+    projectId: PROJECT_ID,
+    organizationId: ORG,
+    attachmentKey: null,
+    attachmentMimeType: null,
+    attachmentName: null,
+    fileId: null,
+    previewPrefs: null,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    updatedAt: new Date("2024-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+const mockStorage = {
+  upload: mock(() => Promise.resolve()),
+  download: mock(() => Promise.resolve({ body: null as never, contentType: "" })),
+  getSignedUrl: mock(() => Promise.resolve("https://example.com/signed")),
+  delete: mock(() => Promise.resolve()),
+};
+
+const mockPrisma = {
+  projectUpdate: {
+    findFirst: mock(() => Promise.resolve(null as unknown)),
+    update: mock((args: PrismaArgs) =>
+      Promise.resolve({ ...makeUpdate(), ...args.data, id: args.where?.id }),
+    ),
+  },
+  projectClient: {
+    findFirst: mock(() => Promise.resolve(null as unknown)),
+  },
+};
+
+const mockNotifications = {
+  notifyProjectUpdate: mock(() => Promise.resolve()),
+} as unknown as NotificationsService;
+
+const mockActivity = {} as unknown as ActivityService;
+
+function clearAllMocks() {
+  mockPrisma.projectUpdate.findFirst.mockClear();
+  mockPrisma.projectUpdate.update.mockClear();
+  mockPrisma.projectClient.findFirst.mockClear();
+}
+
+describe("UpdatesService.update", () => {
+  let service: UpdatesService;
+
+  beforeEach(() => {
+    clearAllMocks();
+    service = new UpdatesService(
+      mockPrisma as unknown as PrismaService,
+      mockNotifications,
+      mockActivity,
+      mockStorage as unknown as StorageProvider,
+    );
+  });
+
+  it("allows the author to edit their own update", async () => {
+    mockPrisma.projectUpdate.findFirst.mockReturnValue(
+      Promise.resolve(makeUpdate({ authorId: AUTHOR })),
+    );
+    // author is a member and IS currently assigned to the project
+    mockPrisma.projectClient.findFirst.mockReturnValue(
+      Promise.resolve({ id: "pc-1", projectId: PROJECT_ID, userId: AUTHOR }),
+    );
+
+    const result = await service.update(
+      UPDATE_ID,
+      { content: "Updated by author" },
+      ORG,
+      AUTHOR,
+      "member",
+    );
+
+    expect(mockPrisma.projectUpdate.update).toHaveBeenCalledWith({
+      where: { id: UPDATE_ID },
+      data: { content: "Updated by author" },
+    });
+    expect(result).toBeDefined();
+  });
+
+  it("allows an owner to edit another user's update", async () => {
+    mockPrisma.projectUpdate.findFirst.mockReturnValue(
+      Promise.resolve(makeUpdate({ authorId: OTHER })),
+    );
+
+    await service.update(
+      UPDATE_ID,
+      { content: "Edited by owner" },
+      ORG,
+      ADMIN,
+      "owner",
+    );
+
+    expect(mockPrisma.projectUpdate.update).toHaveBeenCalled();
+  });
+
+  it("allows an admin to edit another user's update", async () => {
+    mockPrisma.projectUpdate.findFirst.mockReturnValue(
+      Promise.resolve(makeUpdate({ authorId: OTHER })),
+    );
+
+    await service.update(
+      UPDATE_ID,
+      { content: "Edited by admin" },
+      ORG,
+      ADMIN,
+      "admin",
+    );
+
+    expect(mockPrisma.projectUpdate.update).toHaveBeenCalled();
+  });
+
+  it("throws ForbiddenException when a member tries to edit someone else's update", async () => {
+    mockPrisma.projectUpdate.findFirst.mockReturnValue(
+      Promise.resolve(makeUpdate({ authorId: OTHER })),
+    );
+
+    try {
+      await service.update(
+        UPDATE_ID,
+        { content: "Hack" },
+        ORG,
+        AUTHOR,
+        "member",
+      );
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ForbiddenException);
+    }
+
+    expect(mockPrisma.projectUpdate.update).not.toHaveBeenCalled();
+  });
+
+  it("throws NotFoundException when update does not exist", async () => {
+    mockPrisma.projectUpdate.findFirst.mockReturnValue(Promise.resolve(null));
+
+    try {
+      await service.update(
+        "nonexistent",
+        { content: "x" },
+        ORG,
+        AUTHOR,
+        "owner",
+      );
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toBeInstanceOf(NotFoundException);
+    }
+
+    expect(mockPrisma.projectUpdate.update).not.toHaveBeenCalled();
+  });
+
+  it("throws ForbiddenException when author is a client no longer assigned to the project", async () => {
+    // Author matches, but assertProjectAccess will deny because the client
+    // is no longer in projectClient.
+    mockPrisma.projectUpdate.findFirst.mockReturnValue(
+      Promise.resolve(makeUpdate({ authorId: AUTHOR })),
+    );
+    mockPrisma.projectClient.findFirst.mockReturnValue(Promise.resolve(null));
+
+    try {
+      await service.update(
+        UPDATE_ID,
+        { content: "x" },
+        ORG,
+        AUTHOR,
+        "member",
+      );
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ForbiddenException);
+    }
+
+    expect(mockPrisma.projectUpdate.update).not.toHaveBeenCalled();
+  });
+
+  it("scopes the update lookup to the requesting org", async () => {
+    mockPrisma.projectUpdate.findFirst.mockReturnValue(
+      Promise.resolve(makeUpdate({ authorId: AUTHOR })),
+    );
+
+    await service.update(
+      UPDATE_ID,
+      { content: "scoped" },
+      ORG,
+      AUTHOR,
+      "owner",
+    );
+
+    expect(mockPrisma.projectUpdate.findFirst).toHaveBeenCalledWith({
+      where: { id: UPDATE_ID, organizationId: ORG },
+    });
+  });
+});

--- a/apps/api/src/updates/updates.service.ts
+++ b/apps/api/src/updates/updates.service.ts
@@ -27,6 +27,20 @@ const IMAGE_TYPES = new Set([
   "image/webp",
 ]);
 
+type PreviewPrefsMap = Record<
+  string,
+  { size?: "compact" | "full"; hidden?: boolean }
+>;
+
+// Prisma surfaces `previewPrefs` as its internal `JsonValue`, which can't be
+// named across package boundaries. Narrow to our own shape at the response
+// boundary so the inferred controller return types stay portable.
+function coercePreviewPrefs(value: unknown): PreviewPrefsMap | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as PreviewPrefsMap)
+    : null;
+}
+
 @Injectable()
 export class UpdatesService {
   constructor(
@@ -153,6 +167,7 @@ export class UpdatesService {
           hasAttachment: !!u.attachmentKey || !!u.fileId,
           fileId: u.fileId,
           projectId: u.projectId,
+          previewPrefs: coercePreviewPrefs(u.previewPrefs),
           author: author ?? { id: u.authorId, name: "Unknown" },
           commentCount: u._count.comments,
           createdAt: u.createdAt,
@@ -248,6 +263,7 @@ export class UpdatesService {
           attachmentMimeType: u.attachmentMimeType,
           hasAttachment: !!u.attachmentKey || !!u.fileId,
           fileId: u.fileId,
+          previewPrefs: coercePreviewPrefs(u.previewPrefs),
           author: author ?? { id: u.authorId, name: "Unknown" },
           commentCount: u._count.comments,
         };

--- a/apps/api/src/updates/updates.service.ts
+++ b/apps/api/src/updates/updates.service.ts
@@ -171,6 +171,7 @@ export class UpdatesService {
           author: author ?? { id: u.authorId, name: "Unknown" },
           commentCount: u._count.comments,
           createdAt: u.createdAt,
+          updatedAt: u.updatedAt,
         };
       }),
     );
@@ -257,6 +258,7 @@ export class UpdatesService {
           id: u.id,
           kind: "update" as const,
           createdAt: u.createdAt,
+          updatedAt: u.updatedAt,
           content: u.content,
           attachmentUrl,
           attachmentName: u.attachmentName,
@@ -309,6 +311,34 @@ export class UpdatesService {
     }
 
     return this.findTimeline(projectId, organizationId, page, limit);
+  }
+
+  async update(
+    id: string,
+    dto: { content: string },
+    organizationId: string,
+    userId: string,
+    role: string,
+  ): Promise<ProjectUpdate> {
+    const update = await this.prisma.projectUpdate.findFirst({
+      where: { id, organizationId },
+    });
+    if (!update) throw new NotFoundException("Update not found");
+
+    const isPrivileged = role === "owner" || role === "admin";
+    const isAuthor = update.authorId === userId;
+    if (!isAuthor && !isPrivileged) {
+      throw new ForbiddenException("Cannot edit this update");
+    }
+
+    // Ensure the user still has access to the project — a client removed
+    // from the project should not be able to edit their old updates.
+    await assertProjectAccess(this.prisma, update.projectId, userId, role, organizationId);
+
+    return this.prisma.projectUpdate.update({
+      where: { id },
+      data: { content: dto.content },
+    });
   }
 
   async updatePreviewPrefs(

--- a/apps/api/src/updates/updates.service.ts
+++ b/apps/api/src/updates/updates.service.ts
@@ -5,6 +5,7 @@ import {
   BadRequestException,
   ForbiddenException,
 } from "@nestjs/common";
+import type { ProjectUpdate } from "@atrium/database";
 import { PrismaService } from "../prisma/prisma.service";
 import { NotificationsService } from "../notifications/notifications.service";
 import { ActivityService } from "../activity/activity.service";
@@ -42,7 +43,7 @@ export class UpdatesService {
     authorId: string,
     role: string,
     attachment?: UploadedFile,
-  ) {
+  ): Promise<ProjectUpdate> {
     const project = await this.prisma.project.findFirst({
       where: { id: projectId, organizationId },
     });
@@ -292,6 +293,28 @@ export class UpdatesService {
     }
 
     return this.findTimeline(projectId, organizationId, page, limit);
+  }
+
+  async updatePreviewPrefs(
+    id: string,
+    organizationId: string,
+    userId: string,
+    role: string,
+    previewPrefs: Record<string, { size?: "compact" | "full"; hidden?: boolean }>,
+  ): Promise<ProjectUpdate> {
+    const update = await this.prisma.projectUpdate.findFirst({
+      where: { id, organizationId },
+    });
+    if (!update) throw new NotFoundException("Update not found");
+
+    // Anyone with access to the project can tweak preview prefs on an update.
+    // Prefs are a display hint, not content — no stricter guard needed.
+    await assertProjectAccess(this.prisma, update.projectId, userId, role, organizationId);
+
+    return this.prisma.projectUpdate.update({
+      where: { id },
+      data: { previewPrefs: previewPrefs as object },
+    });
   }
 
   async remove(id: string, organizationId: string) {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -23,7 +23,16 @@ const nextConfig: NextConfig = {
         headers: [
           {
             key: "Content-Security-Policy",
-            value: "frame-src https://www.youtube.com https://www.loom.com https://www.figma.com https://docs.google.com;",
+            value:
+              "frame-src " +
+              // Regex-based providers (fast path)
+              "https://www.youtube.com https://www.loom.com https://www.figma.com https://docs.google.com " +
+              // oEmbed providers (resolved via /api/embeds/resolve)
+              "https://www.canva.com https://canva.com " +
+              "https://open.spotify.com " +
+              "https://w.soundcloud.com https://soundcloud.com " +
+              "https://codepen.io " +
+              "https://player.vimeo.com;",
           },
         ],
       },

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/files-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/files-section.tsx
@@ -28,6 +28,7 @@ import {
   ExternalLink,
   LinkIcon,
   Plus,
+  Pencil,
 } from "lucide-react";
 import { track } from "@/lib/track";
 import { downloadFile } from "@/lib/download";
@@ -129,12 +130,14 @@ export function FilesSection({
   files,
   onFileChange,
   projectClients: projectClientsProp = [],
+  currentRole = null,
 }: {
   projectId: string;
   isArchived: boolean;
   files: FileRecord[];
   onFileChange: () => void;
   projectClients?: { userId: string; user: { id: string; name: string; email: string } }[];
+  currentRole?: string | null;
 }) {
   const confirm = useConfirm();
   const { success, error: showError } = useToast();
@@ -172,6 +175,15 @@ export function FilesSection({
   const [linkTitle, setLinkTitle] = useState("");
   const [linkDescription, setLinkDescription] = useState("");
   const [linkSaving, setLinkSaving] = useState(false);
+
+  // Edit file modal state
+  const [editFile, setEditFile] = useState<FileRecord | null>(null);
+  const [editFilename, setEditFilename] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editUrl, setEditUrl] = useState("");
+  const [editSaving, setEditSaving] = useState(false);
+
+  const canManageFiles = currentRole === "owner" || currentRole === "admin";
 
   // Add menu (dropdown) state
   const [showAddMenu, setShowAddMenu] = useState(false);
@@ -284,6 +296,60 @@ export function FilesSection({
     setLinkUrl("");
     setLinkTitle("");
     setLinkDescription("");
+  };
+
+  const openEditFile = (file: FileRecord): void => {
+    setEditFile(file);
+    setEditFilename(file.filename);
+    setEditDescription(file.description ?? "");
+    setEditUrl(file.url ?? "");
+  };
+
+  const closeEditFile = (): void => {
+    setEditFile(null);
+    setEditFilename("");
+    setEditDescription("");
+    setEditUrl("");
+  };
+
+  const handleEditFileSave = async (): Promise<void> => {
+    if (!editFile) return;
+    const nextFilename = editFilename.trim();
+    if (!nextFilename) return;
+    const body: { filename?: string; description?: string; url?: string } = {};
+    if (nextFilename !== editFile.filename) {
+      body.filename = nextFilename;
+    }
+    const nextDescription = editDescription.trim();
+    const originalDescription = editFile.description ?? "";
+    if (nextDescription !== originalDescription) {
+      body.description = nextDescription;
+    }
+    if (editFile.type === "LINK") {
+      const nextUrl = editUrl.trim();
+      const originalUrl = editFile.url ?? "";
+      if (nextUrl && nextUrl !== originalUrl) {
+        body.url = nextUrl;
+      }
+    }
+    if (Object.keys(body).length === 0) {
+      closeEditFile();
+      return;
+    }
+    setEditSaving(true);
+    try {
+      await apiFetch(`/files/${editFile.id}`, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      });
+      closeEditFile();
+      onFileChange();
+      success("File updated");
+    } catch (err) {
+      showError(err instanceof Error ? err.message : "Failed to update file");
+    } finally {
+      setEditSaving(false);
+    }
   };
 
   const handleLinkSubmit = async () => {
@@ -832,6 +898,15 @@ export function FilesSection({
                   ) : (
                     <Download size={14} className="text-[var(--muted-foreground)]" />
                   )}
+                  {!isArchived && canManageFiles && (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); openEditFile(file); }}
+                      title="Edit"
+                      className="p-1.5 rounded text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--muted)] transition-colors"
+                    >
+                      <Pencil size={14} />
+                    </button>
+                  )}
                   {!isArchived && (
                     <button
                       onClick={(e) => { e.stopPropagation(); handleFileDelete(file.id); }}
@@ -1033,6 +1108,73 @@ export function FilesSection({
                 className="px-4 py-1.5 bg-[var(--primary)] text-white rounded-lg text-sm hover:opacity-90 disabled:opacity-50"
               >
                 {linkSaving ? "Adding..." : "Add link"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Edit File Modal */}
+      {editFile && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={(e) => { if (e.target === e.currentTarget) closeEditFile(); }}
+        >
+          <div className="bg-[var(--background)] rounded-xl shadow-lg w-full max-w-[480px] mx-4 p-6 space-y-4">
+            <h3 className="text-lg font-semibold">
+              {editFile.type === "LINK" ? "Edit Link" : "Edit File"}
+            </h3>
+            {editFile.type === "LINK" && (
+              <div>
+                <label className="text-sm text-[var(--muted-foreground)]">URL</label>
+                <input
+                  type="url"
+                  value={editUrl}
+                  onChange={(e) => setEditUrl(e.target.value)}
+                  placeholder="https://..."
+                  className="w-full mt-1 px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm"
+                />
+              </div>
+            )}
+            <div>
+              <label className="text-sm text-[var(--muted-foreground)]">
+                {editFile.type === "LINK" ? "Title" : "Filename"}
+              </label>
+              <input
+                type="text"
+                value={editFilename}
+                onChange={(e) => setEditFilename(e.target.value)}
+                maxLength={255}
+                className="w-full mt-1 px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm"
+              />
+            </div>
+            <div>
+              <label className="text-sm text-[var(--muted-foreground)]">Description (optional)</label>
+              <textarea
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+                placeholder="What is this for?"
+                rows={2}
+                className="w-full mt-1 px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm resize-none"
+              />
+            </div>
+            <div className="flex items-center justify-end gap-2 pt-2 border-t border-[var(--border)]">
+              <button
+                onClick={closeEditFile}
+                className="px-4 py-1.5 border border-[var(--border)] rounded-lg text-sm hover:bg-[var(--muted)]"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleEditFileSave}
+                disabled={
+                  editSaving ||
+                  !editFilename.trim() ||
+                  (editFile.type === "LINK" && !editUrl.trim())
+                }
+                className="px-4 py-1.5 bg-[var(--primary)] text-white rounded-lg text-sm hover:opacity-90 disabled:opacity-50"
+              >
+                {editSaving ? "Saving..." : "Save"}
               </button>
             </div>
           </div>

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/files-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/files-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { apiFetch } from "@/lib/api";
 import { formatBytes, formatRelativeTime } from "@/lib/utils";
 import { useConfirm } from "@/components/confirm-modal";
@@ -25,6 +25,9 @@ import {
   Link2,
   Copy,
   XCircle,
+  ExternalLink,
+  LinkIcon,
+  Plus,
 } from "lucide-react";
 import { track } from "@/lib/track";
 import { downloadFile } from "@/lib/download";
@@ -43,8 +46,11 @@ const SigningViewer = dynamic(
 interface FileRecord {
   id: string;
   filename: string;
-  mimeType: string;
-  sizeBytes: number;
+  type?: "UPLOAD" | "LINK";
+  mimeType?: string | null;
+  sizeBytes?: number | null;
+  url?: string | null;
+  description?: string | null;
   createdAt: string;
 }
 
@@ -160,6 +166,27 @@ export function FilesSection({
   const [newLinkToken, setNewLinkToken] = useState<string | null>(null);
   const [placerDocId, setPlacerDocId] = useState<string | null>(null);
 
+  // Add Link modal state
+  const [showAddLink, setShowAddLink] = useState(false);
+  const [linkUrl, setLinkUrl] = useState("");
+  const [linkTitle, setLinkTitle] = useState("");
+  const [linkDescription, setLinkDescription] = useState("");
+  const [linkSaving, setLinkSaving] = useState(false);
+
+  // Add menu (dropdown) state
+  const [showAddMenu, setShowAddMenu] = useState(false);
+  const addMenuRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!showAddMenu) return;
+    const onClick = (e: MouseEvent) => {
+      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) {
+        setShowAddMenu(false);
+      }
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [showAddMenu]);
+
   // Doc upload form
   const [docTitle, setDocTitle] = useState("");
   const [docType, setDocType] = useState("contract");
@@ -250,6 +277,38 @@ export function FilesSection({
       success("File deleted");
     } catch (err) {
       showError(err instanceof Error ? err.message : "Failed to delete file");
+    }
+  };
+
+  const resetLinkForm = () => {
+    setLinkUrl("");
+    setLinkTitle("");
+    setLinkDescription("");
+  };
+
+  const handleLinkSubmit = async () => {
+    const url = linkUrl.trim();
+    const title = linkTitle.trim();
+    if (!url || !title) return;
+    setLinkSaving(true);
+    try {
+      await apiFetch("/files/link", {
+        method: "POST",
+        body: JSON.stringify({
+          projectId,
+          url,
+          title,
+          description: linkDescription.trim() || undefined,
+        }),
+      });
+      setShowAddLink(false);
+      resetLinkForm();
+      onFileChange();
+      success("Link added");
+    } catch (err) {
+      showError(err instanceof Error ? err.message : "Failed to add link");
+    } finally {
+      setLinkSaving(false);
     }
   };
 
@@ -411,13 +470,40 @@ export function FilesSection({
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-sm font-medium">Files</h2>
         {!isArchived && (
-          <button
-            onClick={() => setShowDocUpload(true)}
-            className="flex items-center gap-2 px-3 py-1.5 bg-[var(--primary)] text-white rounded-lg text-sm hover:opacity-90"
-          >
-            <Upload size={14} />
-            Upload
-          </button>
+          <div className="relative" ref={addMenuRef}>
+            <button
+              onClick={() => setShowAddMenu((v) => !v)}
+              className="flex items-center gap-2 px-3 py-1.5 bg-[var(--primary)] text-white rounded-lg text-sm hover:opacity-90"
+            >
+              <Plus size={14} />
+              Add
+              <ChevronDown size={12} />
+            </button>
+            {showAddMenu && (
+              <div className="absolute right-0 mt-1 w-64 bg-[var(--background)] border border-[var(--border)] rounded-lg shadow-lg z-10 py-1">
+                <button
+                  onClick={() => { setShowAddMenu(false); setShowDocUpload(true); }}
+                  className="w-full flex items-start gap-3 px-3 py-2.5 hover:bg-[var(--muted)] text-left"
+                >
+                  <Upload size={14} className="mt-0.5 shrink-0 text-[var(--muted-foreground)]" />
+                  <div>
+                    <p className="text-sm font-medium">Upload file</p>
+                    <p className="text-xs text-[var(--muted-foreground)]">Upload a document from your device</p>
+                  </div>
+                </button>
+                <button
+                  onClick={() => { setShowAddMenu(false); setShowAddLink(true); }}
+                  className="w-full flex items-start gap-3 px-3 py-2.5 hover:bg-[var(--muted)] text-left"
+                >
+                  <LinkIcon size={14} className="mt-0.5 shrink-0 text-[var(--muted-foreground)]" />
+                  <div>
+                    <p className="text-sm font-medium">Add link</p>
+                    <p className="text-xs text-[var(--muted-foreground)]">Link to an external resource (Nextcloud, Canva, etc.)</p>
+                  </div>
+                </button>
+              </div>
+            )}
+          </div>
         )}
       </div>
 
@@ -690,28 +776,76 @@ export function FilesSection({
 
       {/* Plain files list */}
       <div className="space-y-2">
-        {sortedFiles.map((file) => (
-          <div key={file.id} className="p-3 border border-[var(--border)] rounded-lg">
-            <div className="flex items-start justify-between gap-2 flex-wrap sm:flex-nowrap">
-              <div className="min-w-0">
-                <p className="text-sm font-medium truncate">{file.filename}</p>
-                <p className="text-xs text-[var(--muted-foreground)]">
-                  {formatBytes(file.sizeBytes)} &middot; {formatRelativeTime(file.createdAt)}
-                </p>
-              </div>
-              <div className="flex flex-wrap gap-2 shrink-0">
-                <button onClick={() => handleFileDownload(file.id, file.filename)} className="flex items-center gap-1.5 text-sm text-[var(--primary)] hover:underline">
-                  <Download size={14} /> Download
-                </button>
-                {!isArchived && (
-                  <button onClick={() => handleFileDelete(file.id)} className="flex items-center gap-1.5 text-sm text-red-500 hover:underline">
-                    <Trash2 size={14} /> Delete
-                  </button>
-                )}
+        {sortedFiles.map((file) => {
+          const isLink = file.type === "LINK";
+          let hostname = "";
+          if (isLink && file.url) {
+            try { hostname = new URL(file.url).hostname; } catch { hostname = file.url; }
+          }
+          const handleCardClick = () => {
+            if (isLink && file.url) {
+              window.open(file.url, "_blank", "noopener,noreferrer");
+            } else {
+              handleFileDownload(file.id, file.filename);
+            }
+          };
+          return (
+            <div
+              key={file.id}
+              role="button"
+              tabIndex={0}
+              onClick={handleCardClick}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleCardClick();
+                }
+              }}
+              className="p-3 border border-[var(--border)] rounded-lg cursor-pointer hover:bg-[var(--muted)]/40 transition-colors focus:outline-none focus:ring-1 focus:ring-[var(--primary)]"
+            >
+              <div className="flex items-start justify-between gap-2 flex-wrap sm:flex-nowrap">
+                <div className="min-w-0 flex items-start gap-2">
+                  {isLink ? (
+                    <LinkIcon size={14} className="mt-0.5 shrink-0 text-[var(--muted-foreground)]" />
+                  ) : (
+                    <FileIcon size={14} className="mt-0.5 shrink-0 text-[var(--muted-foreground)]" />
+                  )}
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium truncate">{file.filename}</p>
+                    {isLink ? (
+                      <p className="text-xs text-[var(--muted-foreground)] truncate">
+                        {hostname} &middot; {formatRelativeTime(file.createdAt)}
+                      </p>
+                    ) : (
+                      <p className="text-xs text-[var(--muted-foreground)]">
+                        {formatBytes(file.sizeBytes ?? 0)} &middot; {formatRelativeTime(file.createdAt)}
+                      </p>
+                    )}
+                    {isLink && file.description && (
+                      <p className="text-xs text-[var(--muted-foreground)] mt-1">{file.description}</p>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-1 shrink-0" onClick={(e) => e.stopPropagation()}>
+                  {isLink ? (
+                    <ExternalLink size={14} className="text-[var(--muted-foreground)]" />
+                  ) : (
+                    <Download size={14} className="text-[var(--muted-foreground)]" />
+                  )}
+                  {!isArchived && (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); handleFileDelete(file.id); }}
+                      title="Delete"
+                      className="p-1.5 rounded text-[var(--muted-foreground)] hover:text-red-500 hover:bg-red-500/10 transition-colors"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  )}
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
         {files.length === 0 && documents.length === 0 && (
           <div className="text-center py-8">
             <FileX size={32} className="mx-auto text-[var(--muted-foreground)] mb-2" />
@@ -850,6 +984,57 @@ export function FilesSection({
               <button onClick={() => handleDocUpload(true)} disabled={docUploading || !docTitle.trim() || !docFile} className="px-4 py-1.5 bg-[var(--primary)] text-white rounded-lg text-sm hover:opacity-90 disabled:opacity-50">{docUploading ? "Uploading..." : "Upload & Send"}</button>
             </div>
             <p className="text-[11px] text-[var(--muted-foreground)] text-right -mt-2">Sending notifies the client immediately.</p>
+          </div>
+        </div>
+      )}
+
+      {/* Add Link Modal */}
+      {showAddLink && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={(e) => { if (e.target === e.currentTarget) { setShowAddLink(false); resetLinkForm(); } }}>
+          <div className="bg-[var(--background)] rounded-xl shadow-lg w-full max-w-[480px] mx-4 p-6 space-y-4">
+            <h3 className="text-lg font-semibold">Add Link</h3>
+            <p className="text-sm text-[var(--muted-foreground)]">Link to an external resource like a Nextcloud document, Canva design, or any other URL.</p>
+            <div>
+              <label className="text-sm text-[var(--muted-foreground)]">URL</label>
+              <input
+                type="url"
+                value={linkUrl}
+                onChange={(e) => setLinkUrl(e.target.value)}
+                placeholder="https://..."
+                className="w-full mt-1 px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm"
+              />
+            </div>
+            <div>
+              <label className="text-sm text-[var(--muted-foreground)]">Title</label>
+              <input
+                type="text"
+                value={linkTitle}
+                onChange={(e) => setLinkTitle(e.target.value)}
+                placeholder="e.g., Design mockup (Canva)"
+                maxLength={255}
+                className="w-full mt-1 px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm"
+              />
+            </div>
+            <div>
+              <label className="text-sm text-[var(--muted-foreground)]">Description (optional)</label>
+              <textarea
+                value={linkDescription}
+                onChange={(e) => setLinkDescription(e.target.value)}
+                placeholder="What is this link for?"
+                rows={2}
+                className="w-full mt-1 px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm resize-none"
+              />
+            </div>
+            <div className="flex items-center justify-end gap-2 pt-2 border-t border-[var(--border)]">
+              <button onClick={() => { setShowAddLink(false); resetLinkForm(); }} className="px-4 py-1.5 border border-[var(--border)] rounded-lg text-sm hover:bg-[var(--muted)]">Cancel</button>
+              <button
+                onClick={handleLinkSubmit}
+                disabled={linkSaving || !linkUrl.trim() || !linkTitle.trim()}
+                className="px-4 py-1.5 bg-[var(--primary)] text-white rounded-lg text-sm hover:opacity-90 disabled:opacity-50"
+              >
+                {linkSaving ? "Adding..." : "Add link"}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/files-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/files-section.tsx
@@ -867,6 +867,7 @@ export function FilesSection({
                   handleCardClick();
                 }
               }}
+              data-testid={`file-row-${file.id}`}
               className="p-3 border border-[var(--border)] rounded-lg cursor-pointer hover:bg-[var(--muted)]/40 transition-colors focus:outline-none focus:ring-1 focus:ring-[var(--primary)]"
             >
               <div className="flex items-start justify-between gap-2 flex-wrap sm:flex-nowrap">
@@ -902,6 +903,8 @@ export function FilesSection({
                     <button
                       onClick={(e) => { e.stopPropagation(); openEditFile(file); }}
                       title="Edit"
+                      aria-label="Edit file"
+                      data-testid={`edit-file-${file.id}`}
                       className="p-1.5 rounded text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--muted)] transition-colors"
                     >
                       <Pencil size={14} />
@@ -1132,6 +1135,7 @@ export function FilesSection({
                   value={editUrl}
                   onChange={(e) => setEditUrl(e.target.value)}
                   placeholder="https://..."
+                  data-testid="edit-file-url"
                   className="w-full mt-1 px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm"
                 />
               </div>
@@ -1145,6 +1149,7 @@ export function FilesSection({
                 value={editFilename}
                 onChange={(e) => setEditFilename(e.target.value)}
                 maxLength={255}
+                data-testid="edit-file-name"
                 className="w-full mt-1 px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm"
               />
             </div>
@@ -1155,6 +1160,7 @@ export function FilesSection({
                 onChange={(e) => setEditDescription(e.target.value)}
                 placeholder="What is this for?"
                 rows={2}
+                data-testid="edit-file-description"
                 className="w-full mt-1 px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm resize-none"
               />
             </div>
@@ -1172,6 +1178,7 @@ export function FilesSection({
                   !editFilename.trim() ||
                   (editFile.type === "LINK" && !editUrl.trim())
                 }
+                data-testid="edit-file-save"
                 className="px-4 py-1.5 bg-[var(--primary)] text-white rounded-lg text-sm hover:opacity-90 disabled:opacity-50"
               >
                 {editSaving ? "Saving..." : "Save"}

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/updates-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/updates-section.tsx
@@ -16,6 +16,7 @@ import {
   FileCheck,
   Vote,
   Lock,
+  Pencil,
 } from "lucide-react";
 import { linkify } from "@/lib/linkify";
 import { Embeds, type PreviewPrefs } from "@/lib/embeds";
@@ -28,6 +29,7 @@ interface TimelineEntry {
   id: string;
   kind: "update" | "activity";
   createdAt: string;
+  updatedAt?: string;
   // Update fields
   content?: string;
   attachmentUrl?: string;
@@ -87,10 +89,14 @@ export function UpdatesSection({
   projectId,
   isArchived,
   onFileChange,
+  currentUserId = null,
+  currentRole = null,
 }: {
   projectId: string;
   isArchived: boolean;
   onFileChange?: () => void;
+  currentUserId?: string | null;
+  currentRole?: string | null;
 }) {
   const confirm = useConfirm();
   const { success, error: showError } = useToast();
@@ -101,6 +107,11 @@ export function UpdatesSection({
   const [newAttachment, setNewAttachment] = useState<File | null>(null);
   const [posting, setPosting] = useState(false);
   const [showCompose, setShowCompose] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState("");
+  const [editSaving, setEditSaving] = useState(false);
+
+  const isPrivileged = currentRole === "owner" || currentRole === "admin";
 
   const loadTimeline = useCallback(() => {
     apiFetch<PaginatedResponse<TimelineEntry>>(
@@ -116,6 +127,37 @@ export function UpdatesSection({
   useEffect(() => {
     loadTimeline();
   }, [loadTimeline]);
+
+  const startEdit = (entry: TimelineEntry): void => {
+    setEditingId(entry.id);
+    setEditDraft(entry.content || "");
+  };
+
+  const cancelEdit = (): void => {
+    setEditingId(null);
+    setEditDraft("");
+  };
+
+  const saveEdit = async (updateId: string): Promise<void> => {
+    const content = editDraft.trim();
+    if (!content) return;
+    setEditSaving(true);
+    try {
+      await apiFetch(`/updates/${updateId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content }),
+      });
+      setEditingId(null);
+      setEditDraft("");
+      loadTimeline();
+      success("Update edited");
+    } catch (err) {
+      showError(err instanceof Error ? err.message : "Failed to edit update");
+    } finally {
+      setEditSaving(false);
+    }
+  };
 
   const handlePost = async () => {
     if (!newContent.trim()) return;
@@ -333,6 +375,14 @@ export function UpdatesSection({
           const attachmentSrc = entry.fileId
             ? `${API_URL}/api/files/${entry.fileId}/download`
             : entry.attachmentUrl || `${API_URL}/api/updates/${entry.id}/attachment`;
+          const isAuthor =
+            !!currentUserId && !!entry.author?.id && entry.author.id === currentUserId;
+          const canEdit = isAuthor || isPrivileged || !currentRole;
+          const isEditing = editingId === entry.id;
+          const showEdited =
+            !!entry.updatedAt &&
+            new Date(entry.updatedAt).getTime() - new Date(entry.createdAt).getTime() >
+              2 * 60 * 1000;
           return (
             <div
               key={entry.id}
@@ -344,23 +394,69 @@ export function UpdatesSection({
                   <span className="text-xs text-[var(--muted-foreground)]">
                     {formatRelativeTime(entry.createdAt)}
                   </span>
+                  {showEdited && (
+                    <span className="text-xs text-[var(--muted-foreground)] italic">
+                      (edited)
+                    </span>
+                  )}
                 </div>
-                {!isArchived && (
-                  <button
-                    onClick={() => handleDelete(entry.id)}
-                    className="flex items-center gap-1 px-2 py-1 text-xs text-red-500 hover:underline"
-                  >
-                    <Trash2 size={12} />
-                    Delete
-                  </button>
+                {!isArchived && !isEditing && (
+                  <div className="flex items-center gap-1">
+                    {canEdit && (
+                      <button
+                        onClick={() => startEdit(entry)}
+                        className="flex items-center gap-1 px-2 py-1 text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:underline"
+                      >
+                        <Pencil size={12} />
+                        Edit
+                      </button>
+                    )}
+                    <button
+                      onClick={() => handleDelete(entry.id)}
+                      className="flex items-center gap-1 px-2 py-1 text-xs text-red-500 hover:underline"
+                    >
+                      <Trash2 size={12} />
+                      Delete
+                    </button>
+                  </div>
                 )}
               </div>
-              <p className="text-sm whitespace-pre-wrap">{linkify(entry.content || "")}</p>
-              <Embeds
-                text={entry.content || ""}
-                prefs={entry.previewPrefs ?? undefined}
-                onPrefsChange={(next) => handlePrefsChange(entry.id, next)}
-              />
+              {isEditing ? (
+                <div className="space-y-2">
+                  <textarea
+                    value={editDraft}
+                    onChange={(e) => setEditDraft(e.target.value)}
+                    maxLength={5000}
+                    rows={4}
+                    autoFocus
+                    className="w-full px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm resize-none outline-none focus:ring-1 focus:ring-[var(--primary)]"
+                  />
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={cancelEdit}
+                      className="px-3 py-1 border border-[var(--border)] rounded-lg text-xs hover:bg-[var(--muted)] transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => saveEdit(entry.id)}
+                      disabled={editSaving || !editDraft.trim()}
+                      className="px-3 py-1 bg-[var(--primary)] text-white rounded-lg text-xs hover:opacity-90 disabled:opacity-50"
+                    >
+                      {editSaving ? "Saving..." : "Save"}
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <p className="text-sm whitespace-pre-wrap">{linkify(entry.content || "")}</p>
+                  <Embeds
+                    text={entry.content || ""}
+                    prefs={entry.previewPrefs ?? undefined}
+                    onPrefsChange={(next) => handlePrefsChange(entry.id, next)}
+                  />
+                </>
+              )}
               {entry.hasAttachment && isImage && (
                 <img
                   src={attachmentSrc}

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/updates-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/updates-section.tsx
@@ -18,7 +18,7 @@ import {
   Lock,
 } from "lucide-react";
 import { linkify } from "@/lib/linkify";
-import { Embeds } from "@/lib/embeds";
+import { Embeds, type PreviewPrefs } from "@/lib/embeds";
 import { track } from "@/lib/track";
 import { CommentsSection } from "@/components/comments-section";
 
@@ -35,6 +35,7 @@ interface TimelineEntry {
   attachmentMimeType?: string;
   hasAttachment?: boolean;
   fileId?: string;
+  previewPrefs?: PreviewPrefs | null;
   author?: { id: string; name: string };
   commentCount?: number;
   // Activity fields
@@ -161,6 +162,22 @@ export function UpdatesSection({
       URL.revokeObjectURL(url);
     } catch (err) {
       showError(err instanceof Error ? err.message : "Failed to download file");
+    }
+  };
+
+  const handlePrefsChange = async (updateId: string, next: PreviewPrefs) => {
+    // Optimistic update — server errors are silent (prefs are a display hint).
+    setTimeline((prev) =>
+      prev.map((e) => (e.id === updateId ? { ...e, previewPrefs: next } : e)),
+    );
+    try {
+      await apiFetch(`/updates/${updateId}/preview-prefs`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ previewPrefs: next }),
+      });
+    } catch (err) {
+      console.error("Failed to save preview prefs", err);
     }
   };
 
@@ -339,7 +356,11 @@ export function UpdatesSection({
                 )}
               </div>
               <p className="text-sm whitespace-pre-wrap">{linkify(entry.content || "")}</p>
-              <Embeds text={entry.content || ""} />
+              <Embeds
+                text={entry.content || ""}
+                prefs={entry.previewPrefs ?? undefined}
+                onPrefsChange={(next) => handlePrefsChange(entry.id, next)}
+              />
               {entry.hasAttachment && isImage && (
                 <img
                   src={attachmentSrc}

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/updates-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/updates-section.tsx
@@ -386,6 +386,7 @@ export function UpdatesSection({
           return (
             <div
               key={entry.id}
+              data-testid={`update-entry-${entry.id}`}
               className="border border-[var(--border)] rounded-lg p-4"
             >
               <div className="flex items-center justify-between mb-2">
@@ -395,7 +396,10 @@ export function UpdatesSection({
                     {formatRelativeTime(entry.createdAt)}
                   </span>
                   {showEdited && (
-                    <span className="text-xs text-[var(--muted-foreground)] italic">
+                    <span
+                      data-testid="update-edited-indicator"
+                      className="text-xs text-[var(--muted-foreground)] italic"
+                    >
                       (edited)
                     </span>
                   )}
@@ -405,6 +409,8 @@ export function UpdatesSection({
                     {canEdit && (
                       <button
                         onClick={() => startEdit(entry)}
+                        aria-label="Edit update"
+                        data-testid={`edit-update-${entry.id}`}
                         className="flex items-center gap-1 px-2 py-1 text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:underline"
                       >
                         <Pencil size={12} />
@@ -429,6 +435,7 @@ export function UpdatesSection({
                     maxLength={5000}
                     rows={4}
                     autoFocus
+                    data-testid={`edit-update-textarea-${entry.id}`}
                     className="w-full px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm resize-none outline-none focus:ring-1 focus:ring-[var(--primary)]"
                   />
                   <div className="flex justify-end gap-2">
@@ -441,6 +448,7 @@ export function UpdatesSection({
                     <button
                       onClick={() => saveEdit(entry.id)}
                       disabled={editSaving || !editDraft.trim()}
+                      data-testid={`save-update-${entry.id}`}
                       className="px-3 py-1 bg-[var(--primary)] text-white rounded-lg text-xs hover:opacity-90 disabled:opacity-50"
                     >
                       {editSaving ? "Saving..." : "Save"}

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/updates-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/updates-section.tsx
@@ -18,7 +18,7 @@ import {
   Lock,
 } from "lucide-react";
 import { linkify } from "@/lib/linkify";
-import { getEmbeds, EmbedPreview } from "@/lib/embeds";
+import { Embeds } from "@/lib/embeds";
 import { track } from "@/lib/track";
 import { CommentsSection } from "@/components/comments-section";
 
@@ -339,9 +339,7 @@ export function UpdatesSection({
                 )}
               </div>
               <p className="text-sm whitespace-pre-wrap">{linkify(entry.content || "")}</p>
-              {getEmbeds(entry.content || "").map((embed) => (
-                <EmbedPreview key={embed.embedUrl} embed={embed} />
-              ))}
+              <Embeds text={entry.content || ""} />
               {entry.hasAttachment && isImage && (
                 <img
                   src={attachmentSrc}

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/page.tsx
@@ -22,8 +22,11 @@ import { NotesSection } from "./components/notes-section";
 interface FileRecord {
   id: string;
   filename: string;
-  mimeType: string;
-  sizeBytes: number;
+  type?: "UPLOAD" | "LINK";
+  mimeType?: string | null;
+  sizeBytes?: number | null;
+  url?: string | null;
+  description?: string | null;
   createdAt: string;
 }
 

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/page.tsx
@@ -504,13 +504,15 @@ export default function ProjectDetailPage() {
         <div className="flex items-start justify-between gap-2">
           <h1 className="text-lg font-bold leading-tight">{project.name}</h1>
           <div className="shrink-0 flex items-center gap-1.5">
-            <button
-              onClick={openDuplicateModal}
-              className="flex items-center gap-1.5 px-2.5 py-1 border border-[var(--border)] rounded-lg text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)] transition-colors"
-            >
-              <Copy size={13} />
-              Duplicate
-            </button>
+            {(currentRole === "owner" || currentRole === "admin") && (
+              <button
+                onClick={openDuplicateModal}
+                className="flex items-center gap-1.5 px-2.5 py-1 border border-[var(--border)] rounded-lg text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)] transition-colors"
+              >
+                <Copy size={13} />
+                Duplicate
+              </button>
+            )}
             {isArchived ? (
               <button
                 onClick={handleUnarchive}
@@ -608,6 +610,7 @@ export default function ProjectDetailPage() {
                   value={duplicateName}
                   onChange={(e) => setDuplicateName(e.target.value)}
                   autoFocus
+                  maxLength={255}
                   className="w-full bg-transparent border border-[var(--border)] rounded px-2 py-1.5 text-sm"
                 />
               </label>

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/page.tsx
@@ -438,6 +438,7 @@ export default function ProjectDetailPage() {
         {tabs.map((tab) => (
           <button
             key={tab.id}
+            data-testid={`project-tab-${tab.id}`}
             onClick={() => setActiveTab(tab.id)}
             className={`px-3 sm:px-4 py-2.5 text-sm font-medium whitespace-nowrap transition-colors relative after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:rounded-full ${
               activeTab === tab.id

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/page.tsx
@@ -7,7 +7,7 @@ import { useConfirm } from "@/components/confirm-modal";
 import { useToast } from "@/components/toast";
 import { ProjectDetailSkeleton } from "@/components/skeletons";
 import { useRouter } from "next/navigation";
-import { Archive, ArchiveRestore, Trash2, Calendar, ChevronDown, Tag } from "lucide-react";
+import { Archive, ArchiveRestore, Trash2, Calendar, ChevronDown, Tag, Copy } from "lucide-react";
 import { track } from "@/lib/track";
 import { LabelBadge } from "@/components/label-badge";
 import { LabelPicker } from "@/components/label-picker";
@@ -152,6 +152,11 @@ export default function ProjectDetailPage() {
   const [currentRole, setCurrentRole] = useState<string | null>(null);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [orgLabels, setOrgLabels] = useState<LabelRecord[]>([]);
+  const [duplicateOpen, setDuplicateOpen] = useState(false);
+  const [duplicateName, setDuplicateName] = useState("");
+  const [duplicateIncludeTasks, setDuplicateIncludeTasks] = useState(true);
+  const [duplicateIncludeClients, setDuplicateIncludeClients] = useState(false);
+  const [duplicating, setDuplicating] = useState(false);
   const isArchived = !!project?.archivedAt;
   const isOwner = currentRole === "owner";
 
@@ -276,6 +281,39 @@ export default function ProjectDetailPage() {
       success("Project unarchived");
     } catch (err) {
       showError(err instanceof Error ? err.message : "Failed to unarchive project");
+    }
+  };
+
+  const openDuplicateModal = () => {
+    setDuplicateName(project ? `${project.name} (copy)` : "");
+    setDuplicateIncludeTasks(true);
+    setDuplicateIncludeClients(false);
+    setDuplicateOpen(true);
+  };
+
+  const handleDuplicate = async () => {
+    const name = duplicateName.trim();
+    if (!name) {
+      showError("Name is required");
+      return;
+    }
+    setDuplicating(true);
+    try {
+      const created = await apiFetch<{ id: string }>(`/projects/${id}/duplicate`, {
+        method: "POST",
+        body: JSON.stringify({
+          name,
+          includeTasks: duplicateIncludeTasks,
+          includeClients: duplicateIncludeClients,
+        }),
+      });
+      success("Project duplicated");
+      setDuplicateOpen(false);
+      router.push(`/dashboard/projects/${created.id}`);
+    } catch (err) {
+      showError(err instanceof Error ? err.message : "Failed to duplicate project");
+    } finally {
+      setDuplicating(false);
     }
   };
 
@@ -465,23 +503,32 @@ export default function ProjectDetailPage() {
 
         <div className="flex items-start justify-between gap-2">
           <h1 className="text-lg font-bold leading-tight">{project.name}</h1>
-          {isArchived ? (
+          <div className="shrink-0 flex items-center gap-1.5">
             <button
-              onClick={handleUnarchive}
-              className="shrink-0 flex items-center gap-1.5 px-2.5 py-1 border border-[var(--border)] rounded-lg text-xs hover:bg-[var(--muted)] transition-colors"
+              onClick={openDuplicateModal}
+              className="flex items-center gap-1.5 px-2.5 py-1 border border-[var(--border)] rounded-lg text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)] transition-colors"
             >
-              <ArchiveRestore size={13} />
-              Unarchive
+              <Copy size={13} />
+              Duplicate
             </button>
-          ) : (
-            <button
-              onClick={handleArchive}
-              className="shrink-0 flex items-center gap-1.5 px-2.5 py-1 border border-[var(--border)] rounded-lg text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)] transition-colors"
-            >
-              <Archive size={13} />
-              Archive
-            </button>
-          )}
+            {isArchived ? (
+              <button
+                onClick={handleUnarchive}
+                className="flex items-center gap-1.5 px-2.5 py-1 border border-[var(--border)] rounded-lg text-xs hover:bg-[var(--muted)] transition-colors"
+              >
+                <ArchiveRestore size={13} />
+                Unarchive
+              </button>
+            ) : (
+              <button
+                onClick={handleArchive}
+                className="flex items-center gap-1.5 px-2.5 py-1 border border-[var(--border)] rounded-lg text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)] transition-colors"
+              >
+                <Archive size={13} />
+                Archive
+              </button>
+            )}
+          </div>
         </div>
         {project.description && (
           <p className="text-xs text-[var(--muted-foreground)] leading-relaxed -mt-1">
@@ -545,6 +592,64 @@ export default function ProjectDetailPage() {
         {tabBar}
         {tabContent}
       </div>
+
+      {duplicateOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={(e) => { if (e.target === e.currentTarget) setDuplicateOpen(false); }}
+        >
+          <div className="bg-[var(--background)] rounded-xl shadow-lg w-full max-w-[480px] mx-4 p-6 space-y-4">
+            <h3 className="text-lg font-semibold">Duplicate Project</h3>
+            <div className="space-y-3">
+              <label className="block text-sm">
+                <span className="block mb-1 text-[var(--muted-foreground)]">Name</span>
+                <input
+                  type="text"
+                  value={duplicateName}
+                  onChange={(e) => setDuplicateName(e.target.value)}
+                  autoFocus
+                  className="w-full bg-transparent border border-[var(--border)] rounded px-2 py-1.5 text-sm"
+                />
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={duplicateIncludeTasks}
+                  onChange={(e) => setDuplicateIncludeTasks(e.target.checked)}
+                />
+                Include tasks
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={duplicateIncludeClients}
+                  onChange={(e) => setDuplicateIncludeClients(e.target.checked)}
+                />
+                Include client assignments
+              </label>
+              <p className="text-xs text-[var(--muted-foreground)]">
+                Files, updates, invoices, and notes are not copied.
+              </p>
+            </div>
+            <div className="flex items-center justify-end gap-2 pt-2">
+              <button
+                onClick={() => setDuplicateOpen(false)}
+                disabled={duplicating}
+                className="px-3 py-1.5 text-sm border border-[var(--border)] rounded-lg hover:bg-[var(--muted)] transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDuplicate}
+                disabled={duplicating || !duplicateName.trim()}
+                className="px-3 py-1.5 text-sm bg-[var(--foreground)] text-[var(--background)] rounded-lg hover:opacity-90 transition-opacity disabled:opacity-50"
+              >
+                {duplicating ? "Duplicating…" : "Duplicate"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/page.tsx
@@ -150,6 +150,7 @@ export default function ProjectDetailPage() {
     if (searchParams.get("task")) setActiveTab("tasks");
   }, [searchParams]);
   const [currentRole, setCurrentRole] = useState<string | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [orgLabels, setOrgLabels] = useState<LabelRecord[]>([]);
   const isArchived = !!project?.archivedAt;
   const isOwner = currentRole === "owner";
@@ -173,6 +174,9 @@ export default function ProjectDetailPage() {
       .catch(console.error);
     apiFetch<{ role: string }>("/auth/organization/get-active-member")
       .then((member) => setCurrentRole(member.role))
+      .catch(console.error);
+    apiFetch<{ user: { id: string } }>("/auth/get-session")
+      .then((s) => setCurrentUserId(s.user.id))
       .catch(console.error);
     apiFetch<LabelRecord[]>("/labels")
       .then(setOrgLabels)
@@ -417,7 +421,13 @@ export default function ProjectDetailPage() {
         <TasksSection projectId={id} isArchived={isArchived} />
       )}
       {activeTab === "updates" && (
-        <UpdatesSection projectId={id} isArchived={isArchived} onFileChange={loadProject} />
+        <UpdatesSection
+          projectId={id}
+          isArchived={isArchived}
+          onFileChange={loadProject}
+          currentUserId={currentUserId}
+          currentRole={currentRole}
+        />
       )}
       {activeTab === "files" && (
         <FilesSection
@@ -426,6 +436,7 @@ export default function ProjectDetailPage() {
           files={project.files}
           onFileChange={loadProject}
           projectClients={clients.filter((c) => assignedIds.has(c.userId))}
+          currentRole={currentRole}
         />
       )}
       {activeTab === "invoices" && (

--- a/apps/web/src/app/(portal)/portal/projects/[id]/page.tsx
+++ b/apps/web/src/app/(portal)/portal/projects/[id]/page.tsx
@@ -25,10 +25,12 @@ import {
   Clock,
   Plus,
   Paperclip,
+  ExternalLink,
+  Link as LinkIcon,
 } from "lucide-react";
 import { PortalInvoicesSection } from "./components/portal-invoices-section";
 import { linkify } from "@/lib/linkify";
-import { getEmbeds, EmbedPreview } from "@/lib/embeds";
+import { Embeds } from "@/lib/embeds";
 import { downloadFile } from "@/lib/download";
 import { SigningViewer } from "@/components/signing-viewer";
 import { DocumentViewer } from "@/components/document-viewer";
@@ -41,8 +43,11 @@ import { getTaskStatusBadge, getTaskStatusLabel } from "@/lib/task-status";
 interface FileRecord {
   id: string;
   filename: string;
-  mimeType: string;
-  sizeBytes: number;
+  type?: "UPLOAD" | "LINK";
+  mimeType?: string | null;
+  sizeBytes?: number | null;
+  url?: string | null;
+  description?: string | null;
   createdAt: string;
 }
 
@@ -750,9 +755,7 @@ export default function PortalProjectDetailPage() {
                       </span>
                     </div>
                     <p className="text-sm whitespace-pre-wrap">{linkify(entry.content || "")}</p>
-                    {getEmbeds(entry.content || "").map((embed) => (
-                      <EmbedPreview key={embed.embedUrl} embed={embed} />
-                    ))}
+                    <Embeds text={entry.content || ""} />
                     {entry.hasAttachment && isImage && (
                       <img
                         src={attachmentSrc}
@@ -1037,30 +1040,67 @@ export default function PortalProjectDetailPage() {
                 </label>
               </div>
               <div className="space-y-2">
-                {sortedFiles.map((file) => (
-                  <div
-                    key={file.id}
-                    className="p-3 border border-[var(--border)] rounded-lg"
-                  >
-                    <div className="flex items-start justify-between gap-2 flex-wrap sm:flex-nowrap">
-                      <div className="min-w-0">
-                        <p className="text-sm font-medium truncate">
-                          {file.filename}
-                        </p>
-                        <p className="text-xs text-[var(--muted-foreground)]">
-                          {formatBytes(file.sizeBytes)}
-                        </p>
+                {sortedFiles.map((file) => {
+                  const isLink = file.type === "LINK";
+                  let hostname = "";
+                  if (isLink && file.url) {
+                    try { hostname = new URL(file.url).hostname; } catch { hostname = file.url; }
+                  }
+                  const handleCardClick = () => {
+                    if (isLink && file.url) {
+                      window.open(file.url, "_blank", "noopener,noreferrer");
+                    } else {
+                      handleDownload(file.id, file.filename);
+                    }
+                  };
+                  return (
+                    <div
+                      key={file.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={handleCardClick}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          handleCardClick();
+                        }
+                      }}
+                      className="p-3 border border-[var(--border)] rounded-lg cursor-pointer hover:bg-[var(--muted)]/40 transition-colors focus:outline-none focus:ring-1 focus:ring-[var(--primary)]"
+                    >
+                      <div className="flex items-start justify-between gap-2 flex-wrap sm:flex-nowrap">
+                        <div className="min-w-0 flex items-start gap-2">
+                          {isLink ? (
+                            <LinkIcon size={14} className="mt-0.5 shrink-0 text-[var(--muted-foreground)]" />
+                          ) : (
+                            <FileText size={14} className="mt-0.5 shrink-0 text-[var(--muted-foreground)]" />
+                          )}
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium truncate">
+                              {file.filename}
+                            </p>
+                            {isLink ? (
+                              <p className="text-xs text-[var(--muted-foreground)] truncate">
+                                {hostname}
+                              </p>
+                            ) : (
+                              <p className="text-xs text-[var(--muted-foreground)]">
+                                {formatBytes(file.sizeBytes ?? 0)}
+                              </p>
+                            )}
+                            {isLink && file.description && (
+                              <p className="text-xs text-[var(--muted-foreground)] mt-1">{file.description}</p>
+                            )}
+                          </div>
+                        </div>
+                        {isLink ? (
+                          <ExternalLink size={14} className="text-[var(--muted-foreground)] shrink-0" />
+                        ) : (
+                          <Download size={14} className="text-[var(--muted-foreground)] shrink-0" />
+                        )}
                       </div>
-                      <button
-                        onClick={() => handleDownload(file.id, file.filename)}
-                        className="flex items-center gap-1.5 text-sm text-[var(--primary)] hover:underline shrink-0"
-                      >
-                        <Download size={14} />
-                        Download
-                      </button>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
                 {project.files.length === 0 && documents.length === 0 && (
                   <div className="text-center py-8">
                     <FileX size={32} className="mx-auto text-[var(--muted-foreground)] mb-2" />

--- a/apps/web/src/app/(portal)/portal/projects/[id]/page.tsx
+++ b/apps/web/src/app/(portal)/portal/projects/[id]/page.tsx
@@ -30,7 +30,7 @@ import {
 } from "lucide-react";
 import { PortalInvoicesSection } from "./components/portal-invoices-section";
 import { linkify } from "@/lib/linkify";
-import { Embeds } from "@/lib/embeds";
+import { Embeds, type PreviewPrefs } from "@/lib/embeds";
 import { downloadFile } from "@/lib/download";
 import { SigningViewer } from "@/components/signing-viewer";
 import { DocumentViewer } from "@/components/document-viewer";
@@ -72,6 +72,7 @@ interface TimelineEntry {
   attachmentMimeType?: string;
   hasAttachment?: boolean;
   fileId?: string;
+  previewPrefs?: PreviewPrefs | null;
   author?: { id: string; name: string };
   commentCount?: number;
   // Activity fields
@@ -271,6 +272,22 @@ export default function PortalProjectDetailPage() {
       })
       .catch(console.error);
   }, [id, updatesPage]);
+
+  const handlePrefsChange = async (updateId: string, next: PreviewPrefs) => {
+    // Optimistic — prefs are display state, tolerate PATCH failures silently.
+    setUpdates((prev) =>
+      prev.map((e) => (e.id === updateId ? { ...e, previewPrefs: next } : e)),
+    );
+    try {
+      await apiFetch(`/updates/${updateId}/preview-prefs`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ previewPrefs: next }),
+      });
+    } catch (err) {
+      console.error("Failed to save preview prefs", err);
+    }
+  };
 
   const loadTasks = useCallback(() => {
     apiFetch<PaginatedResponse<TaskRecord>>(
@@ -755,7 +772,11 @@ export default function PortalProjectDetailPage() {
                       </span>
                     </div>
                     <p className="text-sm whitespace-pre-wrap">{linkify(entry.content || "")}</p>
-                    <Embeds text={entry.content || ""} />
+                    <Embeds
+                      text={entry.content || ""}
+                      prefs={entry.previewPrefs ?? undefined}
+                      onPrefsChange={(next) => handlePrefsChange(entry.id, next)}
+                    />
                     {entry.hasAttachment && isImage && (
                       <img
                         src={attachmentSrc}

--- a/apps/web/src/app/(portal)/portal/projects/[id]/page.tsx
+++ b/apps/web/src/app/(portal)/portal/projects/[id]/page.tsx
@@ -27,6 +27,7 @@ import {
   Paperclip,
   ExternalLink,
   Link as LinkIcon,
+  Pencil,
 } from "lucide-react";
 import { PortalInvoicesSection } from "./components/portal-invoices-section";
 import { linkify } from "@/lib/linkify";
@@ -65,6 +66,7 @@ interface TimelineEntry {
   id: string;
   kind: "update" | "activity";
   createdAt: string;
+  updatedAt?: string;
   // Update fields
   content?: string;
   attachmentUrl?: string;
@@ -229,6 +231,9 @@ export default function PortalProjectDetailPage() {
   const [sessionLoaded, setSessionLoaded] = useState(false);
   const [showCompletedTasks, setShowCompletedTasks] = useState(false);
   const [openTaskId, setOpenTaskId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<string>("");
+  const [savingEdit, setSavingEdit] = useState<boolean>(false);
 
   // Deep-link sync for task modal
   useEffect(() => {
@@ -335,6 +340,37 @@ export default function PortalProjectDetailPage() {
       toast.error(err instanceof Error ? err.message : "Failed to post update");
     } finally {
       setPostingUpdate(false);
+    }
+  };
+
+  const handleStartEdit = (entry: TimelineEntry): void => {
+    setEditingId(entry.id);
+    setEditDraft(entry.content || "");
+  };
+
+  const handleCancelEdit = (): void => {
+    setEditingId(null);
+    setEditDraft("");
+  };
+
+  const handleSaveEdit = async (updateId: string): Promise<void> => {
+    const content = editDraft.trim();
+    if (!content) return;
+    setSavingEdit(true);
+    try {
+      await apiFetch(`/updates/${updateId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content }),
+      });
+      toast.success("Update edited");
+      setEditingId(null);
+      setEditDraft("");
+      loadUpdates();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to edit update");
+    } finally {
+      setSavingEdit(false);
     }
   };
 
@@ -760,23 +796,90 @@ export default function PortalProjectDetailPage() {
                 const attachmentSrc = entry.fileId
                   ? `${API_URL}/api/files/${entry.fileId}/download`
                   : entry.attachmentUrl || `${API_URL}/api/updates/${entry.id}/attachment`;
+                const isOwnUpdate =
+                  sessionLoaded &&
+                  currentUserId !== null &&
+                  entry.author?.id === currentUserId;
+                const isEditing = editingId === entry.id;
+                const wasEdited =
+                  !!entry.updatedAt &&
+                  new Date(entry.updatedAt).getTime() -
+                    new Date(entry.createdAt).getTime() >
+                    2 * 60 * 1000;
                 return (
                   <div
                     key={entry.id}
                     className="border border-[var(--border)] rounded-lg p-4"
                   >
-                    <div className="flex items-center gap-2 mb-2">
-                      <span className="text-sm font-medium">{entry.author?.name}</span>
-                      <span className="text-xs text-[var(--muted-foreground)]">
-                        {formatRelativeTime(entry.createdAt)}
-                      </span>
+                    <div className="flex items-center justify-between mb-2 gap-2">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="text-sm font-medium">{entry.author?.name}</span>
+                        <span className="text-xs text-[var(--muted-foreground)]">
+                          {formatRelativeTime(entry.createdAt)}
+                        </span>
+                        {wasEdited && (
+                          <span
+                            data-testid="update-edited-indicator"
+                            className="text-xs text-[var(--muted-foreground)] italic"
+                          >
+                            (edited)
+                          </span>
+                        )}
+                      </div>
+                      {isOwnUpdate && !isEditing && (
+                        <button
+                          type="button"
+                          onClick={() => handleStartEdit(entry)}
+                          aria-label="Edit update"
+                          data-testid={`edit-update-${entry.id}`}
+                          className="flex items-center gap-1 px-2 py-1 text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                        >
+                          <Pencil size={12} />
+                          Edit
+                        </button>
+                      )}
                     </div>
-                    <p className="text-sm whitespace-pre-wrap">{linkify(entry.content || "")}</p>
-                    <Embeds
-                      text={entry.content || ""}
-                      prefs={entry.previewPrefs ?? undefined}
-                      onPrefsChange={(next) => handlePrefsChange(entry.id, next)}
-                    />
+                    {isEditing ? (
+                      <div className="space-y-2">
+                        <textarea
+                          value={editDraft}
+                          onChange={(e) => setEditDraft(e.target.value)}
+                          maxLength={5000}
+                          rows={4}
+                          autoFocus
+                          data-testid={`edit-update-textarea-${entry.id}`}
+                          className="w-full px-3 py-2 border border-[var(--border)] rounded-lg bg-[var(--background)] text-sm resize-none outline-none focus:ring-1 focus:ring-[var(--primary)]"
+                        />
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={handleCancelEdit}
+                            disabled={savingEdit}
+                            className="px-3 py-1 border border-[var(--border)] rounded-lg text-xs hover:bg-[var(--muted)] transition-colors disabled:opacity-50"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleSaveEdit(entry.id)}
+                            disabled={savingEdit || !editDraft.trim()}
+                            data-testid={`save-update-${entry.id}`}
+                            className="px-3 py-1 bg-[var(--primary)] text-white rounded-lg text-xs hover:opacity-90 disabled:opacity-50"
+                          >
+                            {savingEdit ? "Saving..." : "Save"}
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <>
+                        <p className="text-sm whitespace-pre-wrap">{linkify(entry.content || "")}</p>
+                        <Embeds
+                          text={entry.content || ""}
+                          prefs={entry.previewPrefs ?? undefined}
+                          onPrefsChange={(next) => handlePrefsChange(entry.id, next)}
+                        />
+                      </>
+                    )}
                     {entry.hasAttachment && isImage && (
                       <img
                         src={attachmentSrc}

--- a/apps/web/src/lib/embeds.test.ts
+++ b/apps/web/src/lib/embeds.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { getEmbeds } from "./embeds";
+import { getEmbeds, extractOEmbedCandidates } from "./embeds";
 
 // ---------------------------------------------------------------------------
 // YouTube
@@ -348,5 +348,64 @@ describe("getEmbeds — stateless across multiple calls", () => {
     const third = getEmbeds(text);
 
     expect(third).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractOEmbedCandidates
+// ---------------------------------------------------------------------------
+
+describe("extractOEmbedCandidates", () => {
+  test("returns external URLs not handled by regex providers", () => {
+    const text =
+      "Check the Canva design: https://www.canva.com/design/DAF123/View";
+    const urls = extractOEmbedCandidates(text);
+
+    expect(urls).toEqual(["https://www.canva.com/design/DAF123/View"]);
+  });
+
+  test("skips URLs already covered by a regex provider (YouTube, Loom, Figma, GDocs)", () => {
+    const text = [
+      "https://www.youtube.com/watch?v=abc12345678",
+      "https://www.loom.com/share/abc123",
+      "https://www.figma.com/file/XYZ/Design",
+      "https://docs.google.com/document/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
+      "https://open.spotify.com/track/abc",
+    ].join(" ");
+
+    const urls = extractOEmbedCandidates(text);
+
+    expect(urls).toEqual(["https://open.spotify.com/track/abc"]);
+  });
+
+  test("strips trailing punctuation from detected URLs", () => {
+    const text = "See (https://codepen.io/anon/pen/abc), it's cool.";
+    const urls = extractOEmbedCandidates(text);
+
+    expect(urls).toContain("https://codepen.io/anon/pen/abc");
+  });
+
+  test("deduplicates identical URLs", () => {
+    const url = "https://codepen.io/anon/pen/abc";
+    const urls = extractOEmbedCandidates(`${url} and again ${url}`);
+
+    expect(urls).toHaveLength(1);
+  });
+
+  test("caps the number of candidates at MAX_EMBEDS (3)", () => {
+    const urls = extractOEmbedCandidates(
+      [
+        "https://codepen.io/a/pen/1",
+        "https://codepen.io/a/pen/2",
+        "https://codepen.io/a/pen/3",
+        "https://codepen.io/a/pen/4",
+      ].join(" "),
+    );
+
+    expect(urls).toHaveLength(3);
+  });
+
+  test("returns an empty array for plain text without URLs", () => {
+    expect(extractOEmbedCandidates("just some words")).toEqual([]);
   });
 });

--- a/apps/web/src/lib/embeds.test.ts
+++ b/apps/web/src/lib/embeds.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from "bun:test";
-import { getEmbeds, extractOEmbedCandidates } from "./embeds";
+import {
+  getEmbeds,
+  extractOEmbedCandidates,
+  applyPrefPatch,
+  nextSize,
+  type PreviewPrefs,
+} from "./embeds";
 
 // ---------------------------------------------------------------------------
 // YouTube
@@ -354,6 +360,58 @@ describe("getEmbeds — stateless across multiple calls", () => {
 // ---------------------------------------------------------------------------
 // extractOEmbedCandidates
 // ---------------------------------------------------------------------------
+
+describe("applyPrefPatch", () => {
+  test("creates an entry for a URL not yet in prefs", () => {
+    const prefs: PreviewPrefs = {};
+    const next = applyPrefPatch(prefs, "https://x.com/", { size: "compact" });
+    expect(next["https://x.com/"]).toEqual({ size: "compact" });
+  });
+
+  test("merges fields with an existing entry instead of replacing", () => {
+    const prefs: PreviewPrefs = { "https://x.com/": { size: "full" } };
+    const next = applyPrefPatch(prefs, "https://x.com/", { hidden: true });
+    expect(next["https://x.com/"]).toEqual({ size: "full", hidden: true });
+  });
+
+  test("overwrites a key when the patch supplies the same field", () => {
+    const prefs: PreviewPrefs = { "https://x.com/": { size: "full" } };
+    const next = applyPrefPatch(prefs, "https://x.com/", { size: "compact" });
+    expect(next["https://x.com/"].size).toBe("compact");
+  });
+
+  test("does not mutate the input prefs object", () => {
+    const prefs: PreviewPrefs = { "https://x.com/": { size: "full" } };
+    applyPrefPatch(prefs, "https://x.com/", { hidden: true });
+    expect(prefs["https://x.com/"]).toEqual({ size: "full" });
+  });
+
+  test("does not mutate the per-URL entry object", () => {
+    const entry = { size: "full" as const };
+    const prefs: PreviewPrefs = { "https://x.com/": entry };
+    applyPrefPatch(prefs, "https://x.com/", { hidden: true });
+    expect(entry).toEqual({ size: "full" });
+  });
+
+  test("preserves other URLs unchanged", () => {
+    const prefs: PreviewPrefs = {
+      "https://a.com/": { size: "full" },
+      "https://b.com/": { hidden: true },
+    };
+    const next = applyPrefPatch(prefs, "https://a.com/", { hidden: true });
+    expect(next["https://b.com/"]).toBe(prefs["https://b.com/"]);
+  });
+});
+
+describe("nextSize", () => {
+  test("full → compact", () => {
+    expect(nextSize("full")).toBe("compact");
+  });
+
+  test("compact → full", () => {
+    expect(nextSize("compact")).toBe("full");
+  });
+});
 
 describe("extractOEmbedCandidates", () => {
   test("returns external URLs not handled by regex providers", () => {

--- a/apps/web/src/lib/embeds.tsx
+++ b/apps/web/src/lib/embeds.tsx
@@ -29,6 +29,25 @@ export interface PreviewPref {
 
 export type PreviewPrefs = Record<string, PreviewPref>;
 
+/**
+ * Merge a pref patch for `url` into `prefs`. Pure; returns a new object so
+ * React can detect the change. Extracted for unit-testability.
+ */
+export function applyPrefPatch(
+  prefs: PreviewPrefs,
+  url: string,
+  patch: PreviewPref,
+): PreviewPrefs {
+  return { ...prefs, [url]: { ...(prefs[url] || {}), ...patch } };
+}
+
+/**
+ * Toggle between compact and full preview sizes.
+ */
+export function nextSize(current: PreviewSize): PreviewSize {
+  return current === "full" ? "compact" : "full";
+}
+
 const PROVIDER_LABELS: Record<EmbedProvider, string> = {
   youtube: "YouTube",
   loom: "Loom",
@@ -495,12 +514,11 @@ export function Embeds({ text, prefs = {}, onPrefsChange }: EmbedsProps) {
   const [oembedFailed, setOembedFailed] = useState<Record<string, boolean>>({});
 
   const mutatePref = (url: string, patch: PreviewPref) => {
-    const next: PreviewPrefs = { ...prefs, [url]: { ...(prefs[url] || {}), ...patch } };
-    onPrefsChange?.(next);
+    onPrefsChange?.(applyPrefPatch(prefs, url, patch));
   };
 
   const toggleSize = (url: string, current: PreviewSize) => {
-    mutatePref(url, { size: current === "full" ? "compact" : "full" });
+    mutatePref(url, { size: nextSize(current) });
   };
 
   const hide = (url: string) => {

--- a/apps/web/src/lib/embeds.tsx
+++ b/apps/web/src/lib/embeds.tsx
@@ -1,9 +1,16 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ChevronDown, ChevronUp, X, ExternalLink } from "lucide-react";
+
 const MAX_EMBEDS = 3;
 
 const YT_RE = /https?:\/\/(?:www\.)?(?:youtube\.com\/watch\?(?:.*&)?v=|youtu\.be\/)([\w-]+)/g;
 const LOOM_RE = /https?:\/\/(?:www\.)?loom\.com\/share\/([\w-]+)/g;
 const FIGMA_RE = /https?:\/\/(?:www\.)?figma\.com\/(?:file|design)\/([\w-]+[^\s]*)/g;
 const GDOCS_RE = /https?:\/\/docs\.google\.com\/(document|spreadsheets|presentation)\/d\/([\w-]+)/g;
+
+const URL_RE = /https?:\/\/[^\s<>"']+/g;
 
 export type EmbedProvider = "youtube" | "loom" | "figma" | "google-docs";
 
@@ -13,12 +20,25 @@ export interface EmbedInfo {
   provider: EmbedProvider;
 }
 
+export type PreviewSize = "compact" | "full";
+
+export interface PreviewPref {
+  size?: PreviewSize;
+  hidden?: boolean;
+}
+
+export type PreviewPrefs = Record<string, PreviewPref>;
+
 const PROVIDER_LABELS: Record<EmbedProvider, string> = {
   youtube: "YouTube",
   loom: "Loom",
   figma: "Figma",
   "google-docs": "Google Docs",
 };
+
+// ---------------------------------------------------------------------------
+// Regex fast-path detection (zero network).
+// ---------------------------------------------------------------------------
 
 export function getEmbeds(text: string): EmbedInfo[] {
   const found: EmbedInfo[] = [];
@@ -55,33 +75,490 @@ export function getEmbeds(text: string): EmbedInfo[] {
   return found.slice(0, MAX_EMBEDS);
 }
 
-export function EmbedPreview({ embed }: { embed: EmbedInfo }) {
+const REGEX_PROVIDER_HOSTS = [
+  "youtube.com",
+  "youtu.be",
+  "loom.com",
+  "figma.com",
+  "docs.google.com",
+];
+
+function hostnameOf(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
+function isRegexProviderHost(host: string): boolean {
+  return REGEX_PROVIDER_HOSTS.some((h) => host === h || host.endsWith(`.${h}`));
+}
+
+export function extractOEmbedCandidates(text: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  URL_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = URL_RE.exec(text)) !== null) {
+    const url = m[0].replace(/[.,;:!?)\]]+$/, "");
+    if (seen.has(url)) continue;
+    const host = hostnameOf(url);
+    if (!host || isRegexProviderHost(host)) continue;
+    seen.add(url);
+    out.push(url);
+    if (out.length >= MAX_EMBEDS) break;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Shared controls + card chrome
+// ---------------------------------------------------------------------------
+
+interface PreviewControlsProps {
+  size: PreviewSize;
+  onToggleSize: () => void;
+  onHide: () => void;
+}
+
+function PreviewControls({ size, onToggleSize, onHide }: PreviewControlsProps) {
+  const toggleLabel = size === "full" ? "Collapse preview" : "Expand preview";
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={onToggleSize}
+        aria-label={toggleLabel}
+        title={toggleLabel}
+        className="p-1 rounded hover:bg-[var(--background)]/60 text-[var(--muted-foreground)]"
+      >
+        {size === "full" ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+      </button>
+      <button
+        type="button"
+        onClick={onHide}
+        aria-label="Hide preview"
+        title="Hide preview"
+        className="p-1 rounded hover:bg-[var(--background)]/60 text-[var(--muted-foreground)]"
+      >
+        <X size={12} />
+      </button>
+    </div>
+  );
+}
+
+interface CardShellProps {
+  label: string;
+  size: PreviewSize;
+  onToggleSize: () => void;
+  onHide: () => void;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+function CardShell({ label, size, onToggleSize, onHide, children, footer }: CardShellProps) {
+  return (
+    <div className="mt-3 rounded-lg overflow-hidden border border-[var(--border)] max-w-xl">
+      <div className="px-3 py-1.5 bg-[var(--muted)] border-b border-[var(--border)] flex items-center justify-between gap-2">
+        <span className="text-xs font-medium text-[var(--muted-foreground)] truncate">
+          {label}
+        </span>
+        <PreviewControls size={size} onToggleSize={onToggleSize} onHide={onHide} />
+      </div>
+      {children}
+      {footer}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Regex-based embed (iframe)
+// ---------------------------------------------------------------------------
+
+export function EmbedPreview({
+  embed,
+  size,
+  onToggleSize,
+  onHide,
+}: {
+  embed: EmbedInfo;
+  size: PreviewSize;
+  onToggleSize: () => void;
+  onHide: () => void;
+}) {
   const label = PROVIDER_LABELS[embed.provider];
+  const footer = (
+    <div className="px-3 py-1.5 bg-[var(--muted)] border-t border-[var(--border)]">
+      <a
+        href={embed.originalUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs text-[var(--primary)] hover:underline inline-flex items-center gap-1"
+      >
+        Open in {label}
+        <ExternalLink size={10} />
+      </a>
+    </div>
+  );
 
   return (
-    <div className="mt-3 rounded-lg overflow-hidden border border-[var(--border)]">
-      <div className="px-3 py-1.5 bg-[var(--muted)] border-b border-[var(--border)]">
-        <span className="text-xs font-medium text-[var(--muted-foreground)]">{label}</span>
-      </div>
-      <div className="relative aspect-video">
-        <iframe
-          src={embed.embedUrl}
-          className="absolute inset-0 w-full h-full"
-          allowFullScreen
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          title={`${label} embed`}
-        />
-      </div>
-      <div className="px-3 py-1.5 bg-[var(--muted)] border-t border-[var(--border)]">
-        <a
-          href={embed.originalUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs text-[var(--primary)] hover:underline"
-        >
-          Open in {label}
-        </a>
-      </div>
+    <CardShell label={label} size={size} onToggleSize={onToggleSize} onHide={onHide} footer={footer}>
+      {size === "full" && (
+        <div className="relative aspect-video">
+          <iframe
+            src={embed.embedUrl}
+            className="absolute inset-0 w-full h-full"
+            allowFullScreen
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            title={`${label} embed`}
+          />
+        </div>
+      )}
+    </CardShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// oEmbed provider (iframe from server-side resolver)
+// ---------------------------------------------------------------------------
+
+interface OEmbedResult {
+  html: string;
+  width?: number;
+  height?: number;
+  providerName: string;
+  title?: string;
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+
+async function resolveOEmbed(url: string): Promise<OEmbedResult | null> {
+  try {
+    const res = await fetch(
+      `${API_URL}/api/embeds/resolve?url=${encodeURIComponent(url)}`,
+      { credentials: "include" },
+    );
+    if (!res.ok) return null;
+    return (await res.json()) as OEmbedResult;
+  } catch {
+    return null;
+  }
+}
+
+export function OEmbedPreview({
+  url,
+  size,
+  onToggleSize,
+  onHide,
+  onFail,
+}: {
+  url: string;
+  size: PreviewSize;
+  onToggleSize: () => void;
+  onHide: () => void;
+  /** Called when oEmbed resolution fails so the caller can fall back to unfurl. */
+  onFail?: () => void;
+}) {
+  const [state, setState] = useState<
+    { kind: "loading" } | { kind: "ready"; result: OEmbedResult } | { kind: "failed" }
+  >({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ kind: "loading" });
+    resolveOEmbed(url).then((result) => {
+      if (cancelled) return;
+      if (result) {
+        setState({ kind: "ready", result });
+      } else {
+        setState({ kind: "failed" });
+        onFail?.();
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+    // onFail is intentionally not a dep — callers memoize it only when they must.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url]);
+
+  if (state.kind === "loading") {
+    return (
+      <CardShell label="Loading embed…" size={size} onToggleSize={onToggleSize} onHide={onHide}>
+        <div className="relative aspect-video bg-[var(--muted)] animate-pulse" />
+      </CardShell>
+    );
+  }
+
+  if (state.kind === "failed") return null;
+
+  const { result } = state;
+  const footer = (
+    <div className="px-3 py-1.5 bg-[var(--muted)] border-t border-[var(--border)]">
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs text-[var(--primary)] hover:underline inline-flex items-center gap-1"
+      >
+        Open in {result.providerName}
+        <ExternalLink size={10} />
+      </a>
     </div>
+  );
+
+  return (
+    <CardShell
+      label={result.providerName}
+      size={size}
+      onToggleSize={onToggleSize}
+      onHide={onHide}
+      footer={footer}
+    >
+      {size === "full" && (
+        <div
+          className="oembed-content [&_iframe]:max-w-full [&_iframe]:w-full [&_iframe]:block"
+          // HTML is sanitized server-side to an iframe-only allowlist.
+          dangerouslySetInnerHTML={{ __html: result.html }}
+        />
+      )}
+    </CardShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Generic Open Graph unfurl card
+// ---------------------------------------------------------------------------
+
+interface UnfurlCard {
+  url: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+  favicon?: string;
+}
+
+async function fetchUnfurl(url: string): Promise<UnfurlCard | null> {
+  try {
+    const res = await fetch(
+      `${API_URL}/api/embeds/unfurl?url=${encodeURIComponent(url)}`,
+      { credentials: "include" },
+    );
+    if (!res.ok) return null;
+    return (await res.json()) as UnfurlCard;
+  } catch {
+    return null;
+  }
+}
+
+export function UnfurlPreview({
+  url,
+  size,
+  onToggleSize,
+  onHide,
+}: {
+  url: string;
+  size: PreviewSize;
+  onToggleSize: () => void;
+  onHide: () => void;
+}) {
+  const [state, setState] = useState<
+    { kind: "loading" } | { kind: "ready"; card: UnfurlCard } | { kind: "failed" }
+  >({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ kind: "loading" });
+    fetchUnfurl(url).then((card) => {
+      if (cancelled) return;
+      setState(card ? { kind: "ready", card } : { kind: "failed" });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  const host = hostnameOf(url) ?? url;
+
+  if (state.kind === "loading") {
+    return (
+      <CardShell label={host} size={size} onToggleSize={onToggleSize} onHide={onHide}>
+        <div className="p-3 animate-pulse">
+          <div className="h-3 w-1/2 bg-[var(--muted)] rounded mb-2" />
+          <div className="h-2 w-full bg-[var(--muted)] rounded" />
+        </div>
+      </CardShell>
+    );
+  }
+
+  if (state.kind === "failed") return null;
+
+  const { card } = state;
+  const label = card.siteName || host;
+
+  return (
+    <CardShell
+      label={label}
+      size={size}
+      onToggleSize={onToggleSize}
+      onHide={onHide}
+    >
+      <a
+        href={card.url || url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block hover:bg-[var(--muted)]/40 transition-colors"
+      >
+        {size === "compact" ? (
+          <div className="flex items-center gap-2 px-3 py-2">
+            {card.favicon && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={card.favicon}
+                alt=""
+                className="w-4 h-4 shrink-0"
+                loading="lazy"
+              />
+            )}
+            <span className="text-sm font-medium truncate">
+              {card.title || url}
+            </span>
+          </div>
+        ) : (
+          <div className="flex flex-col">
+            {card.image && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={card.image}
+                alt=""
+                className="w-full max-h-48 object-cover"
+                loading="lazy"
+              />
+            )}
+            <div className="p-3">
+              <div className="flex items-center gap-2 mb-1">
+                {card.favicon && (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={card.favicon} alt="" className="w-4 h-4 shrink-0" loading="lazy" />
+                )}
+                <span className="text-xs text-[var(--muted-foreground)] truncate">
+                  {host}
+                </span>
+              </div>
+              {card.title && (
+                <p className="text-sm font-medium line-clamp-2 mb-1">{card.title}</p>
+              )}
+              {card.description && (
+                <p className="text-xs text-[var(--muted-foreground)] line-clamp-2">
+                  {card.description}
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+      </a>
+    </CardShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+interface EmbedsProps {
+  text: string;
+  prefs?: PreviewPrefs;
+  onPrefsChange?: (next: PreviewPrefs) => void;
+}
+
+/**
+ * Renders the full set of previews for an update body:
+ * - regex providers (zero network)
+ * - oEmbed providers (server-resolved iframe)
+ * - generic OG unfurl card (server-resolved)
+ *
+ * Each preview supports a compact/full size toggle and a hide × button.
+ * Preference changes are bubbled via `onPrefsChange`; the caller is expected
+ * to persist them (see updates-section.tsx / portal page).
+ */
+export function Embeds({ text, prefs = {}, onPrefsChange }: EmbedsProps) {
+  const regexEmbeds = useMemo(() => getEmbeds(text), [text]);
+  const nonRegexUrls = useMemo(() => {
+    if (regexEmbeds.length >= MAX_EMBEDS) return [];
+    const remaining = MAX_EMBEDS - regexEmbeds.length;
+    return extractOEmbedCandidates(text).slice(0, remaining);
+  }, [text, regexEmbeds.length]);
+
+  // Track which of the non-regex URLs failed oEmbed and should fall back to unfurl.
+  const [oembedFailed, setOembedFailed] = useState<Record<string, boolean>>({});
+
+  const mutatePref = (url: string, patch: PreviewPref) => {
+    const next: PreviewPrefs = { ...prefs, [url]: { ...(prefs[url] || {}), ...patch } };
+    onPrefsChange?.(next);
+  };
+
+  const toggleSize = (url: string, current: PreviewSize) => {
+    mutatePref(url, { size: current === "full" ? "compact" : "full" });
+  };
+
+  const hide = (url: string) => {
+    mutatePref(url, { hidden: true });
+  };
+
+  const markOembedFailed = (url: string) => {
+    setOembedFailed((prev) => (prev[url] ? prev : { ...prev, [url]: true }));
+  };
+
+  if (regexEmbeds.length === 0 && nonRegexUrls.length === 0) return null;
+
+  return (
+    <>
+      {regexEmbeds.map((embed) => {
+        const key = embed.originalUrl;
+        const pref = prefs[key] || {};
+        if (pref.hidden) return null;
+        const size: PreviewSize = pref.size ?? "full";
+        return (
+          <EmbedPreview
+            key={embed.embedUrl}
+            embed={embed}
+            size={size}
+            onToggleSize={() => toggleSize(key, size)}
+            onHide={() => hide(key)}
+          />
+        );
+      })}
+      {nonRegexUrls.map((url) => {
+        const pref = prefs[url] || {};
+        if (pref.hidden) return null;
+        const size: PreviewSize = pref.size ?? "full";
+
+        // If oEmbed previously failed for this URL, go straight to unfurl.
+        if (oembedFailed[url]) {
+          return (
+            <UnfurlPreview
+              key={url}
+              url={url}
+              size={size}
+              onToggleSize={() => toggleSize(url, size)}
+              onHide={() => hide(url)}
+            />
+          );
+        }
+
+        return (
+          <OEmbedPreview
+            key={url}
+            url={url}
+            size={size}
+            onToggleSize={() => toggleSize(url, size)}
+            onHide={() => hide(url)}
+            onFail={() => markOembedFailed(url)}
+          />
+        );
+      })}
+    </>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
         "reflect-metadata": "^0.2.2",
         "resend": "^4.1.0",
         "rxjs": "^7.8.1",
+        "sanitize-html": "^2.17.3",
         "stripe": "^20.4.0",
         "web-push": "^3.6.7",
       },
@@ -59,6 +60,7 @@
         "@types/multer": "^2.1.0",
         "@types/nodemailer": "^7.0.11",
         "@types/pdfkit": "^0.17.5",
+        "@types/sanitize-html": "^2.16.1",
         "@types/web-push": "^3.6.4",
         "bun-types": "^1.3.9",
         "pino-pretty": "^13.1.3",
@@ -812,6 +814,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/sanitize-html": ["@types/sanitize-html@2.16.1", "", { "dependencies": { "htmlparser2": "^10.1" } }, "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA=="],
+
     "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
 
     "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
@@ -1096,7 +1100,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
@@ -1111,6 +1115,8 @@
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
 
@@ -1216,7 +1222,7 @@
 
     "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
 
-    "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -1253,6 +1259,8 @@
     "is-interactive": ["is-interactive@1.0.0", "", {}, "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
@@ -1440,6 +1448,8 @@
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
+    "parse-srcset": ["parse-srcset@1.0.2", "", {}, "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="],
+
     "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
@@ -1609,6 +1619,8 @@
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "sanitize-html": ["sanitize-html@2.17.3", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^10.1.0", "is-plain-object": "^5.0.0", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -1916,6 +1928,8 @@
 
     "defaults/clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
 
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "dotenv-expand/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
@@ -1929,6 +1943,8 @@
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "html-to-text/htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
 
     "https-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -2059,6 +2075,8 @@
     "express/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "finalhandler/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "html-to-text/htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "https-proxy-agent/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/e2e/tests/edits.e2e.ts
+++ b/e2e/tests/edits.e2e.ts
@@ -96,24 +96,16 @@ test.describe("Edit flows", () => {
 
     await page.goto(`/dashboard/projects/${projectId}`);
 
-    // Locate the Edit button on the update we just posted. The dashboard
-    // updates-section renders an Edit control beside Delete when the
-    // parallel agent's work lands — look for a button labelled "Edit"
-    // inside the container holding our update text.
-    const updateContainer = page
-      .locator("p", { hasText: "Initial text" })
-      .locator("..")
-      .locator("..")
-      .first();
+    // Locate the entry by its stable test id (the <p> body is replaced by a
+    // textarea once edit mode begins, so we anchor on the entry container).
+    const updateContainer = page.getByTestId(`update-entry-${updateId}`);
     await expect(updateContainer).toBeVisible({ timeout: 10000 });
 
-    const editButton = updateContainer.getByRole("button", { name: /^edit$/i });
-    await editButton.click();
+    await page.getByTestId(`edit-update-${updateId}`).click();
 
-    // Clear the textarea and type the new content.
-    const textarea = updateContainer.getByRole("textbox");
+    const textarea = page.getByTestId(`edit-update-textarea-${updateId}`);
     await textarea.fill("Edited text");
-    await updateContainer.getByRole("button", { name: /^save$/i }).click();
+    await page.getByTestId(`save-update-${updateId}`).click();
 
     // Assert the edited content appears.
     await expect(
@@ -171,33 +163,18 @@ test.describe("Edit flows", () => {
 
     await page.goto(`/dashboard/projects/${projectId}`);
     // Make sure we're on the Files tab.
-    const filesTab = page.getByRole("button", { name: /^files$/i });
-    if (await filesTab.isVisible().catch(() => false)) {
-      await filesTab.click();
-    }
+    await page.getByTestId("project-tab-files").click();
 
-    const row = page
-      .locator("p", { hasText: "Canva" })
-      .locator("..")
-      .locator("..")
-      .first();
+    const row = page.getByTestId(`file-row-${linkId}`);
     await expect(row).toBeVisible({ timeout: 10000 });
 
-    // The parallel-agent work adds a pencil/edit control to each file row.
-    // Look for any button with aria-label containing "edit" or name "Edit".
-    const editControl = row
-      .getByRole("button", { name: /edit/i })
-      .first();
-    await editControl.click();
+    await page.getByTestId(`edit-file-${linkId}`).click();
 
-    // Fill the name + description fields in the modal/drawer that opens.
-    // These field names match the "Add link" dialog shape.
-    const nameField = page.getByLabel(/name|title/i).first();
-    await nameField.fill("Canva (updated)");
-    const descField = page.getByLabel(/description/i).first();
-    await descField.fill("v2");
+    // Fill the name + description fields in the edit modal.
+    await page.getByTestId("edit-file-name").fill("Canva (updated)");
+    await page.getByTestId("edit-file-description").fill("v2");
 
-    await page.getByRole("button", { name: /^save$/i }).click();
+    await page.getByTestId("edit-file-save").click();
 
     // Assert the updated list entry appears.
     await expect(
@@ -318,18 +295,21 @@ test.describe("Edit flows", () => {
       "Could not resolve client user id via members/clients APIs",
     );
 
-    const assignRes = await ownerPage.request.post(
-      `${API}/projects/${projectId}/clients`,
+    const assignRes = await ownerPage.request.put(
+      `${API}/projects/${projectId}`,
       {
-        data: { userId: clientUserId },
-        headers: { "x-csrf-token": ownerCsrf },
+        data: { clientUserIds: [clientUserId] },
+        headers: {
+          "x-csrf-token": ownerCsrf,
+          "Content-Type": "application/json",
+        },
       },
     );
     expect(assignRes.ok()).toBeTruthy();
 
     // 4. As the client, open the project in the portal and post an update.
     await clientPage.goto(`${WEB_URL}/portal/projects/${projectId}`, {
-      waitUntil: "networkidle",
+      waitUntil: "domcontentloaded",
       timeout: 15000,
     });
 
@@ -344,47 +324,61 @@ test.describe("Edit flows", () => {
       .click();
 
     // The client's own update is visible.
-    const ownContainer = clientPage
-      .locator("p", { hasText: "Client posted this" })
-      .locator("..")
-      .locator("..")
-      .first();
-    await expect(ownContainer).toBeVisible({ timeout: 10000 });
+    await expect(
+      clientPage.locator("p", { hasText: "Client posted this" }).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Resolve the update id via the timeline API so we can use stable testids
+    // (the <p> body is replaced by a textarea once edit mode begins).
+    const ownTimelineRes = await clientPage.request.get(
+      `${API}/updates/timeline/mine/${projectId}`,
+    );
+    expect(ownTimelineRes.ok()).toBeTruthy();
+    const ownTimeline = await ownTimelineRes.json();
+    const ownEntries = (ownTimeline.data ?? ownTimeline) as Array<{
+      id: string;
+      content?: string;
+    }>;
+    const ownEntry = ownEntries.find((e) => e.content === "Client posted this");
+    expect(ownEntry).toBeTruthy();
+    const ownUpdateId = ownEntry!.id;
 
     // Edit button must be visible on the client's own update.
-    const editOwn = ownContainer.getByRole("button", {
-      name: /edit update|^edit$/i,
-    });
+    const editOwn = clientPage.getByTestId(`edit-update-${ownUpdateId}`);
     await expect(editOwn).toBeVisible({ timeout: 10000 });
 
     // Edit the text.
     await editOwn.click();
-    const editTextarea = ownContainer.getByRole("textbox").first();
-    await editTextarea.fill("Client edited this");
-    await ownContainer.getByRole("button", { name: /^save$/i }).click();
+    await clientPage
+      .getByTestId(`edit-update-textarea-${ownUpdateId}`)
+      .fill("Client edited this");
+    await clientPage.getByTestId(`save-update-${ownUpdateId}`).click();
 
     await expect(
       clientPage.locator("p", { hasText: "Client edited this" }).first(),
     ).toBeVisible({ timeout: 10000 });
 
     // 5. As the agency owner, post a second update on the same project.
-    await ownerPage.request.post(`${API}/updates?projectId=${projectId}`, {
-      multipart: { content: "Agency posted this" },
-      headers: { "x-csrf-token": ownerCsrf },
-    });
+    const agencyPostRes = await ownerPage.request.post(
+      `${API}/updates?projectId=${projectId}`,
+      {
+        multipart: { content: "Agency posted this" },
+        headers: { "x-csrf-token": ownerCsrf },
+      },
+    );
+    expect(agencyPostRes.ok()).toBeTruthy();
+    const agencyUpdate = await agencyPostRes.json();
+    const agencyUpdateId = agencyUpdate.id as string;
 
     // 6. Reload the client view and confirm:
     //    - the agency update is visible
     //    - there is NO Edit button on it (not author)
     await clientPage.reload({ waitUntil: "networkidle" });
-    const agencyContainer = clientPage
-      .locator("p", { hasText: "Agency posted this" })
-      .locator("..")
-      .locator("..")
-      .first();
-    await expect(agencyContainer).toBeVisible({ timeout: 10000 });
     await expect(
-      agencyContainer.getByRole("button", { name: /edit update|^edit$/i }),
+      clientPage.locator("p", { hasText: "Agency posted this" }).first(),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(
+      clientPage.getByTestId(`edit-update-${agencyUpdateId}`),
     ).toHaveCount(0);
 
     await ownerCtx.close();

--- a/e2e/tests/edits.e2e.ts
+++ b/e2e/tests/edits.e2e.ts
@@ -1,0 +1,393 @@
+import { test, expect } from "@playwright/test";
+import type { Browser, Page, BrowserContext } from "@playwright/test";
+import { getCsrfToken, getCsrfTokenFromContext } from "./helpers";
+
+const API = "http://localhost:3001/api";
+const API_URL = "http://localhost:3001";
+const WEB_URL = "http://localhost:3000";
+
+interface OwnerSession {
+  context: BrowserContext;
+  page: Page;
+  email: string;
+  password: string;
+}
+
+/**
+ * Create an owner user with a fresh org and a completed setup,
+ * returning the authenticated browser context.
+ */
+async function createOwnerUser(
+  browser: Browser,
+  prefix = "edit-owner",
+): Promise<OwnerSession> {
+  const context = await browser.newContext({ storageState: undefined });
+  const page = await context.newPage();
+
+  const stamp = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+  const email = `${prefix}-${stamp}@test.local`;
+  const password = "EditOwner123!";
+  const orgName = `${prefix} Org ${stamp}`;
+
+  const res = await page.request.post(`${API_URL}/api/onboarding/signup`, {
+    data: { name: "Edit Owner", email, password, orgName },
+  });
+  if (!res.ok()) {
+    const body = await res.text();
+    throw new Error(`Owner signup failed (${res.status()}): ${body}`);
+  }
+
+  await page.goto(`${WEB_URL}/dashboard`, {
+    waitUntil: "networkidle",
+    timeout: 15000,
+  });
+
+  let url = page.url();
+  if (url.includes("/login")) {
+    await page.goto(`${WEB_URL}/login`);
+    await page.getByLabel(/email/i).fill(email);
+    await page.getByLabel(/password/i).fill(password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await page.waitForURL(/\/(setup|dashboard)/, { timeout: 15000 });
+    url = page.url();
+  }
+
+  if (url.includes("/setup")) {
+    await page.request.get(`${API_URL}/api/setup/status`);
+    const csrf = await getCsrfTokenFromContext(context);
+    await page.request.post(`${API_URL}/api/setup/complete`, {
+      headers: { "x-csrf-token": csrf },
+    });
+    await page.goto(`${WEB_URL}/dashboard`, {
+      waitUntil: "networkidle",
+      timeout: 15000,
+    });
+  }
+
+  return { context, page, email, password };
+}
+
+test.describe("Edit flows", () => {
+  // ---------------------------------------------------------------------------
+  // Test A — Dashboard: owner edits own update
+  // ---------------------------------------------------------------------------
+  test("dashboard: owner can edit their own update", async ({ page, request }) => {
+    const csrfToken = getCsrfToken();
+
+    // Seed: create a project and a update authored by the current owner.
+    const projectRes = await request.post(`${API}/projects`, {
+      data: { name: `Edit Updates Test ${Date.now()}` },
+      headers: { "x-csrf-token": csrfToken },
+    });
+    expect(projectRes.ok()).toBeTruthy();
+    const project = await projectRes.json();
+    const projectId = project.id as string;
+
+    const updateRes = await request.post(
+      `${API}/updates?projectId=${projectId}`,
+      {
+        multipart: { content: "Initial text" },
+        headers: { "x-csrf-token": csrfToken },
+      },
+    );
+    expect(updateRes.ok()).toBeTruthy();
+    const update = await updateRes.json();
+    const updateId = update.id as string;
+
+    await page.goto(`/dashboard/projects/${projectId}`);
+
+    // Locate the Edit button on the update we just posted. The dashboard
+    // updates-section renders an Edit control beside Delete when the
+    // parallel agent's work lands — look for a button labelled "Edit"
+    // inside the container holding our update text.
+    const updateContainer = page
+      .locator("p", { hasText: "Initial text" })
+      .locator("..")
+      .locator("..")
+      .first();
+    await expect(updateContainer).toBeVisible({ timeout: 10000 });
+
+    const editButton = updateContainer.getByRole("button", { name: /^edit$/i });
+    await editButton.click();
+
+    // Clear the textarea and type the new content.
+    const textarea = updateContainer.getByRole("textbox");
+    await textarea.fill("Edited text");
+    await updateContainer.getByRole("button", { name: /^save$/i }).click();
+
+    // Assert the edited content appears.
+    await expect(
+      page.locator("p", { hasText: "Edited text" }).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // The "(edited)" indicator requires `updatedAt - createdAt > 2 minutes`
+    // and a Just-edited update won't cross that threshold in an e2e run.
+    // We still verify the API reports updatedAt > createdAt; the visual
+    // indicator assertion is intentionally skipped for timing stability.
+    const verifyRes = await request.get(`${API}/updates/timeline/${projectId}`);
+    expect(verifyRes.ok()).toBeTruthy();
+    const timeline = await verifyRes.json();
+    const edited = (timeline.data ?? timeline).find(
+      (e: { id: string }) => e.id === updateId,
+    );
+    expect(edited).toBeTruthy();
+    expect(edited.content).toBe("Edited text");
+    if (edited.updatedAt && edited.createdAt) {
+      expect(new Date(edited.updatedAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(edited.createdAt).getTime(),
+      );
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test B — Dashboard: owner edits a link file
+  // ---------------------------------------------------------------------------
+  test("dashboard: owner can edit a link file", async ({ page, request }) => {
+    const csrfToken = getCsrfToken();
+
+    const projectRes = await request.post(`${API}/projects`, {
+      data: { name: `Edit Link Test ${Date.now()}` },
+      headers: { "x-csrf-token": csrfToken },
+    });
+    expect(projectRes.ok()).toBeTruthy();
+    const project = await projectRes.json();
+    const projectId = project.id as string;
+
+    // Seed the link via API (matches the "Add link" UI result).
+    const linkRes = await request.post(`${API}/files/link`, {
+      headers: {
+        "Content-Type": "application/json",
+        "x-csrf-token": csrfToken,
+      },
+      data: {
+        projectId,
+        url: "https://www.canva.com/design/foo",
+        title: "Canva",
+      },
+    });
+    expect(linkRes.ok()).toBeTruthy();
+    const link = await linkRes.json();
+    const linkId = link.id as string;
+
+    await page.goto(`/dashboard/projects/${projectId}`);
+    // Make sure we're on the Files tab.
+    const filesTab = page.getByRole("button", { name: /^files$/i });
+    if (await filesTab.isVisible().catch(() => false)) {
+      await filesTab.click();
+    }
+
+    const row = page
+      .locator("p", { hasText: "Canva" })
+      .locator("..")
+      .locator("..")
+      .first();
+    await expect(row).toBeVisible({ timeout: 10000 });
+
+    // The parallel-agent work adds a pencil/edit control to each file row.
+    // Look for any button with aria-label containing "edit" or name "Edit".
+    const editControl = row
+      .getByRole("button", { name: /edit/i })
+      .first();
+    await editControl.click();
+
+    // Fill the name + description fields in the modal/drawer that opens.
+    // These field names match the "Add link" dialog shape.
+    const nameField = page.getByLabel(/name|title/i).first();
+    await nameField.fill("Canva (updated)");
+    const descField = page.getByLabel(/description/i).first();
+    await descField.fill("v2");
+
+    await page.getByRole("button", { name: /^save$/i }).click();
+
+    // Assert the updated list entry appears.
+    await expect(
+      page.locator("p", { hasText: "Canva (updated)" }).first(),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(
+      page.locator("text=v2").first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Also verify via API.
+    const verify = await request.get(`${API}/files/project/${projectId}`);
+    expect(verify.ok()).toBeTruthy();
+    const listed = await verify.json();
+    const updated = (listed.data ?? listed).find(
+      (f: { id: string }) => f.id === linkId,
+    );
+    expect(updated).toBeTruthy();
+    expect(updated.filename).toBe("Canva (updated)");
+    expect(updated.description).toBe("v2");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test C — Portal: client can edit own updates but not agency author's
+  // ---------------------------------------------------------------------------
+  test("portal: client edits own update, cannot edit agency update", async ({
+    browser,
+  }) => {
+    // 1. Create an agency owner with a project, then invite a client member.
+    const { context: ownerCtx, page: ownerPage } = await createOwnerUser(
+      browser,
+      "edit-portal",
+    );
+    const ownerCsrf = await getCsrfTokenFromContext(ownerCtx);
+
+    const projectRes = await ownerPage.request.post(`${API}/projects`, {
+      data: { name: `Portal Edit Test ${Date.now()}` },
+      headers: { "x-csrf-token": ownerCsrf },
+    });
+    expect(projectRes.ok()).toBeTruthy();
+    const project = await projectRes.json();
+    const projectId = project.id as string;
+
+    const clientEmail = `edit-client-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 6)}@test.local`;
+    const clientPassword = "ClientEdit123!";
+
+    // Invite the client as a member of the org.
+    const inviteRes = await ownerPage.request.post(
+      `${API_URL}/api/auth/organization/invite-member`,
+      {
+        data: { email: clientEmail, role: "member" },
+        headers: { Origin: WEB_URL },
+      },
+    );
+    expect(inviteRes.ok()).toBeTruthy();
+    const inviteBody = await inviteRes.json();
+    const invitationId: string =
+      inviteBody?.id || inviteBody?.invitation?.id || inviteBody?.data?.id;
+    expect(invitationId).toBeTruthy();
+
+    // 2. Client accepts the invite by signing up — this establishes a session
+    //    in the client's fresh context.
+    const clientCtx = await browser.newContext({ storageState: undefined });
+    const clientPage = await clientCtx.newPage();
+
+    await clientPage.goto(
+      `${WEB_URL}/accept-invite?id=${invitationId}`,
+      { waitUntil: "networkidle", timeout: 15000 },
+    );
+    await clientPage.getByLabel(/your name/i).fill("Portal Edit Client");
+    await clientPage.getByLabel(/email/i).fill(clientEmail);
+    await clientPage.getByLabel(/password/i).fill(clientPassword);
+    await clientPage
+      .getByRole("button", { name: /create account & join/i })
+      .click();
+    await expect(clientPage).toHaveURL(/\/portal/, { timeout: 20000 });
+
+    // 3. Assign the new client to the project so /projects/mine/:id works.
+    // Look up the client's user id via the owner's session, then add them.
+    const membersRes = await ownerPage.request.get(
+      `${API_URL}/api/auth/organization/list-members`,
+      { headers: { Origin: WEB_URL } },
+    );
+    let clientUserId = "";
+    if (membersRes.ok()) {
+      const membersBody = await membersRes.json();
+      const members = membersBody?.members ?? membersBody?.data ?? membersBody;
+      if (Array.isArray(members)) {
+        const match = members.find(
+          (m: { user?: { email?: string }; email?: string }) =>
+            m.user?.email === clientEmail || m.email === clientEmail,
+        );
+        clientUserId = match?.user?.id ?? match?.userId ?? "";
+      }
+    }
+    // Fallback: fetch clients list used by dashboard.
+    if (!clientUserId) {
+      const clientsRes = await ownerPage.request.get(
+        `${API}/clients?limit=50`,
+      );
+      if (clientsRes.ok()) {
+        const body = await clientsRes.json();
+        const clients = body?.data ?? body;
+        if (Array.isArray(clients)) {
+          const match = clients.find(
+            (c: { email?: string }) => c.email === clientEmail,
+          );
+          clientUserId = match?.id ?? match?.userId ?? "";
+        }
+      }
+    }
+
+    // Skipping this test if we cannot derive the client user id — the
+    // /projects/:projectId/clients endpoint needs it to link the user.
+    test.skip(
+      !clientUserId,
+      "Could not resolve client user id via members/clients APIs",
+    );
+
+    const assignRes = await ownerPage.request.post(
+      `${API}/projects/${projectId}/clients`,
+      {
+        data: { userId: clientUserId },
+        headers: { "x-csrf-token": ownerCsrf },
+      },
+    );
+    expect(assignRes.ok()).toBeTruthy();
+
+    // 4. As the client, open the project in the portal and post an update.
+    await clientPage.goto(`${WEB_URL}/portal/projects/${projectId}`, {
+      waitUntil: "networkidle",
+      timeout: 15000,
+    });
+
+    await clientPage
+      .getByRole("button", { name: /add update/i })
+      .click();
+    await clientPage
+      .getByPlaceholder(/write an update/i)
+      .fill("Client posted this");
+    await clientPage
+      .getByRole("button", { name: /^post$/i })
+      .click();
+
+    // The client's own update is visible.
+    const ownContainer = clientPage
+      .locator("p", { hasText: "Client posted this" })
+      .locator("..")
+      .locator("..")
+      .first();
+    await expect(ownContainer).toBeVisible({ timeout: 10000 });
+
+    // Edit button must be visible on the client's own update.
+    const editOwn = ownContainer.getByRole("button", {
+      name: /edit update|^edit$/i,
+    });
+    await expect(editOwn).toBeVisible({ timeout: 10000 });
+
+    // Edit the text.
+    await editOwn.click();
+    const editTextarea = ownContainer.getByRole("textbox").first();
+    await editTextarea.fill("Client edited this");
+    await ownContainer.getByRole("button", { name: /^save$/i }).click();
+
+    await expect(
+      clientPage.locator("p", { hasText: "Client edited this" }).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // 5. As the agency owner, post a second update on the same project.
+    await ownerPage.request.post(`${API}/updates?projectId=${projectId}`, {
+      multipart: { content: "Agency posted this" },
+      headers: { "x-csrf-token": ownerCsrf },
+    });
+
+    // 6. Reload the client view and confirm:
+    //    - the agency update is visible
+    //    - there is NO Edit button on it (not author)
+    await clientPage.reload({ waitUntil: "networkidle" });
+    const agencyContainer = clientPage
+      .locator("p", { hasText: "Agency posted this" })
+      .locator("..")
+      .locator("..")
+      .first();
+    await expect(agencyContainer).toBeVisible({ timeout: 10000 });
+    await expect(
+      agencyContainer.getByRole("button", { name: /edit update|^edit$/i }),
+    ).toHaveCount(0);
+
+    await ownerCtx.close();
+    await clientCtx.close();
+  });
+});

--- a/e2e/tests/embeds.e2e.ts
+++ b/e2e/tests/embeds.e2e.ts
@@ -97,4 +97,80 @@ test.describe("Content Embeds", () => {
       page.locator('iframe[src*="loom.com/embed"]').first(),
     ).toBeVisible({ timeout: 10000 });
   });
+
+  test("Canva URL in update renders iframe via mocked oEmbed response", async ({
+    page,
+    request,
+  }) => {
+    test.skip(!projectId, "No project available");
+
+    const csrfToken = getCsrfToken();
+    const canvaUrl = "https://www.canva.com/design/DAF0000TEST/view";
+    await request.post(`${API}/updates?projectId=${projectId}`, {
+      multipart: {
+        content: `Check the board: ${canvaUrl}`,
+      },
+      headers: { "x-csrf-token": csrfToken },
+    });
+
+    // Mock the browser-side call to /api/embeds/resolve so we don't hit
+    // Canva's real oEmbed endpoint from the test environment.
+    await page.route("**/api/embeds/resolve*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          html: '<iframe src="https://www.canva.com/design/DAF0000TEST/view?embed" width="800" height="500"></iframe>',
+          width: 800,
+          height: 500,
+          providerName: "Canva",
+          title: "Test Canva Design",
+        }),
+      });
+    });
+
+    await page.goto(`/dashboard/projects/${projectId}`);
+    await expect(
+      page
+        .locator('iframe[src*="canva.com/design/DAF0000TEST"]')
+        .first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("oEmbed failure degrades to plain link (no iframe)", async ({
+    page,
+    request,
+  }) => {
+    test.skip(!projectId, "No project available");
+
+    const csrfToken = getCsrfToken();
+    const vimeoUrl = "https://vimeo.com/000000000";
+    const content = `See: ${vimeoUrl}`;
+    await request.post(`${API}/updates?projectId=${projectId}`, {
+      multipart: { content },
+      headers: { "x-csrf-token": csrfToken },
+    });
+
+    // Simulate an unresolvable oEmbed URL.
+    await page.route("**/api/embeds/resolve*", async (route) => {
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "No oEmbed provider" }),
+      });
+    });
+
+    await page.goto(`/dashboard/projects/${projectId}`);
+
+    // The update itself must render, and the plain linkified URL must be
+    // visible, but no Vimeo iframe should appear.
+    const updateContainer = page
+      .locator("p", { hasText: "See:" })
+      .locator("..")
+      .first();
+    await expect(updateContainer).toBeVisible({ timeout: 10000 });
+    await expect(
+      page.locator('iframe[src*="player.vimeo.com"]'),
+    ).not.toBeVisible();
+  });
 });

--- a/e2e/tests/files-links.e2e.ts
+++ b/e2e/tests/files-links.e2e.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "@playwright/test";
+import { getCsrfToken } from "./helpers";
+
+const API = "http://localhost:3001/api";
+
+test.describe("File links", () => {
+  test("creates a link file, lists it, and blocks download", async ({
+    request,
+  }) => {
+    const csrfToken = getCsrfToken();
+
+    // 1. Find a project to attach the link to
+    const projectsRes = await request.get(`${API}/projects?limit=1`);
+    expect(projectsRes.ok()).toBeTruthy();
+    const projects = await projectsRes.json();
+    if (!projects.data?.length) return;
+    const projectId = projects.data[0].id as string;
+
+    // 2. POST /files/link creates a LINK-type file
+    const linkRes = await request.post(`${API}/files/link`, {
+      headers: {
+        "Content-Type": "application/json",
+        "x-csrf-token": csrfToken,
+      },
+      data: {
+        projectId,
+        url: "https://cloud.example.com/s/abc123",
+        title: "Shared Nextcloud Folder",
+        description: "Design assets and references",
+      },
+    });
+    expect(linkRes.ok()).toBeTruthy();
+    const link = await linkRes.json();
+    expect(link.type).toBe("LINK");
+    expect(link.url).toBe("https://cloud.example.com/s/abc123");
+    expect(link.filename).toBe("Shared Nextcloud Folder");
+    expect(link.description).toBe("Design assets and references");
+    expect(link.storageKey).toBeNull();
+
+    // 3. List endpoint returns the link
+    const listRes = await request.get(`${API}/files/project/${projectId}`);
+    expect(listRes.ok()).toBeTruthy();
+    const list = await listRes.json();
+    const found = (list.data ?? list).find(
+      (f: { id: string }) => f.id === link.id,
+    );
+    expect(found).toBeTruthy();
+    expect(found.type).toBe("LINK");
+
+    // 4. Download endpoint rejects LINK type
+    const downloadRes = await request.get(`${API}/files/${link.id}/download`);
+    expect(downloadRes.status()).toBe(400);
+
+    // 5. URL endpoint rejects LINK type
+    const urlRes = await request.get(`${API}/files/${link.id}/url`);
+    expect(urlRes.status()).toBe(400);
+
+    // 6. Delete endpoint works for LINK type
+    const deleteRes = await request.delete(`${API}/files/${link.id}`, {
+      headers: { "x-csrf-token": csrfToken },
+    });
+    expect(deleteRes.ok()).toBeTruthy();
+  });
+
+  test("rejects non-http(s) URLs", async ({ request }) => {
+    const csrfToken = getCsrfToken();
+
+    const projectsRes = await request.get(`${API}/projects?limit=1`);
+    const projects = await projectsRes.json();
+    if (!projects.data?.length) return;
+    const projectId = projects.data[0].id as string;
+
+    const ftpRes = await request.post(`${API}/files/link`, {
+      headers: {
+        "Content-Type": "application/json",
+        "x-csrf-token": csrfToken,
+      },
+      data: {
+        projectId,
+        url: "ftp://example.com/file.txt",
+        title: "Bad link",
+      },
+    });
+    expect(ftpRes.status()).toBe(400);
+
+    const javascriptRes = await request.post(`${API}/files/link`, {
+      headers: {
+        "Content-Type": "application/json",
+        "x-csrf-token": csrfToken,
+      },
+      data: {
+        projectId,
+        // eslint-disable-next-line no-script-url
+        url: "javascript:alert(1)",
+        title: "XSS attempt",
+      },
+    });
+    expect(javascriptRes.status()).toBe(400);
+  });
+
+  test("rejects missing title", async ({ request }) => {
+    const csrfToken = getCsrfToken();
+
+    const projectsRes = await request.get(`${API}/projects?limit=1`);
+    const projects = await projectsRes.json();
+    if (!projects.data?.length) return;
+    const projectId = projects.data[0].id as string;
+
+    const res = await request.post(`${API}/files/link`, {
+      headers: {
+        "Content-Type": "application/json",
+        "x-csrf-token": csrfToken,
+      },
+      data: {
+        projectId,
+        url: "https://example.com",
+      },
+    });
+    expect(res.status()).toBe(400);
+  });
+});

--- a/e2e/tests/project-duplicate.e2e.ts
+++ b/e2e/tests/project-duplicate.e2e.ts
@@ -19,9 +19,8 @@ test.describe("Project duplication", () => {
     const source = await projectRes.json();
 
     // 2. Seed two tasks (one done, assigned; one decision)
-    const t1 = await request.post(`${API}/tasks`, {
+    const t1 = await request.post(`${API}/tasks?projectId=${source.id}`, {
       data: {
-        projectId: source.id,
         title: "Kickoff meeting",
         description: "Run the kickoff",
       },
@@ -37,12 +36,12 @@ test.describe("Project duplication", () => {
     });
     expect(t1Update.ok()).toBeTruthy();
 
-    const t2 = await request.post(`${API}/tasks`, {
+    const t2 = await request.post(`${API}/tasks?projectId=${source.id}`, {
       data: {
-        projectId: source.id,
         title: "Pick a direction",
         type: "decision",
         question: "Which way?",
+        options: [{ label: "Left" }, { label: "Right" }],
       },
       headers: { "x-csrf-token": csrfToken, "Content-Type": "application/json" },
     });
@@ -110,8 +109,8 @@ test.describe("Project duplication", () => {
     });
     const source = await projectRes.json();
 
-    await request.post(`${API}/tasks`, {
-      data: { projectId: source.id, title: "Only task" },
+    await request.post(`${API}/tasks?projectId=${source.id}`, {
+      data: { title: "Only task" },
       headers: { "x-csrf-token": csrfToken, "Content-Type": "application/json" },
     });
 

--- a/e2e/tests/project-duplicate.e2e.ts
+++ b/e2e/tests/project-duplicate.e2e.ts
@@ -1,0 +1,159 @@
+import { test, expect } from "@playwright/test";
+import { getCsrfToken } from "./helpers";
+
+const API = "http://localhost:3001/api";
+
+test.describe("Project duplication", () => {
+  test("duplicates a project with tasks, resetting state", async ({
+    request,
+  }) => {
+    const csrfToken = getCsrfToken();
+
+    // 1. Create a source project
+    const stamp = Date.now();
+    const projectRes = await request.post(`${API}/projects`, {
+      data: { name: `Dup Source ${stamp}`, description: "Template source" },
+      headers: { "x-csrf-token": csrfToken, "Content-Type": "application/json" },
+    });
+    expect(projectRes.ok()).toBeTruthy();
+    const source = await projectRes.json();
+
+    // 2. Seed two tasks (one done, assigned; one decision)
+    const t1 = await request.post(`${API}/tasks`, {
+      data: {
+        projectId: source.id,
+        title: "Kickoff meeting",
+        description: "Run the kickoff",
+      },
+      headers: { "x-csrf-token": csrfToken, "Content-Type": "application/json" },
+    });
+    expect(t1.ok()).toBeTruthy();
+    const task1 = await t1.json();
+
+    // Mark task1 done so we can verify status resets on duplicate
+    const t1Update = await request.put(`${API}/tasks/${task1.id}`, {
+      data: { status: "done" },
+      headers: { "x-csrf-token": csrfToken, "Content-Type": "application/json" },
+    });
+    expect(t1Update.ok()).toBeTruthy();
+
+    const t2 = await request.post(`${API}/tasks`, {
+      data: {
+        projectId: source.id,
+        title: "Pick a direction",
+        type: "decision",
+        question: "Which way?",
+      },
+      headers: { "x-csrf-token": csrfToken, "Content-Type": "application/json" },
+    });
+    expect(t2.ok()).toBeTruthy();
+
+    // 3. Duplicate
+    const dupRes = await request.post(
+      `${API}/projects/${source.id}/duplicate`,
+      {
+        data: { name: `Dup Source ${stamp} (copy)`, includeTasks: true },
+        headers: {
+          "x-csrf-token": csrfToken,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+    expect(dupRes.ok()).toBeTruthy();
+    const dup = await dupRes.json();
+    expect(dup.id).not.toBe(source.id);
+    expect(dup.name).toBe(`Dup Source ${stamp} (copy)`);
+    // Status should NOT be the source's status — schema default applies.
+    expect(dup.status).toBe("not_started");
+
+    // 4. New project has two tasks, both with reset state
+    const listRes = await request.get(
+      `${API}/tasks/project/${dup.id}?limit=50`,
+    );
+    expect(listRes.ok()).toBeTruthy();
+    const list = await listRes.json();
+    const tasks = (list.data ?? list) as Array<{
+      title: string;
+      status: string;
+      dueDate: string | null;
+      assigneeId: string | null;
+      requestedById: string | null;
+      type: string;
+      question: string | null;
+    }>;
+
+    expect(tasks.length).toBe(2);
+    for (const t of tasks) {
+      expect(t.status).toBe("open");
+      expect(t.dueDate).toBeNull();
+      expect(t.assigneeId).toBeNull();
+    }
+    const titles = tasks.map((t) => t.title).sort();
+    expect(titles).toEqual(["Kickoff meeting", "Pick a direction"]);
+
+    // 5. Cleanup
+    await request.delete(`${API}/projects/${dup.id}`, {
+      headers: { "x-csrf-token": csrfToken },
+    });
+    await request.delete(`${API}/projects/${source.id}`, {
+      headers: { "x-csrf-token": csrfToken },
+    });
+  });
+
+  test("includeTasks=false skips tasks on duplicate", async ({ request }) => {
+    const csrfToken = getCsrfToken();
+    const stamp = Date.now();
+
+    const projectRes = await request.post(`${API}/projects`, {
+      data: { name: `Dup Empty ${stamp}` },
+      headers: { "x-csrf-token": csrfToken, "Content-Type": "application/json" },
+    });
+    const source = await projectRes.json();
+
+    await request.post(`${API}/tasks`, {
+      data: { projectId: source.id, title: "Only task" },
+      headers: { "x-csrf-token": csrfToken, "Content-Type": "application/json" },
+    });
+
+    const dupRes = await request.post(
+      `${API}/projects/${source.id}/duplicate`,
+      {
+        data: { name: `Dup Empty ${stamp} (copy)`, includeTasks: false },
+        headers: {
+          "x-csrf-token": csrfToken,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+    expect(dupRes.ok()).toBeTruthy();
+    const dup = await dupRes.json();
+
+    const listRes = await request.get(
+      `${API}/tasks/project/${dup.id}?limit=50`,
+    );
+    const list = await listRes.json();
+    const tasks = list.data ?? list;
+    expect(tasks.length).toBe(0);
+
+    await request.delete(`${API}/projects/${dup.id}`, {
+      headers: { "x-csrf-token": csrfToken },
+    });
+    await request.delete(`${API}/projects/${source.id}`, {
+      headers: { "x-csrf-token": csrfToken },
+    });
+  });
+
+  test("rejects duplicate when name is missing", async ({ request }) => {
+    const csrfToken = getCsrfToken();
+    const projectsRes = await request.get(`${API}/projects?limit=1`);
+    const projects = await projectsRes.json();
+    if (!projects.data?.length) return;
+    const projectId = projects.data[0].id as string;
+
+    const res = await request.post(`${API}/projects/${projectId}/duplicate`, {
+      data: {},
+      headers: { "x-csrf-token": csrfToken, "Content-Type": "application/json" },
+    });
+    expect(res.status()).toBe(400);
+  });
+});

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -191,6 +191,7 @@ model File {
   organizationId String
   uploadedById   String
   createdAt      DateTime @default(now())
+  updatedAt      DateTime @default(now()) @updatedAt
 
   project          Project           @relation(fields: [projectId], references: [id], onDelete: Cascade)
   updates          ProjectUpdate[]
@@ -216,6 +217,7 @@ model ProjectUpdate {
   organizationId     String
   authorId           String
   createdAt          DateTime @default(now())
+  updatedAt          DateTime @default(now()) @updatedAt
   // Per-URL display preferences for link previews rendered inside this
   // update's content. Shape: { [url: string]: { size?: "compact" | "full", hidden?: boolean } }
   previewPrefs       Json?    @map("preview_prefs")

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -171,12 +171,22 @@ model ProjectClient {
   @@map("project_client")
 }
 
+enum FileType {
+  UPLOAD
+  LINK
+
+  @@map("file_type")
+}
+
 model File {
   id             String   @id @default(cuid())
   filename       String
-  storageKey     String
-  mimeType       String
-  sizeBytes      Int
+  type           FileType @default(UPLOAD)
+  storageKey     String?
+  mimeType       String?
+  sizeBytes      Int?
+  url            String?
+  description    String?
   projectId      String
   organizationId String
   uploadedById   String
@@ -206,6 +216,9 @@ model ProjectUpdate {
   organizationId     String
   authorId           String
   createdAt          DateTime @default(now())
+  // Per-URL display preferences for link previews rendered inside this
+  // update's content. Shape: { [url: string]: { size?: "compact" | "full", hidden?: boolean } }
+  previewPrefs       Json?    @map("preview_prefs")
 
   project  Project          @relation(fields: [projectId], references: [id], onDelete: Cascade)
   file     File?            @relation(fields: [fileId], references: [id])


### PR DESCRIPTION
Closes #36

## Summary
- **Content embedding** in project updates (oEmbed + OpenGraph fallback, SSRF-hardened)
- **Link-type file entries** alongside uploads
- **Inline edit** for updates and file entries
- **Project duplication** with optional tasks/clients (closes #36's template-project ask)

## Linear Issue
https://linear.app/vibralabs/issue/VRB-93

## Changes
- **API**
  - `PATCH /updates/:id` — authors can edit own updates; owners/admins can edit any. 5000-char cap.
  - `PATCH /files/:id` — owners/admins only; url edits only on LINK-type; `new URL()` + http(s) validation; `assertProjectAccess` for parity.
  - `POST /projects/:id/duplicate` — owners/admins, plan-limited. Copies core fields, project labels, tasks (status reset to `open`), decision options, and task labels. Optional `includeClients`. Files/updates/invoices/notes are not copied.
  - oEmbed registry with iframe-only sanitization + per-provider host pinning.
  - OpenGraph unfurl (`unfurl.service`) with meta-tag parsing, 256KB head-scan cap, favicon absolutization.
  - `safe-fetch` SSRF guards (private IPv4/v6, 169.254.169.254, CGNAT, link-local, ULA).
- **Web**
  - Dashboard: pencil edit UI for updates (inline textarea) and files (modal). Preview prefs toggle (compact/full/hide). Duplicate button + modal on project detail page.
  - Portal: author-only edit UI gated via `/auth/get-session`. Preview prefs wired.
- **DB**: `ProjectUpdate.updatedAt` and `File.updatedAt` with `@default(now()) @updatedAt` (safe for existing rows).

## Testing
- [ ] Unit: 599 API tests pass (projects.duplicate: 4 new, updates.service: 7, files.service update: 7, unfurl: parseMeta + SSRF, safe-fetch: IP classifier)
- [ ] Unit: 42 web tests pass (embeds: applyPrefPatch + nextSize)
- [ ] E2E: `edits.e2e.ts` — dashboard update edit, dashboard file link edit, portal author-only gating
- [ ] Manual: edit own update in portal; edit any update as owner in dashboard; edit link filename/url/description
- [ ] Manual: paste YouTube / CodePen URL in an update → oEmbed renders; paste arbitrary URL → OG unfurl
- [ ] Manual: toggle preview between compact/full/hide, reload, confirm prefs persist
- [ ] Manual: duplicate a project with tasks — new project has tasks with status `open`; check labels carried over; confirm files/updates/invoices not copied