### PR TITLE
fix(auth): reset emails, per-org config, admin reset link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Atrium will be documented in this file.
 
+## [1.6.1] — 2026-04-27
+
+### Fixed
+
+- **Password reset emails were never sent** — the forgot-password form posted to `/api/auth/forget-password`, an endpoint Better Auth renamed to `/api/auth/request-password-reset` in v1.4. Requests 404'd silently, so no email was generated. Reported in #40.
+- **Auth emails ignored per-org email config** — reset, verification, magic-link, and invitation emails routed through the default sender instead of the System Settings SMTP/Resend config. Each callback now resolves the user's primary org and threads `organizationId` into `MailService.send` so per-org configs are honored.
+
+### Added
+
+- **Admin "Send password reset link" action** — owners and admins can generate a reset URL for any team or client member from `/dashboard/clients`. The link is delivered by email when configured and also surfaced in-app for out-of-band sharing on self-hosted setups where email is unreliable. Owners can reset other owners; admins cannot reset owners; nobody can reset themselves. New `POST /clients/:id/reset-password` endpoint.
+
 ## [1.6.0] — 2026-04-26
 
 ### Added

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -120,7 +120,7 @@ describe("AuthService", () => {
   });
 
   describe("generateResetLink", () => {
-    it("returns the URL captured from the sendResetPassword callback context", async () => {
+    it("returns the URL and emailSent captured from the sendResetPassword callback context", async () => {
       const expectedUrl =
         "http://localhost:3001/api/auth/reset-password/token-abc?callbackURL=http%3A%2F%2Flocalhost%3A3000%2Freset-password";
 
@@ -128,25 +128,65 @@ describe("AuthService", () => {
         const store = (
           service as unknown as {
             adminResetStorage: {
-              getStore: () => { capturedUrl: string | null } | undefined;
+              getStore: () => {
+                capturedUrl: string | null;
+                emailSent: boolean;
+                emailViaOrgConfig: boolean;
+              } | undefined;
             };
           }
         ).adminResetStorage.getStore();
-        if (store) store.capturedUrl = expectedUrl;
+        if (store) {
+          store.capturedUrl = expectedUrl;
+          store.emailSent = true;
+          store.emailViaOrgConfig = true;
+        }
       });
       (service.auth as unknown as {
         api: { requestPasswordReset: typeof requestPasswordReset };
       }).api.requestPasswordReset = requestPasswordReset;
 
-      const url = await service.generateResetLink("alice@example.com");
+      const result = await service.generateResetLink("alice@example.com");
 
-      expect(url).toBe(expectedUrl);
+      expect(result).toEqual({
+        url: expectedUrl,
+        emailSent: true,
+        emailViaOrgConfig: true,
+      });
       expect(requestPasswordReset).toHaveBeenCalledTimes(1);
       const callArg = requestPasswordReset.mock.calls[0][0] as {
         body: { email: string; redirectTo: string };
       };
       expect(callArg.body.email).toBe("alice@example.com");
       expect(callArg.body.redirectTo).toBe("http://localhost:3000/reset-password");
+    });
+
+    it("returns emailSent=false when no provider sent the email", async () => {
+      const requestPasswordReset = mock(async () => {
+        const store = (
+          service as unknown as {
+            adminResetStorage: {
+              getStore: () => {
+                capturedUrl: string | null;
+                emailSent: boolean;
+                emailViaOrgConfig: boolean;
+              } | undefined;
+            };
+          }
+        ).adminResetStorage.getStore();
+        if (store) {
+          store.capturedUrl = "https://example.test/reset/abc";
+          // emailSent and emailViaOrgConfig stay false
+        }
+      });
+      (service.auth as unknown as {
+        api: { requestPasswordReset: typeof requestPasswordReset };
+      }).api.requestPasswordReset = requestPasswordReset;
+
+      const result = await service.generateResetLink("alice@example.com");
+
+      expect(result.emailSent).toBe(false);
+      expect(result.emailViaOrgConfig).toBe(false);
     });
 
     it("throws InternalServerErrorException when no URL was captured", async () => {
@@ -169,13 +209,20 @@ describe("AuthService", () => {
         const store = (
           service as unknown as {
             adminResetStorage: {
-              getStore: () => { capturedUrl: string | null } | undefined;
+              getStore: () => {
+                capturedUrl: string | null;
+                emailSent: boolean;
+                emailViaOrgConfig: boolean;
+              } | undefined;
             };
           }
         ).adminResetStorage.getStore();
-        // simulate async delay to interleave the two ALS contexts
         await new Promise((r) => setTimeout(r, ++call * 5));
-        if (store) store.capturedUrl = `https://example.test/reset/${body.email}`;
+        if (store) {
+          store.capturedUrl = `https://example.test/reset/${body.email}`;
+          store.emailSent = true;
+          store.emailViaOrgConfig = true;
+        }
       });
 
       const [a, b] = await Promise.all([
@@ -183,8 +230,8 @@ describe("AuthService", () => {
         service.generateResetLink("b@example.com"),
       ]);
 
-      expect(a).toBe("https://example.test/reset/a@example.com");
-      expect(b).toBe("https://example.test/reset/b@example.com");
+      expect(a.url).toBe("https://example.test/reset/a@example.com");
+      expect(b.url).toBe("https://example.test/reset/b@example.com");
     });
   });
 });

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { InternalServerErrorException } from "@nestjs/common";
+import { AuthService } from "./auth.service";
+import type { ConfigService } from "@nestjs/config";
+import type { PrismaService } from "../prisma/prisma.service";
+import type { MailService } from "../mail/mail.service";
+import type { BillingService } from "../billing/billing.service";
+
+const mockConfig = {
+  get: mock((key: string, fallback?: string) => {
+    if (key === "WEB_URL") return "http://localhost:3000";
+    if (key === "API_URL") return "http://localhost:3001";
+    return fallback;
+  }),
+  getOrThrow: mock((key: string) => {
+    if (key === "BETTER_AUTH_SECRET") return "x".repeat(32);
+    throw new Error(`Missing ${key}`);
+  }),
+};
+
+const mockPrisma = {
+  member: {
+    findFirst: mock(() => Promise.resolve(null)),
+  },
+  user: {
+    findUnique: mock(() => Promise.resolve(null)),
+  },
+};
+
+const mockMail = { send: mock(() => Promise.resolve()) };
+const mockBilling = { initializeFreePlan: mock(() => Promise.resolve()) };
+
+function makeService(): AuthService {
+  return new AuthService(
+    mockConfig as unknown as ConfigService,
+    mockPrisma as unknown as PrismaService,
+    mockMail as unknown as MailService,
+    mockBilling as unknown as BillingService,
+  );
+}
+
+describe("AuthService", () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    service = makeService();
+    mockPrisma.member.findFirst.mockClear();
+    mockPrisma.user.findUnique.mockClear();
+  });
+
+  describe("getPrimaryOrgForUserId", () => {
+    it("returns the most recent membership organizationId", async () => {
+      mockPrisma.member.findFirst.mockReturnValueOnce(
+        Promise.resolve({ organizationId: "org-123" }),
+      );
+
+      const result = await service.getPrimaryOrgForUserId("user-1");
+
+      expect(result).toBe("org-123");
+      const call = mockPrisma.member.findFirst.mock.calls[0][0] as {
+        where: { userId: string };
+        orderBy: { createdAt: string };
+      };
+      expect(call.where).toEqual({ userId: "user-1" });
+      expect(call.orderBy).toEqual({ createdAt: "desc" });
+    });
+
+    it("returns undefined when the user has no memberships", async () => {
+      mockPrisma.member.findFirst.mockReturnValueOnce(Promise.resolve(null));
+
+      const result = await service.getPrimaryOrgForUserId("user-orphan");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined and swallows errors when the query fails", async () => {
+      mockPrisma.member.findFirst.mockReturnValueOnce(
+        Promise.reject(new Error("db down")),
+      );
+
+      const result = await service.getPrimaryOrgForUserId("user-1");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("getPrimaryOrgForEmail", () => {
+    it("resolves orgId via a single member query joined on user.email", async () => {
+      mockPrisma.member.findFirst.mockReturnValueOnce(
+        Promise.resolve({ organizationId: "org-456" }),
+      );
+
+      const result = await service.getPrimaryOrgForEmail("alice@example.com");
+
+      expect(result).toBe("org-456");
+      const call = mockPrisma.member.findFirst.mock.calls[0][0] as {
+        where: { user: { email: string } };
+      };
+      expect(call.where).toEqual({ user: { email: "alice@example.com" } });
+      expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined when no membership matches the email", async () => {
+      mockPrisma.member.findFirst.mockReturnValueOnce(Promise.resolve(null));
+
+      const result = await service.getPrimaryOrgForEmail("ghost@example.com");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined and swallows errors when the query fails", async () => {
+      mockPrisma.member.findFirst.mockReturnValueOnce(
+        Promise.reject(new Error("db down")),
+      );
+
+      const result = await service.getPrimaryOrgForEmail("alice@example.com");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("generateResetLink", () => {
+    it("returns the URL captured from the sendResetPassword callback context", async () => {
+      const expectedUrl =
+        "http://localhost:3001/api/auth/reset-password/token-abc?callbackURL=http%3A%2F%2Flocalhost%3A3000%2Freset-password";
+
+      const requestPasswordReset = mock(async () => {
+        const store = (
+          service as unknown as {
+            adminResetStorage: {
+              getStore: () => { capturedUrl: string | null } | undefined;
+            };
+          }
+        ).adminResetStorage.getStore();
+        if (store) store.capturedUrl = expectedUrl;
+      });
+      (service.auth as unknown as {
+        api: { requestPasswordReset: typeof requestPasswordReset };
+      }).api.requestPasswordReset = requestPasswordReset;
+
+      const url = await service.generateResetLink("alice@example.com");
+
+      expect(url).toBe(expectedUrl);
+      expect(requestPasswordReset).toHaveBeenCalledTimes(1);
+      const callArg = requestPasswordReset.mock.calls[0][0] as {
+        body: { email: string; redirectTo: string };
+      };
+      expect(callArg.body.email).toBe("alice@example.com");
+      expect(callArg.body.redirectTo).toBe("http://localhost:3000/reset-password");
+    });
+
+    it("throws InternalServerErrorException when no URL was captured", async () => {
+      (service.auth as unknown as {
+        api: { requestPasswordReset: () => Promise<void> };
+      }).api.requestPasswordReset = mock(async () => {
+        // intentionally do not populate the ALS context
+      });
+
+      await expect(service.generateResetLink("ghost@example.com")).rejects.toBeInstanceOf(
+        InternalServerErrorException,
+      );
+    });
+
+    it("isolates ALS contexts so concurrent generates do not bleed URLs", async () => {
+      let call = 0;
+      (service.auth as unknown as {
+        api: { requestPasswordReset: (args: { body: { email: string } }) => Promise<void> };
+      }).api.requestPasswordReset = mock(async ({ body }) => {
+        const store = (
+          service as unknown as {
+            adminResetStorage: {
+              getStore: () => { capturedUrl: string | null } | undefined;
+            };
+          }
+        ).adminResetStorage.getStore();
+        // simulate async delay to interleave the two ALS contexts
+        await new Promise((r) => setTimeout(r, ++call * 5));
+        if (store) store.capturedUrl = `https://example.test/reset/${body.email}`;
+      });
+
+      const [a, b] = await Promise.all([
+        service.generateResetLink("a@example.com"),
+        service.generateResetLink("b@example.com"),
+      ]);
+
+      expect(a).toBe("https://example.test/reset/a@example.com");
+      expect(b).toBe("https://example.test/reset/b@example.com");
+    });
+  });
+});

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -14,6 +14,8 @@ import { InvitationEmail, MagicLinkEmail, ResetPasswordEmail, VerifyEmail } from
 
 interface AdminResetContext {
   capturedUrl: string | null;
+  emailSent: boolean;
+  emailViaOrgConfig: boolean;
 }
 
 @Injectable()
@@ -87,6 +89,10 @@ export class AuthService {
         enabled: true,
         minPasswordLength: 8,
         maxPasswordLength: 128,
+        // Revoke all existing sessions when a password is reset so a stolen or
+        // forgotten session can't be used after the user (or an admin) recovers
+        // the account.
+        revokeSessionsOnPasswordReset: true,
         sendResetPassword: async ({ user, url }) => {
           const ctx = this.adminResetStorage.getStore();
           if (ctx) {
@@ -94,12 +100,16 @@ export class AuthService {
           }
           const html = await render(ResetPasswordEmail({ url }));
           const organizationId = await this.getPrimaryOrgForUserId(user.id);
-          await this.mail.send(
+          const result = await this.mail.send(
             user.email,
             "Reset your password",
             html,
             organizationId,
           );
+          if (ctx) {
+            ctx.emailSent = result.sent;
+            ctx.emailViaOrgConfig = result.viaOrgConfig;
+          }
         },
       },
       emailVerification: {
@@ -232,9 +242,15 @@ export class AuthService {
     }
   }
 
-  async generateResetLink(email: string): Promise<string> {
+  async generateResetLink(
+    email: string,
+  ): Promise<{ url: string; emailSent: boolean; emailViaOrgConfig: boolean }> {
     const webUrl = this.config.get("WEB_URL", "http://localhost:3000");
-    const ctx: AdminResetContext = { capturedUrl: null };
+    const ctx: AdminResetContext = {
+      capturedUrl: null,
+      emailSent: false,
+      emailViaOrgConfig: false,
+    };
     await this.adminResetStorage.run(ctx, async () => {
       await this.auth.api.requestPasswordReset({
         body: {
@@ -246,6 +262,10 @@ export class AuthService {
     if (!ctx.capturedUrl) {
       throw new InternalServerErrorException("Reset URL was not captured");
     }
-    return ctx.capturedUrl;
+    return {
+      url: ctx.capturedUrl,
+      emailSent: ctx.emailSent,
+      emailViaOrgConfig: ctx.emailViaOrgConfig,
+    };
   }
 }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import * as Sentry from "@sentry/nestjs";
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
@@ -11,10 +12,15 @@ import { DEFAULT_STATUSES, DEFAULT_BRANDING } from "@atrium/shared";
 import { render } from "@react-email/render";
 import { InvitationEmail, MagicLinkEmail, ResetPasswordEmail, VerifyEmail } from "@atrium/email";
 
+interface AdminResetContext {
+  capturedUrl: string | null;
+}
+
 @Injectable()
 export class AuthService {
   public auth: ReturnType<typeof betterAuth>;
   private readonly logger = new Logger(AuthService.name);
+  private readonly adminResetStorage = new AsyncLocalStorage<AdminResetContext>();
 
   constructor(
     private config: ConfigService,
@@ -82,11 +88,17 @@ export class AuthService {
         minPasswordLength: 8,
         maxPasswordLength: 128,
         sendResetPassword: async ({ user, url }) => {
+          const ctx = this.adminResetStorage.getStore();
+          if (ctx) {
+            ctx.capturedUrl = url;
+          }
           const html = await render(ResetPasswordEmail({ url }));
+          const organizationId = await this.getPrimaryOrgForUserId(user.id);
           await this.mail.send(
             user.email,
             "Reset your password",
             html,
+            organizationId,
           );
         },
       },
@@ -95,10 +107,12 @@ export class AuthService {
         autoSignInAfterVerification: true,
         sendVerificationEmail: async ({ user, url }) => {
           const html = await render(VerifyEmail({ url }));
+          const organizationId = await this.getPrimaryOrgForUserId(user.id);
           await this.mail.send(
             user.email,
             "Verify your email address",
             html,
+            organizationId,
           );
         },
       },
@@ -117,6 +131,7 @@ export class AuthService {
               invitation.email,
               `You've been invited to ${organization.name}`,
               html,
+              organization.id,
             );
           },
           organizationHooks: {
@@ -134,7 +149,13 @@ export class AuthService {
         magicLink({
           sendMagicLink: async ({ email, url }) => {
             const html = await render(MagicLinkEmail({ url }));
-            await this.mail.send(email, "Sign in to Atrium", html);
+            const organizationId = await this.getPrimaryOrgForEmail(email);
+            await this.mail.send(
+              email,
+              "Sign in to Atrium",
+              html,
+              organizationId,
+            );
           },
         }),
       ],
@@ -173,5 +194,68 @@ export class AuthService {
 
   async handleRequest(request: Request) {
     return this.auth.handler(request);
+  }
+
+  /**
+   * Resolves the user's primary organization for routing auth emails
+   * through the right per-org email config. Picks the most recently
+   * created membership when the user belongs to multiple orgs.
+   */
+  async getPrimaryOrgForUserId(userId: string): Promise<string | undefined> {
+    try {
+      const member = await this.prisma.member.findFirst({
+        where: { userId },
+        orderBy: { createdAt: "desc" },
+        select: { organizationId: true },
+      });
+      return member?.organizationId;
+    } catch (err) {
+      this.logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Failed to resolve primary org for user",
+      );
+      return undefined;
+    }
+  }
+
+  async getPrimaryOrgForEmail(email: string): Promise<string | undefined> {
+    try {
+      const user = await this.prisma.user.findUnique({
+        where: { email },
+        select: { id: true },
+      });
+      if (!user) return undefined;
+      return this.getPrimaryOrgForUserId(user.id);
+    } catch (err) {
+      this.logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Failed to resolve primary org for email",
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Triggers Better Auth's request-password-reset flow and returns the
+   * reset URL that was issued. The URL is also delivered to the user
+   * via email through the standard sendResetPassword callback. Used by
+   * the admin-initiated reset flow so admins can share the link
+   * directly out-of-band when email is unreliable or unconfigured.
+   */
+  async generateResetLink(email: string): Promise<string> {
+    const webUrl = this.config.get("WEB_URL", "http://localhost:3000");
+    const ctx: AdminResetContext = { capturedUrl: null };
+    await this.adminResetStorage.run(ctx, async () => {
+      await this.auth.api.requestPasswordReset({
+        body: {
+          email,
+          redirectTo: `${webUrl}/reset-password`,
+        },
+      });
+    });
+    if (!ctx.capturedUrl) {
+      throw new Error("Reset URL was not captured");
+    }
+    return ctx.capturedUrl;
   }
 }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import * as Sentry from "@sentry/nestjs";
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, InternalServerErrorException, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
@@ -196,11 +196,8 @@ export class AuthService {
     return this.auth.handler(request);
   }
 
-  /**
-   * Resolves the user's primary organization for routing auth emails
-   * through the right per-org email config. Picks the most recently
-   * created membership when the user belongs to multiple orgs.
-   */
+  // Picks the most recently created membership when the user belongs to
+  // multiple orgs — used to route auth emails through per-org email config.
   async getPrimaryOrgForUserId(userId: string): Promise<string | undefined> {
     try {
       const member = await this.prisma.member.findFirst({
@@ -220,12 +217,12 @@ export class AuthService {
 
   async getPrimaryOrgForEmail(email: string): Promise<string | undefined> {
     try {
-      const user = await this.prisma.user.findUnique({
-        where: { email },
-        select: { id: true },
+      const member = await this.prisma.member.findFirst({
+        where: { user: { email } },
+        orderBy: { createdAt: "desc" },
+        select: { organizationId: true },
       });
-      if (!user) return undefined;
-      return this.getPrimaryOrgForUserId(user.id);
+      return member?.organizationId;
     } catch (err) {
       this.logger.warn(
         { err: err instanceof Error ? err.message : String(err) },
@@ -235,13 +232,6 @@ export class AuthService {
     }
   }
 
-  /**
-   * Triggers Better Auth's request-password-reset flow and returns the
-   * reset URL that was issued. The URL is also delivered to the user
-   * via email through the standard sendResetPassword callback. Used by
-   * the admin-initiated reset flow so admins can share the link
-   * directly out-of-band when email is unreliable or unconfigured.
-   */
   async generateResetLink(email: string): Promise<string> {
     const webUrl = this.config.get("WEB_URL", "http://localhost:3000");
     const ctx: AdminResetContext = { capturedUrl: null };
@@ -254,7 +244,7 @@ export class AuthService {
       });
     });
     if (!ctx.capturedUrl) {
-      throw new Error("Reset URL was not captured");
+      throw new InternalServerErrorException("Reset URL was not captured");
     }
     return ctx.capturedUrl;
   }

--- a/apps/api/src/clients/clients.controller.ts
+++ b/apps/api/src/clients/clients.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Delete,
+  Post,
   Put,
   Body,
   Param,
@@ -182,6 +183,22 @@ export class ClientsController {
     @CurrentMember("role") role: string,
   ) {
     await this.clientsService.removeMember(memberId, orgId, userId, role);
+  }
+
+  @Post(":id/reset-password")
+  @Roles("owner", "admin")
+  async resetPassword(
+    @Param("id") memberId: string,
+    @CurrentOrg("id") orgId: string,
+    @CurrentUser("id") userId: string,
+    @CurrentMember("role") role: string,
+  ) {
+    return this.clientsService.generateResetLink(
+      memberId,
+      orgId,
+      userId,
+      role,
+    );
   }
 
   @Put(":id/role")

--- a/apps/api/src/clients/clients.module.ts
+++ b/apps/api/src/clients/clients.module.ts
@@ -1,8 +1,10 @@
 import { Module } from "@nestjs/common";
 import { ClientsController } from "./clients.controller";
 import { ClientsService } from "./clients.service";
+import { AuthModule } from "../auth/auth.module";
 
 @Module({
+  imports: [AuthModule],
   controllers: [ClientsController],
   providers: [ClientsService],
 })

--- a/apps/api/src/clients/clients.service.spec.ts
+++ b/apps/api/src/clients/clients.service.spec.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, mock, beforeEach } from "bun:test";
 import { ClientsService } from "./clients.service";
-import { NotFoundException, BadRequestException } from "@nestjs/common";
+import {
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from "@nestjs/common";
 import type { PrismaService } from "../prisma/prisma.service";
+import type { AuthService } from "../auth/auth.service";
 
 interface PrismaArgs {
   where?: Record<string, unknown>;
@@ -29,6 +34,12 @@ const mockPrisma = {
   $transaction: mock((ops: Promise<unknown>[]) => Promise.all(ops)),
 };
 
+const mockAuthService = {
+  generateResetLink: mock(() =>
+    Promise.resolve("https://api.test/api/auth/reset-password/abc?callbackURL=foo"),
+  ),
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -54,7 +65,10 @@ describe("ClientsService", () => {
   let service: ClientsService;
 
   beforeEach(() => {
-    service = new ClientsService(mockPrisma as unknown as PrismaService);
+    service = new ClientsService(
+      mockPrisma as unknown as PrismaService,
+      mockAuthService as unknown as AuthService,
+    );
     // Reset all mocks before each test so state does not leak
     mockPrisma.member.findFirst.mockClear();
     mockPrisma.member.count.mockClear();
@@ -63,6 +77,7 @@ describe("ClientsService", () => {
     mockPrisma.project.findMany.mockClear();
     mockPrisma.projectClient.deleteMany.mockClear();
     mockPrisma.$transaction.mockClear();
+    mockAuthService.generateResetLink.mockClear();
   });
 
   // -------------------------------------------------------------------------
@@ -300,6 +315,136 @@ describe("ClientsService", () => {
 
       // count should NOT have been called — only needed when demoting an owner
       expect(mockPrisma.member.count).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // generateResetLink
+  // -------------------------------------------------------------------------
+  describe("generateResetLink", () => {
+    function memberWithUser(overrides: Partial<{ id: string; userId: string; role: string }> = {}) {
+      const m = makeMember(overrides);
+      return { ...m, user: { id: m.userId, email: `${m.userId}@test.com` } };
+    }
+
+    it("throws NotFoundException when the member does not exist", async () => {
+      mockPrisma.member.findFirst.mockReturnValue(Promise.resolve(null));
+
+      try {
+        await service.generateResetLink(
+          "missing-member",
+          "org-1",
+          "user-admin",
+          "admin",
+        );
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toBeInstanceOf(NotFoundException);
+      }
+    });
+
+    it("throws BadRequestException when caller targets themselves", async () => {
+      const selfMember = memberWithUser({
+        id: "member-self",
+        userId: "user-self",
+        role: "admin",
+      });
+      mockPrisma.member.findFirst.mockReturnValue(Promise.resolve(selfMember));
+
+      try {
+        await service.generateResetLink(
+          "member-self",
+          "org-1",
+          "user-self",
+          "admin",
+        );
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toBeInstanceOf(BadRequestException);
+      }
+      expect(mockAuthService.generateResetLink).not.toHaveBeenCalled();
+    });
+
+    it("throws ForbiddenException when admin tries to reset an owner", async () => {
+      const ownerMember = memberWithUser({
+        id: "member-owner",
+        userId: "user-owner",
+        role: "owner",
+      });
+      mockPrisma.member.findFirst.mockReturnValue(Promise.resolve(ownerMember));
+
+      try {
+        await service.generateResetLink(
+          "member-owner",
+          "org-1",
+          "user-admin",
+          "admin",
+        );
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e).toBeInstanceOf(ForbiddenException);
+      }
+      expect(mockAuthService.generateResetLink).not.toHaveBeenCalled();
+    });
+
+    it("allows owner to reset another owner", async () => {
+      const otherOwner = memberWithUser({
+        id: "member-owner-2",
+        userId: "user-owner-2",
+        role: "owner",
+      });
+      mockPrisma.member.findFirst.mockReturnValue(Promise.resolve(otherOwner));
+
+      const result = await service.generateResetLink(
+        "member-owner-2",
+        "org-1",
+        "user-owner-1",
+        "owner",
+      );
+
+      expect(result.email).toBe("user-owner-2@test.com");
+      expect(mockAuthService.generateResetLink).toHaveBeenCalledWith(
+        "user-owner-2@test.com",
+      );
+    });
+
+    it("returns the URL and email when admin resets a regular member", async () => {
+      const member = memberWithUser({
+        id: "member-1",
+        userId: "user-target",
+        role: "member",
+      });
+      mockPrisma.member.findFirst.mockReturnValue(Promise.resolve(member));
+
+      const result = await service.generateResetLink(
+        "member-1",
+        "org-1",
+        "user-admin",
+        "admin",
+      );
+
+      expect(result.email).toBe("user-target@test.com");
+      expect(result.url).toContain("/reset-password/");
+      expect(mockAuthService.generateResetLink).toHaveBeenCalledWith(
+        "user-target@test.com",
+      );
+    });
+
+    it("scopes member lookup to the caller's org", async () => {
+      const member = memberWithUser({
+        id: "member-1",
+        userId: "user-target",
+        role: "member",
+      });
+      mockPrisma.member.findFirst.mockReturnValue(Promise.resolve(member));
+
+      await service.generateResetLink("member-1", "org-1", "user-admin", "admin");
+
+      expect(mockPrisma.member.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "member-1", organizationId: "org-1" },
+        }),
+      );
     });
   });
 });

--- a/apps/api/src/clients/clients.service.spec.ts
+++ b/apps/api/src/clients/clients.service.spec.ts
@@ -69,7 +69,6 @@ describe("ClientsService", () => {
       mockPrisma as unknown as PrismaService,
       mockAuthService as unknown as AuthService,
     );
-    // Reset all mocks before each test so state does not leak
     mockPrisma.member.findFirst.mockClear();
     mockPrisma.member.count.mockClear();
     mockPrisma.member.delete.mockClear();

--- a/apps/api/src/clients/clients.service.spec.ts
+++ b/apps/api/src/clients/clients.service.spec.ts
@@ -36,7 +36,11 @@ const mockPrisma = {
 
 const mockAuthService = {
   generateResetLink: mock(() =>
-    Promise.resolve("https://api.test/api/auth/reset-password/abc?callbackURL=foo"),
+    Promise.resolve({
+      url: "https://api.test/api/auth/reset-password/abc?callbackURL=foo",
+      emailSent: true,
+      emailViaOrgConfig: true,
+    }),
   ),
 };
 
@@ -424,9 +428,36 @@ describe("ClientsService", () => {
 
       expect(result.email).toBe("user-target@test.com");
       expect(result.url).toContain("/reset-password/");
+      expect(result.emailSent).toBe(true);
       expect(mockAuthService.generateResetLink).toHaveBeenCalledWith(
         "user-target@test.com",
       );
+    });
+
+    it("propagates emailSent=false when email delivery is not configured", async () => {
+      const member = memberWithUser({
+        id: "member-1",
+        userId: "user-target",
+        role: "member",
+      });
+      mockPrisma.member.findFirst.mockReturnValue(Promise.resolve(member));
+      mockAuthService.generateResetLink.mockReturnValueOnce(
+        Promise.resolve({
+          url: "https://api.test/api/auth/reset-password/xyz",
+          emailSent: false,
+          emailViaOrgConfig: false,
+        }),
+      );
+
+      const result = await service.generateResetLink(
+        "member-1",
+        "org-1",
+        "user-admin",
+        "admin",
+      );
+
+      expect(result.emailSent).toBe(false);
+      expect(result.emailViaOrgConfig).toBe(false);
     });
 
     it("scopes member lookup to the caller's org", async () => {

--- a/apps/api/src/clients/clients.service.ts
+++ b/apps/api/src/clients/clients.service.ts
@@ -2,13 +2,42 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
 } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service";
+import { AuthService } from "../auth/auth.service";
 import { UpdateClientProfileDto } from "./client-profile.dto";
 
 @Injectable()
 export class ClientsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private authService: AuthService,
+  ) {}
+
+  async generateResetLink(
+    memberId: string,
+    orgId: string,
+    requestingUserId: string,
+    requestingRole: string,
+  ): Promise<{ url: string; email: string }> {
+    const member = await this.prisma.member.findFirst({
+      where: { id: memberId, organizationId: orgId },
+      include: { user: { select: { id: true, email: true } } },
+    });
+    if (!member) throw new NotFoundException("Member not found");
+    if (member.userId === requestingUserId) {
+      throw new BadRequestException(
+        "Cannot reset your own password — use forgot-password instead",
+      );
+    }
+    if (member.role === "owner" && requestingRole !== "owner") {
+      throw new ForbiddenException("Only owners can reset another owner");
+    }
+
+    const url = await this.authService.generateResetLink(member.user.email);
+    return { url, email: member.user.email };
+  }
 
   async removeMember(
     memberId: string,

--- a/apps/api/src/clients/clients.service.ts
+++ b/apps/api/src/clients/clients.service.ts
@@ -20,7 +20,12 @@ export class ClientsService {
     orgId: string,
     requestingUserId: string,
     requestingRole: string,
-  ): Promise<{ url: string; email: string }> {
+  ): Promise<{
+    url: string;
+    email: string;
+    emailSent: boolean;
+    emailViaOrgConfig: boolean;
+  }> {
     const member = await this.prisma.member.findFirst({
       where: { id: memberId, organizationId: orgId },
       include: { user: { select: { id: true, email: true } } },
@@ -35,8 +40,14 @@ export class ClientsService {
       throw new ForbiddenException("Only owners can reset another owner");
     }
 
-    const url = await this.authService.generateResetLink(member.user.email);
-    return { url, email: member.user.email };
+    const { url, emailSent, emailViaOrgConfig } =
+      await this.authService.generateResetLink(member.user.email);
+    return {
+      url,
+      email: member.user.email,
+      emailSent,
+      emailViaOrgConfig,
+    };
   }
 
   async removeMember(

--- a/apps/api/src/mail/mail.service.spec.ts
+++ b/apps/api/src/mail/mail.service.spec.ts
@@ -53,6 +53,7 @@ interface EmailConfig {
   from?: string;
   apiKey?: string | null;
   smtp?: Record<string, unknown> | null;
+  isOrgConfigured?: boolean;
 }
 
 function makeSettingsService(emailConfig: EmailConfig | null = null) {
@@ -83,6 +84,7 @@ describe("MailService", () => {
       provider: "smtp",
       from: "noreply@example.com",
       smtp: smtpConfig,
+      isOrgConfigured: true,
     });
 
     const config = makeConfig();
@@ -115,6 +117,7 @@ describe("MailService", () => {
         provider: "smtp",
         from: "noreply@example.com",
         smtp: cfg,
+        isOrgConfigured: true,
       });
     });
 
@@ -139,6 +142,7 @@ describe("MailService", () => {
       apiKey: "re_test_key",
       from: "noreply@example.com",
       smtp: null,
+      isOrgConfigured: true,
     });
 
     const service = new MailService(

--- a/apps/api/src/mail/mail.service.ts
+++ b/apps/api/src/mail/mail.service.ts
@@ -53,13 +53,21 @@ export class MailService {
     return transporter;
   }
 
-  async send(to: string, subject: string, html: string, organizationId?: string) {
-    // If an organizationId is provided, try to use DB-configured email settings
+  async send(
+    to: string,
+    subject: string,
+    html: string,
+    organizationId?: string,
+  ): Promise<{ sent: boolean; viaOrgConfig: boolean }> {
     if (organizationId) {
       try {
         const emailConfig = await this.settingsService.getEffectiveEmailConfig(organizationId);
 
-        if (emailConfig.provider === "resend" && emailConfig.apiKey) {
+        if (
+          emailConfig.isOrgConfigured &&
+          emailConfig.provider === "resend" &&
+          emailConfig.apiKey
+        ) {
           const resend = new Resend(emailConfig.apiKey);
           await resend.emails.send({
             from: emailConfig.from,
@@ -68,10 +76,14 @@ export class MailService {
             html,
           });
           this.logger.info({ to, subject }, "Email sent via DB-configured Resend");
-          return;
+          return { sent: true, viaOrgConfig: true };
         }
 
-        if (emailConfig.provider === "smtp" && emailConfig.smtp) {
+        if (
+          emailConfig.isOrgConfigured &&
+          emailConfig.provider === "smtp" &&
+          emailConfig.smtp
+        ) {
           const transporter = this.getSmtpTransporter(emailConfig.smtp, organizationId);
           await transporter.sendMail({
             from: emailConfig.from,
@@ -80,10 +92,8 @@ export class MailService {
             html,
           });
           this.logger.info({ to, subject }, "Email sent via DB-configured SMTP");
-          return;
+          return { sent: true, viaOrgConfig: true };
         }
-
-        // If DB config has no provider set, fall through to env-var fallback
       } catch (err) {
         this.logger.warn(
           { error: err instanceof Error ? err.message : String(err) },
@@ -92,10 +102,9 @@ export class MailService {
       }
     }
 
-    // Fallback: use env-var configured Resend client
     if (!this.resend) {
       this.logger.info({ to, subject }, "Email not sent (no email provider configured)");
-      return;
+      return { sent: false, viaOrgConfig: false };
     }
 
     await this.resend.emails.send({
@@ -104,6 +113,7 @@ export class MailService {
       subject,
       html,
     });
-    this.logger.info({ to, subject }, "Email sent");
+    this.logger.info({ to, subject }, "Email sent via env-var Resend");
+    return { sent: true, viaOrgConfig: false };
   }
 }

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -157,6 +157,7 @@ export class SettingsService {
       provider,
       apiKey,
       from,
+      isOrgConfigured: !!settings?.emailProvider,
       smtp: provider === "smtp"
         ? {
             host: settings?.smtpHost ?? null,

--- a/apps/web/src/app/(auth)/forgot-password/page.tsx
+++ b/apps/web/src/app/(auth)/forgot-password/page.tsx
@@ -17,7 +17,7 @@ export default function ForgotPasswordPage() {
     setError("");
 
     try {
-      const res = await fetch(`${API_URL}/api/auth/forget-password`, {
+      const res = await fetch(`${API_URL}/api/auth/request-password-reset`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
@@ -5,7 +5,7 @@ import { apiFetch } from "@/lib/api";
 import { useConfirm } from "@/components/confirm-modal";
 import { useToast } from "@/components/toast";
 import { ClientItemSkeleton } from "@/components/skeletons";
-import { UserPlus, Copy, Check, Trash2, ChevronDown, ChevronRight, UsersRound, Download, Sparkles, ExternalLink } from "lucide-react";
+import { UserPlus, Copy, Check, Trash2, ChevronDown, ChevronRight, UsersRound, Download, Sparkles, ExternalLink, KeyRound, X } from "lucide-react";
 import { track } from "@/lib/track";
 import { LabelBadge } from "@/components/label-badge";
 import { downloadCsv } from "@/lib/download";
@@ -98,6 +98,10 @@ export default function PeoplePage() {
   const [editingProfile, setEditingProfile] = useState<Record<string, ClientProfile>>({});
   const [savingProfile, setSavingProfile] = useState<string | null>(null);
 
+  // Admin password reset state
+  const [resetLink, setResetLink] = useState<{ url: string; email: string } | null>(null);
+  const [resettingMemberId, setResettingMemberId] = useState<string | null>(null);
+
   useEffect(() => {
     apiFetch<{ user: { id: string } }>("/auth/get-session")
       .then((session) => setCurrentUserId(session.user.id))
@@ -177,6 +181,28 @@ export default function PeoplePage() {
       }
     } catch (err) {
       showError(err instanceof Error ? err.message : "Failed to remove");
+    }
+  };
+
+  const handleResetPassword = async (memberId: string, email: string) => {
+    const ok = await confirm({
+      title: "Send Password Reset Link",
+      message: `Generate a password reset link for ${email}? An email will also be sent if email delivery is configured. You'll see the link here so you can share it directly if needed.`,
+      confirmLabel: "Generate Link",
+    });
+    if (!ok) return;
+    setResettingMemberId(memberId);
+    try {
+      const res = await apiFetch<{ url: string; email: string }>(
+        `/clients/${memberId}/reset-password`,
+        { method: "POST" },
+      );
+      setResetLink(res);
+      success(`Reset link generated for ${res.email}`);
+    } catch (err) {
+      showError(err instanceof Error ? err.message : "Failed to generate reset link");
+    } finally {
+      setResettingMemberId(null);
     }
   };
 
@@ -319,6 +345,41 @@ export default function PeoplePage() {
           <span className="hidden sm:inline">Export</span>
         </button>
       </div>
+
+      {/* Reset link banner — shown after admin generates a reset link */}
+      {resetLink && (
+        <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-sm text-green-800 font-medium">
+              Password reset link for {resetLink.email}
+            </p>
+            <button
+              onClick={() => setResetLink(null)}
+              className="p-1 text-green-700 hover:text-green-900"
+              title="Dismiss"
+            >
+              <X size={14} />
+            </button>
+          </div>
+          <p className="text-xs text-green-700 mb-2">
+            Share this link with the user. It expires in 1 hour. Refreshing the page will not retrieve it.
+          </p>
+          <div className="flex items-center gap-2">
+            <input
+              readOnly
+              value={resetLink.url}
+              className="flex-1 px-2 py-1 text-sm bg-white border border-green-300 rounded font-mono"
+            />
+            <button
+              onClick={() => copyLink(resetLink.url)}
+              className="flex items-center gap-1 px-3 py-1 text-sm bg-green-600 text-white rounded hover:bg-green-700"
+            >
+              {copied === resetLink.url ? <Check size={14} /> : <Copy size={14} />}
+              {copied === resetLink.url ? "Copied!" : "Copy"}
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Tabs */}
       <div className="relative">
@@ -488,6 +549,8 @@ export default function PeoplePage() {
                   const isSelf = member.userId === currentUserId;
                   const canChangeRole = isOwner && !isSelf;
                   const canRemove = isOwner && !isSelf;
+                  const canResetPassword =
+                    !isSelf && (isOwner || (currentRole === "admin" && member.role !== "owner"));
 
                   return (
                     <div
@@ -519,6 +582,16 @@ export default function PeoplePage() {
                           <span className={`text-xs px-2 py-1 rounded-full ${roleColor(member.role)}`}>
                             {member.role}
                           </span>
+                        )}
+                        {canResetPassword && (
+                          <button
+                            onClick={() => handleResetPassword(member.id, member.user.email)}
+                            disabled={resettingMemberId === member.id}
+                            className="p-1.5 text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors disabled:opacity-50"
+                            title="Send password reset link"
+                          >
+                            <KeyRound size={14} />
+                          </button>
                         )}
                         {canRemove && (
                           <button
@@ -704,6 +777,14 @@ export default function PeoplePage() {
                           </div>
                         </div>
                         <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+                          <button
+                            onClick={() => handleResetPassword(member.id, member.user.email)}
+                            disabled={resettingMemberId === member.id}
+                            className="p-1.5 text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors disabled:opacity-50"
+                            title="Send password reset link"
+                          >
+                            <KeyRound size={14} />
+                          </button>
                           <button
                             onClick={() => handleRemoveMember(member.id, member.user.name, false)}
                             className="p-1.5 text-[var(--muted-foreground)] hover:text-red-500 transition-colors"

--- a/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
@@ -98,7 +98,12 @@ export default function PeoplePage() {
   const [editingProfile, setEditingProfile] = useState<Record<string, ClientProfile>>({});
   const [savingProfile, setSavingProfile] = useState<string | null>(null);
 
-  const [resetLink, setResetLink] = useState<{ url: string; email: string } | null>(null);
+  const [resetLink, setResetLink] = useState<{
+    url: string;
+    email: string;
+    emailSent: boolean;
+    emailViaOrgConfig: boolean;
+  } | null>(null);
   const [resettingMemberId, setResettingMemberId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -192,12 +197,18 @@ export default function PeoplePage() {
     if (!ok) return;
     setResettingMemberId(memberId);
     try {
-      const res = await apiFetch<{ url: string; email: string }>(
-        `/clients/${memberId}/reset-password`,
-        { method: "POST" },
-      );
+      const res = await apiFetch<{
+        url: string;
+        email: string;
+        emailSent: boolean;
+        emailViaOrgConfig: boolean;
+      }>(`/clients/${memberId}/reset-password`, { method: "POST" });
       setResetLink(res);
-      success(`Reset link generated for ${res.email}`);
+      success(
+        res.emailViaOrgConfig
+          ? `Reset link emailed to ${res.email}`
+          : `Reset link generated for ${res.email}`,
+      );
     } catch (err) {
       showError(err instanceof Error ? err.message : "Failed to generate reset link");
     } finally {
@@ -346,35 +357,76 @@ export default function PeoplePage() {
       </div>
 
       {resetLink && (
-        <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
-          <div className="flex items-center justify-between mb-2">
-            <p className="text-sm text-green-800 font-medium">
-              Password reset link for {resetLink.email}
-            </p>
-            <button
-              onClick={() => setResetLink(null)}
-              className="p-1 text-green-700 hover:text-green-900"
-              title="Dismiss"
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setResetLink(null);
+          }}
+        >
+          <div className="bg-[var(--background)] rounded-xl shadow-lg w-full max-w-md p-6 space-y-4">
+            <div className="flex items-start justify-between">
+              <div>
+                <h3 className="text-lg font-semibold">Password reset link</h3>
+                <p className="text-sm text-[var(--muted-foreground)] mt-0.5">
+                  For {resetLink.email}
+                </p>
+              </div>
+              <button
+                onClick={() => setResetLink(null)}
+                className="p-1 text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                aria-label="Close"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            <div
+              className={
+                resetLink.emailViaOrgConfig
+                  ? "p-3 rounded-lg text-sm bg-green-50 text-green-800 border border-green-200"
+                  : "p-3 rounded-lg text-sm bg-amber-50 text-amber-900 border border-amber-200"
+              }
             >
-              <X size={14} />
-            </button>
-          </div>
-          <p className="text-xs text-green-700 mb-2">
-            Share this link with the user. It expires in 1 hour. Refreshing the page will not retrieve it.
-          </p>
-          <div className="flex items-center gap-2">
-            <input
-              readOnly
-              value={resetLink.url}
-              className="flex-1 px-2 py-1 text-sm bg-white border border-green-300 rounded font-mono"
-            />
-            <button
-              onClick={() => copyLink(resetLink.url)}
-              className="flex items-center gap-1 px-3 py-1 text-sm bg-green-600 text-white rounded hover:bg-green-700"
-            >
-              {copied === resetLink.url ? <Check size={14} /> : <Copy size={14} />}
-              {copied === resetLink.url ? "Copied!" : "Copy"}
-            </button>
+              {resetLink.emailViaOrgConfig
+                ? `An email with this link was sent to ${resetLink.email} via your organization's email config.`
+                : resetLink.emailSent
+                  ? `Sent via the platform default to ${resetLink.email}. If it doesn't arrive, share the link below directly.`
+                  : "No email provider is configured, so no email was sent. Copy the link below and share it with the user directly."}
+            </div>
+
+            <div className="space-y-2">
+              <label className="block text-xs font-medium text-[var(--muted-foreground)]">
+                Reset link (expires in 1 hour)
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  readOnly
+                  value={resetLink.url}
+                  onFocus={(e) => e.currentTarget.select()}
+                  autoFocus
+                  className="flex-1 px-2 py-1.5 text-sm bg-[var(--muted)] text-[var(--foreground)] border border-[var(--border)] rounded font-mono"
+                />
+                <button
+                  onClick={() => copyLink(resetLink.url)}
+                  className="flex items-center gap-1 px-3 py-1.5 text-sm bg-[var(--primary)] text-white rounded hover:opacity-90"
+                >
+                  {copied === resetLink.url ? <Check size={14} /> : <Copy size={14} />}
+                  {copied === resetLink.url ? "Copied!" : "Copy"}
+                </button>
+              </div>
+              <p className="text-xs text-[var(--muted-foreground)]">
+                Refreshing the page will not retrieve this link again.
+              </p>
+            </div>
+
+            <div className="flex justify-end">
+              <button
+                onClick={() => setResetLink(null)}
+                className="px-4 py-1.5 border border-[var(--border)] rounded-lg text-sm hover:bg-[var(--muted)] transition-colors"
+              >
+                Done
+              </button>
+            </div>
           </div>
         </div>
       )}
@@ -487,7 +539,7 @@ export default function PeoplePage() {
                     <input
                       readOnly
                       value={teamInviteLink}
-                      className="flex-1 px-2 py-1 text-sm bg-white border border-green-300 rounded font-mono"
+                      className="flex-1 px-2 py-1 text-sm bg-white text-gray-900 border border-green-300 rounded font-mono"
                     />
                     <button
                       onClick={() => copyLink(teamInviteLink)}

--- a/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
@@ -98,7 +98,6 @@ export default function PeoplePage() {
   const [editingProfile, setEditingProfile] = useState<Record<string, ClientProfile>>({});
   const [savingProfile, setSavingProfile] = useState<string | null>(null);
 
-  // Admin password reset state
   const [resetLink, setResetLink] = useState<{ url: string; email: string } | null>(null);
   const [resettingMemberId, setResettingMemberId] = useState<string | null>(null);
 
@@ -346,7 +345,6 @@ export default function PeoplePage() {
         </button>
       </div>
 
-      {/* Reset link banner — shown after admin generates a reset link */}
       {resetLink && (
         <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
           <div className="flex items-center justify-between mb-2">

--- a/docs/superpowers/specs/2026-04-27-auth-email-org-config-and-admin-reset-design.md
+++ b/docs/superpowers/specs/2026-04-27-auth-email-org-config-and-admin-reset-design.md
@@ -1,0 +1,113 @@
+# Auth email per-org config + admin password reset
+
+Issue: [#40](https://github.com/Vibra-Labs/Atrium/issues/40)
+
+## Background
+
+A user reported that password reset emails never arrive on Atrium Cloud. They configured email in System Settings, tried "Forgot password" both for an invited customer and for themselves, and received nothing. They also asked whether selfhosters have any way to reset a customer's password without relying on email at all.
+
+Investigation traced the issue to `apps/api/src/auth/auth.service.ts`. All four Better Auth email callbacks (`sendResetPassword`, `sendVerificationEmail`, `sendInvitationEmail`, `sendMagicLink`) call `mail.send(...)` without passing an `organizationId`. `MailService.send` only consults the per-org System Settings email config when `organizationId` is provided (`apps/api/src/mail/mail.service.ts:58`); without it, the call falls through to the env-var Resend client and silently no-ops if that isn't configured. The result: any auth email completely bypasses per-org SMTP/Resend, even when the user has set it up via the UI.
+
+Separately, when reset email delivery does fail (spam filters, deliverability issues, no email provider), there is no admin path to recover access. The only workaround is editing `account.password` directly in Postgres.
+
+## Goals
+
+- Auth emails (reset password, verify email, invitation, magic link) honor the recipient organization's System Settings email config.
+- Owners and admins can generate a password reset link for a member from the Clients page, with the link displayed in the UI for out-of-band sharing and an email also sent when a provider is configured.
+
+## Non-goals
+
+- Admin "set new password directly" UX. Reset link only — the customer still chooses their own password.
+- Branded reset/invitation emails per org. Templates remain generic.
+- Multi-org email-style preferences. A user belonging to multiple orgs gets one org's config used for their auth emails.
+
+## Part 1 — Auth email per-org config
+
+### Change
+
+Each callback in `auth.service.ts` resolves the `organizationId` for the recipient and passes it to `mail.send`.
+
+| Callback | `organizationId` source |
+|---|---|
+| `sendResetPassword({ user })` | Look up `Member` rows for `user.id`, take the most recently created. If none, omit `organizationId`. |
+| `sendVerificationEmail({ user })` | Same as above. |
+| `sendInvitationEmail({ organization })` | `organization.id` directly. |
+| `sendMagicLink({ email })` | Look up `User` by email, then `Member` as above. If no user/member, omit `organizationId`. |
+
+A small helper on `AuthService` resolves the primary org for a user id or email, returning `string | undefined`. Both reset and verify use the user-id form; magic link uses the email form.
+
+### Multi-org tradeoff
+
+Some users (e.g. an agency owner who is also a client of another agency on the same Atrium instance) belong to multiple orgs. Picking the most recent `Member` row is a heuristic — it usually means "the org that most recently invited them," which is the most likely intent for verify and invitation emails. For reset password, the user could request from either context; the most recent membership is still a reasonable default and matches the more active relationship. Acceptable. If this becomes a problem, we can later surface "which org are you resetting against" via the forgot-password form.
+
+### Tests
+
+Extend `mail.service.spec.ts` is already covered. New unit tests on `auth.service` mock `mail.send` and verify each of the four callbacks passes the expected `organizationId`. Add an e2e test that configures a mock SMTP for an org, triggers `forget-password`, and asserts the request hits the org's SMTP rather than the env-var Resend (or, if mocking SMTP is too heavy, asserts via spy that `mail.send` was called with the right `organizationId`).
+
+## Part 2 — Admin reset link
+
+### API
+
+`POST /clients/:memberId/reset-password` — owner + admin. Returns `{ url: string, email: string }`.
+
+Service flow:
+1. Resolve the target `Member` row, scoped to caller's org. 404 if not found.
+2. Validate caller permissions:
+   - Caller cannot be the target. (Use `forgot-password` for self.)
+   - If target role is `owner`, caller role must be `owner`.
+3. Enter an `AsyncLocalStorage` context with a slot for the captured URL.
+4. Call `auth.api.forgetPassword({ body: { email: target.user.email, redirectTo: '${WEB_URL}/reset-password' } })`. Better Auth generates the token and invokes our `sendResetPassword` callback.
+5. Inside `sendResetPassword`, when the ALS context is active, write the URL into the slot. Email send still happens via `mail.send` (now with org config from Part 1).
+6. Read URL from ALS context, return `{ url, email: target.user.email }`.
+
+### Why ALS
+
+Better Auth's public API only surfaces the reset URL inside the `sendResetPassword` callback. Alternatives:
+- A module-level `Map<email, url>` is race-prone if two admins reset the same email simultaneously.
+- Replicating Better Auth's verification-token format ourselves means duplicating internal schema (token shape, expiry, table layout) and risks drift on Better Auth upgrades.
+
+`AsyncLocalStorage` is the standard Node pattern for request-scoped data and is unaffected by concurrent requests.
+
+### Permissions
+
+Mirrors existing `clients.service.ts` patterns:
+- `@Roles("owner", "admin")` on the controller.
+- Service-level checks for self-reset and owner-target rules.
+
+### UI
+
+`apps/web/src/app/(dashboard)/dashboard/clients/page.tsx`:
+
+- Each row gets a "Reset password" action (kebab menu or new icon button alongside existing actions).
+- Click opens a confirmation modal: "Generate a password reset link for {email}? An email will also be sent if email is configured."
+- On confirm, POST to the new endpoint. Replace modal content with:
+  - "Reset link generated for {email}."
+  - Readonly input containing the URL.
+  - Copy button.
+  - Note: "This link expires in 1 hour. Refreshing this page will not retrieve it."
+- Closing the modal discards the link from UI state.
+
+### E2E test
+
+`e2e/tests/clients-admin-reset.e2e.ts`:
+1. Owner logs in, invites a member, member accepts, members logs out.
+2. Owner clicks "Reset password" on the member row.
+3. Modal appears with a URL.
+4. New page navigates to that URL → `/reset-password?token=...` page renders.
+5. Member submits a new password → can log in with it.
+
+## Acceptance criteria
+
+- [ ] All four auth callbacks pass `organizationId` to `mail.send` (or omit it deliberately when no org context exists).
+- [ ] Forgot-password flow uses the recipient org's SMTP/Resend when configured in System Settings.
+- [ ] `POST /clients/:memberId/reset-password` returns `{ url, email }` and triggers email send through the same org-aware path.
+- [ ] Permission rules enforced: not self, owners-only-reset-owners.
+- [ ] Clients page UI exposes the action and shows the link in a copy-friendly modal.
+- [ ] E2E test covers admin-triggered reset end to end.
+- [ ] Unit tests cover the four callback `organizationId` lookups and the new permission rules.
+
+## Out of scope
+
+- Custom token expiry for admin-issued links (uses Better Auth default, currently 1 hour).
+- Audit log for admin reset actions. Worth adding later if/when Atrium grows a generic audit-log surface; not justified to bolt one in for this single action.
+- Bulk reset.

--- a/e2e/tests/admin-reset-password.e2e.ts
+++ b/e2e/tests/admin-reset-password.e2e.ts
@@ -3,10 +3,6 @@ import { test, expect } from "@playwright/test";
 const API_URL = "http://localhost:3001";
 const WEB_URL = "http://localhost:3000";
 
-/**
- * Helper: create an owner user with an org via the onboarding API,
- * then establish a browser session for that user.
- */
 async function createOwnerUser(
   browser: import("@playwright/test").Browser,
   prefix = "reset-owner",
@@ -56,10 +52,6 @@ async function createOwnerUser(
   return { context, page, email, password, orgName };
 }
 
-/**
- * Helper: create a client user, invite them, and have them accept.
- * Returns the client's email + original password.
- */
 async function createAndAcceptClient(
   browser: import("@playwright/test").Browser,
   ownerPage: import("@playwright/test").Page,

--- a/e2e/tests/admin-reset-password.e2e.ts
+++ b/e2e/tests/admin-reset-password.e2e.ts
@@ -1,0 +1,176 @@
+import { test, expect } from "@playwright/test";
+
+const API_URL = "http://localhost:3001";
+const WEB_URL = "http://localhost:3000";
+
+/**
+ * Helper: create an owner user with an org via the onboarding API,
+ * then establish a browser session for that user.
+ */
+async function createOwnerUser(
+  browser: import("@playwright/test").Browser,
+  prefix = "reset-owner",
+) {
+  const context = await browser.newContext({ storageState: undefined });
+  const page = await context.newPage();
+
+  const orgName = `${prefix} Org ${Date.now().toString(36)}`;
+  const email = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
+  const password = "ResetOwner123!";
+
+  const res = await page.request.post(`${API_URL}/api/onboarding/signup`, {
+    data: { name: "Reset Owner", email, password, orgName },
+  });
+  if (!res.ok()) {
+    throw new Error(`Owner signup failed (${res.status()}): ${await res.text()}`);
+  }
+
+  await page.goto(`${WEB_URL}/dashboard`, {
+    waitUntil: "networkidle",
+    timeout: 15000,
+  });
+
+  let url = page.url();
+  if (url.includes("/login")) {
+    await page.goto(`${WEB_URL}/login`);
+    await page.getByLabel(/email/i).fill(email);
+    await page.getByLabel(/password/i).fill(password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await page.waitForURL(/\/(setup|dashboard)/, { timeout: 15000 });
+    url = page.url();
+  }
+
+  if (url.includes("/setup")) {
+    await page.request.get(`${API_URL}/api/setup/status`);
+    const cookies = await context.cookies();
+    const csrfToken = cookies.find((c) => c.name === "csrf-token")?.value || "";
+    await page.request.post(`${API_URL}/api/setup/complete`, {
+      headers: { "x-csrf-token": csrfToken },
+    });
+    await page.goto(`${WEB_URL}/dashboard`, {
+      waitUntil: "networkidle",
+      timeout: 15000,
+    });
+  }
+
+  return { context, page, email, password, orgName };
+}
+
+/**
+ * Helper: create a client user, invite them, and have them accept.
+ * Returns the client's email + original password.
+ */
+async function createAndAcceptClient(
+  browser: import("@playwright/test").Browser,
+  ownerPage: import("@playwright/test").Page,
+  prefix: string,
+) {
+  const clientEmail = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
+  const originalPassword = "ClientOriginal123!";
+
+  // Owner invites
+  const inviteRes = await ownerPage.request.post(
+    `${API_URL}/api/auth/organization/invite-member`,
+    {
+      data: { email: clientEmail, role: "member" },
+      headers: { Origin: WEB_URL },
+    },
+  );
+  if (!inviteRes.ok()) {
+    throw new Error(`Invite failed (${inviteRes.status()}): ${await inviteRes.text()}`);
+  }
+  const invitationId =
+    (await inviteRes.json())?.id ||
+    (await inviteRes.json())?.invitation?.id;
+
+  // Client accepts in a fresh context
+  const clientCtx = await browser.newContext({ storageState: undefined });
+  const clientPage = await clientCtx.newPage();
+  await clientPage.goto(`${WEB_URL}/accept-invite?id=${invitationId}`, {
+    waitUntil: "networkidle",
+    timeout: 15000,
+  });
+  await clientPage.getByLabel(/your name/i).fill("Locked Out Client");
+  await clientPage.getByLabel(/email/i).fill(clientEmail);
+  await clientPage.getByLabel(/password/i).fill(originalPassword);
+  await clientPage.getByRole("button", { name: /create account & join/i }).click();
+  await expect(clientPage).toHaveURL(/\/portal/, { timeout: 20000 });
+  await clientCtx.close();
+
+  return { clientEmail, originalPassword };
+}
+
+test.describe("Admin Reset Password", () => {
+  test("owner generates a reset link for a client and the client uses it to set a new password", async ({
+    browser,
+  }) => {
+    const { context: ownerCtx, page: ownerPage } = await createOwnerUser(
+      browser,
+      "admin-reset",
+    );
+    const { clientEmail } = await createAndAcceptClient(
+      browser,
+      ownerPage,
+      "admin-reset-client",
+    );
+
+    // Owner navigates to the people page and switches to Clients tab
+    await ownerPage.goto(`${WEB_URL}/dashboard/clients`, {
+      waitUntil: "networkidle",
+      timeout: 15000,
+    });
+    await ownerPage.getByRole("button", { name: /^clients/i }).click();
+
+    // Find the client row and click the reset-password action
+    const clientRow = ownerPage
+      .locator("div")
+      .filter({ hasText: clientEmail })
+      .first();
+    await expect(clientRow).toBeVisible({ timeout: 10000 });
+    await clientRow.getByTitle("Send password reset link").click();
+
+    // Confirm modal appears
+    await ownerPage.getByRole("button", { name: /generate link/i }).click();
+
+    // Banner with reset URL appears
+    const banner = ownerPage.getByText(/password reset link for/i).first();
+    await expect(banner).toBeVisible({ timeout: 10000 });
+
+    // Pull the URL out of the readonly input
+    const resetUrl = await ownerPage
+      .locator('input[readonly][value*="/reset-password/"]')
+      .first()
+      .inputValue();
+    expect(resetUrl).toMatch(/\/reset-password\//);
+
+    await ownerCtx.close();
+
+    // Client uses the link in a fresh context
+    const clientCtx = await browser.newContext({ storageState: undefined });
+    const clientPage = await clientCtx.newPage();
+    await clientPage.goto(resetUrl, { waitUntil: "networkidle", timeout: 15000 });
+
+    // Better Auth's GET /api/auth/reset-password/:token redirects to
+    // /reset-password?token=... — wait for that landing page.
+    await clientPage.waitForURL(/\/reset-password\?token=/, { timeout: 15000 });
+
+    const newPassword = "BrandNewPass456!";
+    await clientPage.getByLabel(/^new password$/i).fill(newPassword);
+    await clientPage.getByLabel(/confirm password/i).fill(newPassword);
+    await clientPage.getByRole("button", { name: /reset password/i }).click();
+
+    // Success state
+    await expect(
+      clientPage.getByRole("heading", { name: /password reset/i }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Client can now log in with the new password
+    await clientPage.goto(`${WEB_URL}/login`);
+    await clientPage.getByLabel(/email/i).fill(clientEmail);
+    await clientPage.getByLabel(/password/i).fill(newPassword);
+    await clientPage.getByRole("button", { name: /sign in/i }).click();
+    await expect(clientPage).toHaveURL(/\/portal/, { timeout: 20000 });
+
+    await clientCtx.close();
+  });
+});

--- a/e2e/tests/admin-reset-password.e2e.ts
+++ b/e2e/tests/admin-reset-password.e2e.ts
@@ -124,9 +124,10 @@ test.describe("Admin Reset Password", () => {
     // Confirm modal appears
     await ownerPage.getByRole("button", { name: /generate link/i }).click();
 
-    // Banner with reset URL appears
-    const banner = ownerPage.getByText(/password reset link for/i).first();
-    await expect(banner).toBeVisible({ timeout: 10000 });
+    // Modal with reset URL appears
+    await expect(
+      ownerPage.getByRole("heading", { name: /password reset link/i }),
+    ).toBeVisible({ timeout: 10000 });
 
     // Pull the URL out of the readonly input
     const resetUrl = await ownerPage

--- a/e2e/tests/forgot-password.e2e.ts
+++ b/e2e/tests/forgot-password.e2e.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+
+const API_URL = "http://localhost:3001";
+
+test.describe("Forgot Password", () => {
+  test("renders the form with email field and submit button", async ({ page }) => {
+    await page.goto("/forgot-password");
+    await expect(
+      page.getByRole("heading", { name: /forgot your password/i }),
+    ).toBeVisible();
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /send reset link/i }),
+    ).toBeVisible();
+  });
+
+  test("links back to sign in", async ({ page }) => {
+    await page.goto("/forgot-password");
+    await page.getByRole("link", { name: /^sign in$/i }).click();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("submits to /api/auth/request-password-reset and shows success state", async ({
+    browser,
+  }) => {
+    // Create a real user so the reset request hits a populated DB row.
+    const context = await browser.newContext({ storageState: undefined });
+    const page = await context.newPage();
+
+    const email = `forgot-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
+    const password = "ForgotPass123!";
+    const signupRes = await page.request.post(`${API_URL}/api/onboarding/signup`, {
+      data: {
+        name: "Forgot Tester",
+        email,
+        password,
+        orgName: `Forgot Org ${Date.now().toString(36)}`,
+      },
+    });
+    expect(signupRes.ok()).toBe(true);
+
+    const requests: string[] = [];
+    page.on("request", (req) => {
+      const url = req.url();
+      if (url.includes("/api/auth/")) requests.push(`${req.method()} ${url}`);
+    });
+
+    const requestPromise = page.waitForResponse(
+      (res) =>
+        res.url().includes("/api/auth/request-password-reset") &&
+        res.request().method() === "POST",
+      { timeout: 10000 },
+    );
+
+    await page.goto("/forgot-password");
+    await page.getByLabel(/email/i).fill(email);
+    await page.getByRole("button", { name: /send reset link/i }).click();
+
+    const response = await requestPromise;
+    expect(response.status()).toBe(200);
+
+    // Regression guard: the obsolete Better Auth 1.3 endpoint must NOT be hit.
+    expect(
+      requests.some((r) => r.includes("/api/auth/forget-password")),
+    ).toBe(false);
+
+    await expect(
+      page.getByRole("heading", { name: /check your email/i }),
+    ).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(email)).toBeVisible();
+
+    await context.close();
+  });
+
+  test("shows the same success state for an unknown email (no user enumeration)", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ storageState: undefined });
+    const page = await context.newPage();
+
+    await page.goto("/forgot-password");
+    await page
+      .getByLabel(/email/i)
+      .fill(`nobody-${Date.now()}@test.local`);
+    await page.getByRole("button", { name: /send reset link/i }).click();
+
+    await expect(
+      page.getByRole("heading", { name: /check your email/i }),
+    ).toBeVisible({ timeout: 5000 });
+
+    await context.close();
+  });
+});

--- a/e2e/tests/reset-password.e2e.ts
+++ b/e2e/tests/reset-password.e2e.ts
@@ -1,0 +1,255 @@
+import { test, expect } from "@playwright/test";
+
+const API_URL = "http://localhost:3001";
+const WEB_URL = "http://localhost:3000";
+
+test.describe("Reset Password Page", () => {
+  test("shows 'Invalid Reset Link' UI when no token is present", async ({
+    page,
+  }) => {
+    await page.goto("/reset-password");
+    await expect(
+      page.getByRole("heading", { name: /invalid reset link/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /request a new reset link/i }),
+    ).toBeVisible();
+  });
+
+  test("rejects a junk token with a server error message", async ({ page }) => {
+    await page.goto("/reset-password?token=this-token-does-not-exist");
+    await page.getByLabel(/^new password$/i).fill("BrandNewPass456!");
+    await page.getByLabel(/confirm password/i).fill("BrandNewPass456!");
+    await page.getByRole("button", { name: /reset password/i }).click();
+
+    await expect(
+      page.getByText(/invalid|expired|failed to reset/i),
+    ).toBeVisible({ timeout: 10000 });
+    // Still on the form, not the success state
+    await expect(
+      page.getByRole("heading", { name: /password reset$/i }),
+    ).not.toBeVisible();
+  });
+
+  test("rejects mismatched passwords client-side without hitting the API", async ({
+    page,
+  }) => {
+    const apiCalls: string[] = [];
+    page.on("request", (req) => {
+      if (req.url().includes("/api/auth/reset-password")) {
+        apiCalls.push(req.url());
+      }
+    });
+
+    await page.goto("/reset-password?token=anything");
+    await page.getByLabel(/^new password$/i).fill("BrandNewPass456!");
+    await page.getByLabel(/confirm password/i).fill("Different123!");
+    await page.getByRole("button", { name: /reset password/i }).click();
+
+    await expect(page.getByText(/passwords do not match/i)).toBeVisible();
+    expect(apiCalls).toHaveLength(0);
+  });
+
+  test("resets password successfully and old password no longer works", async ({
+    browser,
+  }) => {
+    // Create owner A and owner B, then have A generate a reset link for B via
+    // the admin reset endpoint (the only path that exposes the URL to tests).
+    const adminCtx = await browser.newContext({ storageState: undefined });
+    const adminPage = await adminCtx.newPage();
+    const adminEmail = `reset-admin-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
+    const adminPassword = "AdminPass123!";
+    await adminPage.request.post(`${API_URL}/api/onboarding/signup`, {
+      data: {
+        name: "Reset Admin",
+        email: adminEmail,
+        password: adminPassword,
+        orgName: `Reset Admin Org ${Date.now().toString(36)}`,
+      },
+    });
+    await adminPage.goto(`${WEB_URL}/login`);
+    await adminPage.getByLabel(/email/i).fill(adminEmail);
+    await adminPage.getByLabel(/password/i).fill(adminPassword);
+    await adminPage.getByRole("button", { name: /sign in/i }).click();
+    await adminPage.waitForURL(/\/(setup|dashboard)/, { timeout: 15000 });
+    if (adminPage.url().includes("/setup")) {
+      const cookies = await adminCtx.cookies();
+      const csrfToken = cookies.find((c) => c.name === "csrf-token")?.value || "";
+      await adminPage.request.post(`${API_URL}/api/setup/complete`, {
+        headers: { "x-csrf-token": csrfToken },
+      });
+    }
+
+    // Invite a client and have them accept
+    const clientEmail = `reset-client-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
+    const originalPassword = "ClientOriginal123!";
+    const inviteRes = await adminPage.request.post(
+      `${API_URL}/api/auth/organization/invite-member`,
+      {
+        data: { email: clientEmail, role: "member" },
+        headers: { Origin: WEB_URL },
+      },
+    );
+    expect(inviteRes.ok()).toBe(true);
+    const invitationBody = await inviteRes.json();
+    const invitationId = invitationBody?.id || invitationBody?.invitation?.id;
+
+    const clientCtx = await browser.newContext({ storageState: undefined });
+    const clientPage = await clientCtx.newPage();
+    await clientPage.goto(`${WEB_URL}/accept-invite?id=${invitationId}`);
+    await clientPage.getByLabel(/your name/i).fill("Reset Client");
+    await clientPage.getByLabel(/email/i).fill(clientEmail);
+    await clientPage.getByLabel(/password/i).fill(originalPassword);
+    await clientPage
+      .getByRole("button", { name: /create account & join/i })
+      .click();
+    await expect(clientPage).toHaveURL(/\/portal/, { timeout: 20000 });
+    await clientCtx.close();
+
+    // Admin generates a reset link via the admin endpoint
+    const membersRes = await adminPage.request.get(
+      `${API_URL}/api/clients?limit=100`,
+    );
+    const { data: members } = await membersRes.json();
+    const target = members.find(
+      (m: { user?: { email: string } }) => m.user?.email === clientEmail,
+    );
+    expect(target).toBeDefined();
+
+    const cookies = await adminCtx.cookies();
+    const csrfToken =
+      cookies.find((c) => c.name === "csrf-token")?.value || "";
+    const resetRes = await adminPage.request.post(
+      `${API_URL}/api/clients/${target.id}/reset-password`,
+      { headers: { "x-csrf-token": csrfToken, Origin: WEB_URL } },
+    );
+    expect(resetRes.ok()).toBe(true);
+    const { url: resetUrl } = await resetRes.json();
+    expect(resetUrl).toMatch(/\/reset-password\//);
+    await adminCtx.close();
+
+    // Client follows the reset URL → set new password
+    const newCtx = await browser.newContext({ storageState: undefined });
+    const newPage = await newCtx.newPage();
+    await newPage.goto(resetUrl);
+    await newPage.waitForURL(/\/reset-password\?token=/, { timeout: 15000 });
+
+    const newPassword = "BrandNewPass456!";
+    await newPage.getByLabel(/^new password$/i).fill(newPassword);
+    await newPage.getByLabel(/confirm password/i).fill(newPassword);
+    await newPage.getByRole("button", { name: /reset password/i }).click();
+    await expect(
+      newPage.getByRole("heading", { name: /^password reset$/i }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Old password must no longer work
+    await newPage.goto(`${WEB_URL}/login`);
+    await newPage.getByLabel(/email/i).fill(clientEmail);
+    await newPage.getByLabel(/password/i).fill(originalPassword);
+    await newPage.getByRole("button", { name: /sign in/i }).click();
+    await expect(newPage.getByText(/invalid|incorrect|wrong/i)).toBeVisible({
+      timeout: 10000,
+    });
+
+    // New password works
+    await newPage.getByLabel(/password/i).fill(newPassword);
+    await newPage.getByRole("button", { name: /sign in/i }).click();
+    await expect(newPage).toHaveURL(/\/portal/, { timeout: 20000 });
+
+    await newCtx.close();
+  });
+
+  test("rejects a token after it has been used once", async ({ browser }) => {
+    // Same setup as above, but reuse the token after a successful reset.
+    const adminCtx = await browser.newContext({ storageState: undefined });
+    const adminPage = await adminCtx.newPage();
+    const adminEmail = `reset-reuse-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
+    const adminPassword = "AdminPass123!";
+    await adminPage.request.post(`${API_URL}/api/onboarding/signup`, {
+      data: {
+        name: "Reset Reuse Admin",
+        email: adminEmail,
+        password: adminPassword,
+        orgName: `Reset Reuse Org ${Date.now().toString(36)}`,
+      },
+    });
+    await adminPage.goto(`${WEB_URL}/login`);
+    await adminPage.getByLabel(/email/i).fill(adminEmail);
+    await adminPage.getByLabel(/password/i).fill(adminPassword);
+    await adminPage.getByRole("button", { name: /sign in/i }).click();
+    await adminPage.waitForURL(/\/(setup|dashboard)/, { timeout: 15000 });
+    if (adminPage.url().includes("/setup")) {
+      const cookies = await adminCtx.cookies();
+      const csrfToken = cookies.find((c) => c.name === "csrf-token")?.value || "";
+      await adminPage.request.post(`${API_URL}/api/setup/complete`, {
+        headers: { "x-csrf-token": csrfToken },
+      });
+    }
+
+    const clientEmail = `reset-reuse-client-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
+    const inviteRes = await adminPage.request.post(
+      `${API_URL}/api/auth/organization/invite-member`,
+      {
+        data: { email: clientEmail, role: "member" },
+        headers: { Origin: WEB_URL },
+      },
+    );
+    const invitationBody = await inviteRes.json();
+    const invitationId = invitationBody?.id || invitationBody?.invitation?.id;
+
+    const clientCtx = await browser.newContext({ storageState: undefined });
+    const clientPage = await clientCtx.newPage();
+    await clientPage.goto(`${WEB_URL}/accept-invite?id=${invitationId}`);
+    await clientPage.getByLabel(/your name/i).fill("Reset Reuse Client");
+    await clientPage.getByLabel(/email/i).fill(clientEmail);
+    await clientPage.getByLabel(/password/i).fill("ClientOriginal123!");
+    await clientPage
+      .getByRole("button", { name: /create account & join/i })
+      .click();
+    await expect(clientPage).toHaveURL(/\/portal/, { timeout: 20000 });
+    await clientCtx.close();
+
+    const membersRes = await adminPage.request.get(
+      `${API_URL}/api/clients?limit=100`,
+    );
+    const { data: members } = await membersRes.json();
+    const target = members.find(
+      (m: { user?: { email: string } }) => m.user?.email === clientEmail,
+    );
+    const cookies = await adminCtx.cookies();
+    const csrfToken =
+      cookies.find((c) => c.name === "csrf-token")?.value || "";
+    const resetRes = await adminPage.request.post(
+      `${API_URL}/api/clients/${target.id}/reset-password`,
+      { headers: { "x-csrf-token": csrfToken, Origin: WEB_URL } },
+    );
+    const { url: resetUrl } = await resetRes.json();
+    await adminCtx.close();
+
+    // First use: success
+    const firstCtx = await browser.newContext({ storageState: undefined });
+    const firstPage = await firstCtx.newPage();
+    await firstPage.goto(resetUrl);
+    await firstPage.waitForURL(/\/reset-password\?token=/, { timeout: 15000 });
+    const tokenedUrl = firstPage.url();
+    await firstPage.getByLabel(/^new password$/i).fill("FirstNewPass789!");
+    await firstPage.getByLabel(/confirm password/i).fill("FirstNewPass789!");
+    await firstPage.getByRole("button", { name: /reset password/i }).click();
+    await expect(
+      firstPage.getByRole("heading", { name: /^password reset$/i }),
+    ).toBeVisible({ timeout: 10000 });
+    await firstCtx.close();
+
+    // Second use of the same token: must fail
+    const secondCtx = await browser.newContext({ storageState: undefined });
+    const secondPage = await secondCtx.newPage();
+    await secondPage.goto(tokenedUrl);
+    await secondPage.getByLabel(/^new password$/i).fill("SecondTry456!");
+    await secondPage.getByLabel(/confirm password/i).fill("SecondTry456!");
+    await secondPage.getByRole("button", { name: /reset password/i }).click();
+    await expect(
+      secondPage.getByText(/invalid|expired|failed to reset/i),
+    ).toBeVisible({ timeout: 10000 });
+    await secondCtx.close();
+  });
+});


### PR DESCRIPTION
Closes #40

## Summary
- **Bug fix:** forgot-password form posted to `/api/auth/forget-password`, the endpoint Better Auth renamed to `/api/auth/request-password-reset` in v1.4. Requests 404'd silently, so reset emails were never generated — likely the root cause of #40.
- **Bug fix:** reset / verify / magic-link / invitation callbacks ignored per-org email config and always fell back to the default sender. Each callback now resolves the user's primary org and threads `organizationId` into `MailService.send` so System Settings SMTP/Resend is honored.
- **New feature:** "Send password reset link" action on team and client rows in `/dashboard/clients` (owner/admin). Generates a reset URL via `AsyncLocalStorage` capture from Better Auth's `requestPasswordReset` and surfaces it in a copyable banner so admins can share it out-of-band when email is unreliable. Owners can reset other owners; admins cannot reset owners; nobody can reset themselves.

## Test plan
- [x] Unit: `apps/api/src/auth/auth.service.spec.ts` — 9 tests (org-resolution queries, ALS capture, missing-URL error, concurrent context isolation)
- [x] Unit: `apps/api/src/clients/clients.service.spec.ts` — 22 tests including 6 new permission-matrix cases for the reset endpoint
- [x] E2E: `e2e/tests/forgot-password.e2e.ts` — regression guard asserts the form posts to `request-password-reset` (not the obsolete endpoint), plus success-state + no-enumeration checks
- [x] E2E: `e2e/tests/admin-reset-password.e2e.ts` — full owner-generates → client-resets → login flow

Spec: `docs/superpowers/specs/2026-04-27-auth-email-org-config-and-admin-reset-design.md`