### PR TITLE
fix(invite): pin active org to invited org on accept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Atrium will be documented in this file.
 
+## [1.6.2] — 2026-04-28
+
+### Fixed
+
+- **Client invite signup landed on the org setup wizard** — when an invitee already belonged to another org (e.g. their own agency), the post-invite redirect picked an arbitrary `orgs[0]` as the active org and routed by *that* org's role, sending the client to `/dashboard` (or `/setup` if that org's wizard was incomplete) instead of the inviting org's portal. The invited org id from `acceptInvitation` is now pinned as active before redirecting.
+
 ## [1.6.1] — 2026-04-27
 
 ### Fixed

--- a/apps/web/src/app/(auth)/accept-invite/page.tsx
+++ b/apps/web/src/app/(auth)/accept-invite/page.tsx
@@ -94,9 +94,23 @@ function AcceptInviteContent() {
         throw new Error(data.message || "Failed to accept invitation");
       }
 
+      // Pin the active org to the one we just joined. Without this, users who
+      // already belong to another org (e.g. their own agency) can be routed
+      // to that org's dashboard/setup instead of the invited org's portal.
+      const acceptData: {
+        member?: { organizationId?: string };
+        invitation?: { organizationId?: string };
+      } = await acceptRes.json().catch(() => ({}));
+      const joinedOrgId =
+        acceptData.member?.organizationId ??
+        acceptData.invitation?.organizationId;
+
       // Step 3: Set active organization and redirect by role
       track("invite_accepted");
-      window.location.href = await setActiveOrgAndRedirect("/portal");
+      window.location.href = await setActiveOrgAndRedirect(
+        "/portal",
+        joinedOrgId,
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -67,22 +67,33 @@ export async function apiFetch<T = unknown>(
 /**
  * After authentication, sets the active org and returns the redirect path
  * based on the user's role (owner/admin -> /dashboard, member -> /portal).
+ *
+ * `preferredOrgId` is used when the caller knows which org the user is acting
+ * on (e.g. the org they just accepted an invite to). Without it, users who
+ * belong to multiple orgs would be routed by an arbitrary `orgs[0]`, which
+ * can land an invited client on the dashboard of an unrelated org they own.
  */
 export async function setActiveOrgAndRedirect(
   defaultPath = "/portal",
+  preferredOrgId?: string,
 ): Promise<string> {
   const orgsRes = await fetch(`${API_URL}/api/auth/organization/list`, {
     credentials: "include",
   });
   if (!orgsRes.ok) return defaultPath;
 
-  const orgs = await orgsRes.json();
+  const orgs: { id: string }[] = await orgsRes.json();
   if (!orgs?.length) return defaultPath;
+
+  const targetOrgId =
+    preferredOrgId && orgs.some((o) => o.id === preferredOrgId)
+      ? preferredOrgId
+      : orgs[0].id;
 
   await fetch(`${API_URL}/api/auth/organization/set-active`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ organizationId: orgs[0].id }),
+    body: JSON.stringify({ organizationId: targetOrgId }),
     credentials: "include",
   });
 

--- a/e2e/tests/accept-invite.e2e.ts
+++ b/e2e/tests/accept-invite.e2e.ts
@@ -210,6 +210,69 @@ test.describe("Accept Invite", () => {
     await clientCtx.close();
   });
 
+  test("client invited while already owning another org lands on portal, not setup", async ({
+    browser,
+  }) => {
+    // The bug: setActiveOrgAndRedirect picked orgs[0] regardless of which org
+    // was just joined, so a user who already owned an org would be sent to
+    // /dashboard (and onward to /setup if that org had pending setup) instead
+    // of /portal for the org they were invited to as a client.
+
+    // Step 1: Inviter org and inviter session
+    const {
+      context: inviterCtx,
+      page: inviterPage,
+    } = await createOwnerUser(browser, "inv-multi-inviter");
+
+    // Step 2: Invitee already owns their own (separate) org
+    const inviteeEmail = `inv-multi-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
+    const inviteePassword = "MultiOrgClient123!";
+    const ownCtx = await browser.newContext({ storageState: undefined });
+    const ownPage = await ownCtx.newPage();
+    const ownSignup = await ownPage.request.post(
+      `${API_URL}/api/onboarding/signup`,
+      {
+        data: {
+          name: "Multi Org Invitee",
+          email: inviteeEmail,
+          password: inviteePassword,
+          orgName: `Invitee Own Org ${Date.now().toString(36)}`,
+        },
+      },
+    );
+    if (!ownSignup.ok()) {
+      throw new Error(
+        `Invitee own-org signup failed (${ownSignup.status()}): ${await ownSignup.text()}`,
+      );
+    }
+    await ownCtx.close();
+
+    // Step 3: Inviter invites the invitee as a client (member role)
+    const invitationId = await inviteClient(inviterPage, inviteeEmail);
+    await inviterCtx.close();
+
+    // Step 4: Invitee opens the invite link in a fresh context and signs in
+    const clientCtx = await browser.newContext({ storageState: undefined });
+    const clientPage = await clientCtx.newPage();
+    await clientPage.goto(
+      `${WEB_URL}/accept-invite?id=${invitationId}`,
+      { waitUntil: "networkidle", timeout: 15000 },
+    );
+
+    await clientPage.getByRole("button", { name: /sign in instead/i }).click();
+    await clientPage.getByLabel(/email/i).fill(inviteeEmail);
+    await clientPage.getByLabel(/password/i).fill(inviteePassword);
+    await clientPage.getByRole("button", { name: /sign in & join/i }).click();
+
+    // Step 5: Must land in the portal of the inviting org, NOT on their own
+    // dashboard or setup wizard.
+    await expect(clientPage).toHaveURL(/\/portal/, { timeout: 20000 });
+    expect(clientPage.url()).not.toMatch(/\/dashboard/);
+    expect(clientPage.url()).not.toMatch(/\/setup/);
+
+    await clientCtx.close();
+  });
+
   test("shows invalid invitation message when no ID is provided", async ({
     browser,
   }) => {


### PR DESCRIPTION
## Summary

- Client invitees who already belonged to another org (e.g. their own agency) were redirected to that org's `/dashboard` — and onward to `/setup` if its wizard was incomplete — instead of the inviting org's `/portal`.
- Root cause: `setActiveOrgAndRedirect` blindly set `orgs[0]` as active, overriding the org Better Auth had just pinned via `acceptInvitation`.
- The accept-invite page now reads `member.organizationId` from the `acceptInvitation` response and passes it as `preferredOrgId` to `setActiveOrgAndRedirect`, which uses it when present.

## Test plan

- [x] New e2e: `Accept Invite › client invited while already owning another org lands on portal, not setup`
- [x] All 4 `accept-invite.e2e.ts` cases pass locally
- [ ] Verify on cloud after deploy: invitee with an existing owner org lands on `/portal`, not `/setup`