### PR TITLE
docs(changelog): release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Atrium will be documented in this file.
 
-## [Unreleased]
+## [1.6.0] — 2026-04-26
 
 ### Added
 


### PR DESCRIPTION
## Summary
- Stamp the previously-Unreleased section as `[1.6.0] — 2026-04-26` to match the published tag.

## Test plan
- [x] No code changes; docs-only.