### PR TITLE
feat: view as customer (preview portal as a client)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -29,6 +29,8 @@ import { PaymentsModule } from "./payments/payments.module";
 import { EmbedsModule } from "./embeds/embeds.module";
 import { HealthController } from "./health.controller";
 import { SessionMiddleware } from "./auth/session.middleware";
+import { PreviewModeMiddleware } from "./auth/preview-mode.middleware";
+import { PreviewModeGuard } from "./auth/preview-mode.guard";
 import { AllExceptionsFilter } from "./common";
 import { CsrfGuard } from "./common/guards/csrf.guard";
 import { PlanGuard } from "./common/guards/plan.guard";
@@ -100,10 +102,16 @@ import { PlanGuard } from "./common/guards/plan.guard";
       provide: APP_GUARD,
       useClass: PlanGuard,
     },
+    {
+      provide: APP_GUARD,
+      useClass: PreviewModeGuard,
+    },
   ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(SessionMiddleware).forRoutes("*");
+    consumer
+      .apply(SessionMiddleware, PreviewModeMiddleware)
+      .forRoutes("*");
   }
 }

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -2,13 +2,14 @@ import { Module } from "@nestjs/common";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { SessionMiddleware } from "./session.middleware";
+import { PreviewModeMiddleware } from "./preview-mode.middleware";
 import { MailModule } from "../mail/mail.module";
 import { BillingModule } from "../billing/billing.module";
 
 @Module({
   imports: [MailModule, BillingModule],
   controllers: [AuthController],
-  providers: [AuthService, SessionMiddleware],
-  exports: [AuthService, SessionMiddleware],
+  providers: [AuthService, SessionMiddleware, PreviewModeMiddleware],
+  exports: [AuthService, SessionMiddleware, PreviewModeMiddleware],
 })
 export class AuthModule {}

--- a/apps/api/src/auth/preview-mode.guard.spec.ts
+++ b/apps/api/src/auth/preview-mode.guard.spec.ts
@@ -24,6 +24,10 @@ describe("PreviewModeGuard", () => {
     expect(guard.canActivate(buildContext("HEAD", true))).toBe(true);
   });
 
+  it("allows OPTIONS preflight when previewMode is true", () => {
+    expect(guard.canActivate(buildContext("OPTIONS", true))).toBe(true);
+  });
+
   it("rejects POST when previewMode is true", () => {
     expect(() => guard.canActivate(buildContext("POST", true))).toThrow(
       ForbiddenException,

--- a/apps/api/src/auth/preview-mode.guard.spec.ts
+++ b/apps/api/src/auth/preview-mode.guard.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import { PreviewModeGuard } from "./preview-mode.guard";
+import { ExecutionContext, ForbiddenException } from "@nestjs/common";
+
+function buildContext(method: string, previewMode: boolean): ExecutionContext {
+  const request = { method, previewMode };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => ({}),
+      getNext: () => () => {},
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe("PreviewModeGuard", () => {
+  const guard = new PreviewModeGuard();
+
+  it("allows GET when previewMode is true", () => {
+    expect(guard.canActivate(buildContext("GET", true))).toBe(true);
+  });
+
+  it("allows HEAD when previewMode is true", () => {
+    expect(guard.canActivate(buildContext("HEAD", true))).toBe(true);
+  });
+
+  it("rejects POST when previewMode is true", () => {
+    expect(() => guard.canActivate(buildContext("POST", true))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it("rejects PUT when previewMode is true", () => {
+    expect(() => guard.canActivate(buildContext("PUT", true))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it("rejects PATCH when previewMode is true", () => {
+    expect(() => guard.canActivate(buildContext("PATCH", true))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it("rejects DELETE when previewMode is true", () => {
+    expect(() => guard.canActivate(buildContext("DELETE", true))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it("allows POST when previewMode is false", () => {
+    expect(guard.canActivate(buildContext("POST", false))).toBe(true);
+  });
+
+  it("allows POST when previewMode flag is missing", () => {
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({ method: "POST" }),
+        getResponse: () => ({}),
+        getNext: () => () => {},
+      }),
+    } as unknown as ExecutionContext;
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+});

--- a/apps/api/src/auth/preview-mode.guard.ts
+++ b/apps/api/src/auth/preview-mode.guard.ts
@@ -6,7 +6,7 @@ import {
 } from "@nestjs/common";
 import type { AuthenticatedRequest } from "../common";
 
-const SAFE_METHODS = new Set(["GET", "HEAD"]);
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
 @Injectable()
 export class PreviewModeGuard implements CanActivate {

--- a/apps/api/src/auth/preview-mode.guard.ts
+++ b/apps/api/src/auth/preview-mode.guard.ts
@@ -1,0 +1,24 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from "@nestjs/common";
+import type { AuthenticatedRequest } from "../common";
+
+const SAFE_METHODS = new Set(["GET", "HEAD"]);
+
+@Injectable()
+export class PreviewModeGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context
+      .switchToHttp()
+      .getRequest<AuthenticatedRequest>();
+
+    if (request.previewMode && !SAFE_METHODS.has(request.method)) {
+      throw new ForbiddenException("Read-only preview mode");
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/auth/preview-mode.middleware.spec.ts
+++ b/apps/api/src/auth/preview-mode.middleware.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, mock } from "bun:test";
+import { PreviewModeMiddleware } from "./preview-mode.middleware";
+import type { Request, Response, NextFunction } from "express";
+
+interface MockReq extends Partial<Request> {
+  headers: Record<string, string>;
+  user?: { id: string; name: string; email: string };
+  member?: { role: string; organizationId: string };
+  organization?: { id: string };
+  previewMode?: boolean;
+}
+
+function buildReq(overrides: Partial<MockReq> = {}): MockReq {
+  return {
+    headers: {},
+    user: { id: "owner-1", name: "Owner", email: "owner@test.com" },
+    member: { role: "owner", organizationId: "org-1" },
+    organization: { id: "org-1" },
+    ...overrides,
+  };
+}
+
+function buildPrismaMock(member: { userId: string; role: string; organizationId: string } | null) {
+  return {
+    member: { findFirst: mock(() => Promise.resolve(member)) },
+  };
+}
+
+describe("PreviewModeMiddleware", () => {
+  it("passes through unchanged when X-Preview-As header is absent", async () => {
+    const prisma = buildPrismaMock(null);
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq();
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await mw.use(req as Request, {} as Response, next);
+
+    expect(req.user?.id).toBe("owner-1");
+    expect(req.previewMode).toBeUndefined();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("overrides user.id when owner previews a valid client", async () => {
+    const prisma = buildPrismaMock({
+      userId: "client-9",
+      role: "member",
+      organizationId: "org-1",
+    });
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({ headers: { "x-preview-as": "client-9" } });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await mw.use(req as Request, {} as Response, next);
+
+    expect(req.user?.id).toBe("client-9");
+    expect(req.previewMode).toBe(true);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("overrides user.id when admin previews a valid client", async () => {
+    const prisma = buildPrismaMock({
+      userId: "client-9",
+      role: "member",
+      organizationId: "org-1",
+    });
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({
+      headers: { "x-preview-as": "client-9" },
+      member: { role: "admin", organizationId: "org-1" },
+    });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await mw.use(req as Request, {} as Response, next);
+
+    expect(req.user?.id).toBe("client-9");
+    expect(req.previewMode).toBe(true);
+  });
+
+  it("rejects with 401 when requester is not owner or admin", async () => {
+    const prisma = buildPrismaMock({
+      userId: "client-9",
+      role: "member",
+      organizationId: "org-1",
+    });
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({
+      headers: { "x-preview-as": "client-9" },
+      member: { role: "member", organizationId: "org-1" },
+    });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await expect(mw.use(req as Request, {} as Response, next)).rejects.toThrow(
+      "Preview unavailable",
+    );
+  });
+
+  it("rejects with 401 when target is not a member of the active org", async () => {
+    const prisma = buildPrismaMock(null);
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({ headers: { "x-preview-as": "client-9" } });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await expect(mw.use(req as Request, {} as Response, next)).rejects.toThrow(
+      "Preview unavailable",
+    );
+  });
+
+  it("rejects with 401 when target is owner or admin (not a client)", async () => {
+    const prisma = buildPrismaMock({
+      userId: "other-admin",
+      role: "admin",
+      organizationId: "org-1",
+    });
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({ headers: { "x-preview-as": "other-admin" } });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await expect(mw.use(req as Request, {} as Response, next)).rejects.toThrow(
+      "Preview unavailable",
+    );
+  });
+
+  it("does not mutate the original cached user object", async () => {
+    const cachedUser = { id: "owner-1", name: "Owner", email: "owner@test.com" };
+    const prisma = buildPrismaMock({
+      userId: "client-9",
+      role: "member",
+      organizationId: "org-1",
+    });
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({
+      headers: { "x-preview-as": "client-9" },
+      user: cachedUser,
+    });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await mw.use(req as Request, {} as Response, next);
+
+    expect(cachedUser.id).toBe("owner-1");
+    expect(req.user?.id).toBe("client-9");
+  });
+});

--- a/apps/api/src/auth/preview-mode.middleware.spec.ts
+++ b/apps/api/src/auth/preview-mode.middleware.spec.ts
@@ -40,6 +40,27 @@ describe("PreviewModeMiddleware", () => {
     expect(next).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores X-Preview-As header on /api/auth/* routes", async () => {
+    const prisma = buildPrismaMock({
+      userId: "client-9",
+      role: "member",
+      organizationId: "org-1",
+    });
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({
+      headers: { "x-preview-as": "client-9" },
+      originalUrl: "/api/auth/get-session",
+    });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await mw.use(req as Request, {} as Response, next);
+
+    expect(req.user?.id).toBe("owner-1");
+    expect(req.previewMode).toBeUndefined();
+    expect(prisma.member.findFirst).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
   it("overrides user.id when owner previews a valid client", async () => {
     const prisma = buildPrismaMock({
       userId: "client-9",

--- a/apps/api/src/auth/preview-mode.middleware.spec.ts
+++ b/apps/api/src/auth/preview-mode.middleware.spec.ts
@@ -139,4 +139,49 @@ describe("PreviewModeMiddleware", () => {
     expect(cachedUser.id).toBe("owner-1");
     expect(req.user?.id).toBe("client-9");
   });
+
+  it("uses first value when X-Preview-As header is an array", async () => {
+    const prisma = buildPrismaMock({
+      userId: "client-9",
+      role: "member",
+      organizationId: "org-1",
+    });
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq() as MockReq & { headers: Record<string, string | string[]> };
+    req.headers["x-preview-as"] = ["client-9", "ignored-second-value"];
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await mw.use(req as unknown as Request, {} as Response, next);
+
+    expect(req.user?.id).toBe("client-9");
+    expect(req.previewMode).toBe(true);
+  });
+
+  it("rejects with 401 when requester has no member context", async () => {
+    const prisma = buildPrismaMock(null);
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({
+      headers: { "x-preview-as": "client-9" },
+      member: undefined,
+    });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await expect(mw.use(req as Request, {} as Response, next)).rejects.toThrow(
+      "Preview unavailable",
+    );
+  });
+
+  it("rejects with 401 when requester has no organization context", async () => {
+    const prisma = buildPrismaMock(null);
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({
+      headers: { "x-preview-as": "client-9" },
+      organization: undefined,
+    });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await expect(mw.use(req as Request, {} as Response, next)).rejects.toThrow(
+      "Preview unavailable",
+    );
+  });
 });

--- a/apps/api/src/auth/preview-mode.middleware.ts
+++ b/apps/api/src/auth/preview-mode.middleware.ts
@@ -4,11 +4,12 @@ import {
   UnauthorizedException,
 } from "@nestjs/common";
 import { Request, Response, NextFunction } from "express";
+import { ROLES } from "@atrium/shared";
 import { PrismaService } from "../prisma/prisma.service";
 import type { AuthenticatedRequest } from "../common";
 
 const HEADER_NAME = "x-preview-as";
-const PRIVILEGED_ROLES = new Set(["owner", "admin"]);
+const PRIVILEGED_ROLES = new Set<string>([ROLES.OWNER, ROLES.ADMIN]);
 
 @Injectable()
 export class PreviewModeMiddleware implements NestMiddleware {
@@ -36,7 +37,7 @@ export class PreviewModeMiddleware implements NestMiddleware {
       select: { userId: true, role: true, organizationId: true },
     });
 
-    if (!targetMember || targetMember.role !== "member") {
+    if (!targetMember || targetMember.role !== ROLES.MEMBER) {
       throw new UnauthorizedException("Preview unavailable");
     }
 

--- a/apps/api/src/auth/preview-mode.middleware.ts
+++ b/apps/api/src/auth/preview-mode.middleware.ts
@@ -17,6 +17,12 @@ export class PreviewModeMiddleware implements NestMiddleware {
 
   async use(req: Request, _res: Response, next: NextFunction): Promise<void> {
     const authReq = req as AuthenticatedRequest;
+    const url: string = req.originalUrl || req.url || "";
+    if (url.startsWith("/api/auth/")) {
+      next();
+      return;
+    }
+
     const headerValue = req.headers[HEADER_NAME];
     const targetUserId = Array.isArray(headerValue) ? headerValue[0] : headerValue;
 

--- a/apps/api/src/auth/preview-mode.middleware.ts
+++ b/apps/api/src/auth/preview-mode.middleware.ts
@@ -1,0 +1,48 @@
+import {
+  Injectable,
+  NestMiddleware,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { Request, Response, NextFunction } from "express";
+import { PrismaService } from "../prisma/prisma.service";
+import type { AuthenticatedRequest } from "../common";
+
+const HEADER_NAME = "x-preview-as";
+const PRIVILEGED_ROLES = new Set(["owner", "admin"]);
+
+@Injectable()
+export class PreviewModeMiddleware implements NestMiddleware {
+  constructor(private prisma: PrismaService) {}
+
+  async use(req: Request, _res: Response, next: NextFunction): Promise<void> {
+    const authReq = req as AuthenticatedRequest;
+    const headerValue = req.headers[HEADER_NAME];
+    const targetUserId = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+
+    if (!targetUserId) {
+      next();
+      return;
+    }
+
+    const requesterRole = authReq.member?.role;
+    const orgId = authReq.organization?.id;
+
+    if (!requesterRole || !orgId || !PRIVILEGED_ROLES.has(requesterRole)) {
+      throw new UnauthorizedException("Preview unavailable");
+    }
+
+    const targetMember = await this.prisma.member.findFirst({
+      where: { userId: targetUserId, organizationId: orgId },
+      select: { userId: true, role: true, organizationId: true },
+    });
+
+    if (!targetMember || targetMember.role !== "member") {
+      throw new UnauthorizedException("Preview unavailable");
+    }
+
+    // Shallow-clone so we never mutate the SessionMiddleware cache.
+    authReq.user = { ...authReq.user, id: targetMember.userId };
+    authReq.previewMode = true;
+    next();
+  }
+}

--- a/apps/api/src/common/types/authenticated-request.ts
+++ b/apps/api/src/common/types/authenticated-request.ts
@@ -46,4 +46,5 @@ export interface AuthenticatedRequest extends Request {
   session: AuthSession;
   organization: FullOrganization;
   member: OrgMember;
+  previewMode?: boolean;
 }

--- a/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
@@ -188,9 +188,18 @@ export default function PeoplePage() {
     }
   };
 
-  const handleViewAsClient = (clientUserId: string) => {
+  const handleViewAsClient = (
+    clientUserId: string,
+    clientName: string,
+    clientEmail: string,
+  ) => {
     track("client_viewed_as");
-    window.open(`/portal?previewAs=${clientUserId}`, "_blank", "noopener");
+    const params = new URLSearchParams({
+      previewAs: clientUserId,
+      previewName: clientName,
+      previewEmail: clientEmail,
+    });
+    window.open(`/portal?${params.toString()}`, "_blank", "noopener");
   };
 
   const handleResetPassword = async (memberId: string, email: string) => {
@@ -834,7 +843,13 @@ export default function PeoplePage() {
                         <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
                           {(currentRole === "owner" || currentRole === "admin") && (
                             <button
-                              onClick={() => handleViewAsClient(member.userId)}
+                              onClick={() =>
+                                handleViewAsClient(
+                                  member.userId,
+                                  member.user.name,
+                                  member.user.email,
+                                )
+                              }
                               className="p-1.5 text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors"
                               title="View as customer"
                               aria-label={`View portal as ${member.user.name}`}

--- a/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
@@ -5,7 +5,7 @@ import { apiFetch } from "@/lib/api";
 import { useConfirm } from "@/components/confirm-modal";
 import { useToast } from "@/components/toast";
 import { ClientItemSkeleton } from "@/components/skeletons";
-import { UserPlus, Copy, Check, Trash2, ChevronDown, ChevronRight, UsersRound, Download, Sparkles, ExternalLink, KeyRound, X } from "lucide-react";
+import { UserPlus, Copy, Check, Trash2, ChevronDown, ChevronRight, UsersRound, Download, Sparkles, ExternalLink, KeyRound, X, Eye } from "lucide-react";
 import { track } from "@/lib/track";
 import { LabelBadge } from "@/components/label-badge";
 import { downloadCsv } from "@/lib/download";
@@ -186,6 +186,11 @@ export default function PeoplePage() {
     } catch (err) {
       showError(err instanceof Error ? err.message : "Failed to remove");
     }
+  };
+
+  const handleViewAsClient = (clientUserId: string) => {
+    track("client_viewed_as");
+    window.open(`/portal?previewAs=${clientUserId}`, "_blank", "noopener");
   };
 
   const handleResetPassword = async (memberId: string, email: string) => {
@@ -827,6 +832,16 @@ export default function PeoplePage() {
                           </div>
                         </div>
                         <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+                          {(currentRole === "owner" || currentRole === "admin") && (
+                            <button
+                              onClick={() => handleViewAsClient(member.userId)}
+                              className="p-1.5 text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors"
+                              title="View as customer"
+                              aria-label={`View portal as ${member.user.name}`}
+                            >
+                              <Eye size={14} />
+                            </button>
+                          )}
                           <button
                             onClick={() => handleResetPassword(member.id, member.user.email)}
                             disabled={resettingMemberId === member.id}

--- a/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
@@ -7,6 +7,7 @@ import { useToast } from "@/components/toast";
 import { ClientItemSkeleton } from "@/components/skeletons";
 import { UserPlus, Copy, Check, Trash2, ChevronDown, ChevronRight, UsersRound, Download, Sparkles, ExternalLink, KeyRound, X, Eye } from "lucide-react";
 import { track } from "@/lib/track";
+import { startPreview } from "@/lib/preview-mode";
 import { LabelBadge } from "@/components/label-badge";
 import { downloadCsv } from "@/lib/download";
 import Link from "next/link";
@@ -194,12 +195,7 @@ export default function PeoplePage() {
     clientEmail: string,
   ) => {
     track("client_viewed_as");
-    const params = new URLSearchParams({
-      previewAs: clientUserId,
-      previewName: clientName,
-      previewEmail: clientEmail,
-    });
-    window.open(`/portal?${params.toString()}`, "_blank", "noopener");
+    startPreview(clientUserId, clientName, clientEmail);
   };
 
   const handleResetPassword = async (memberId: string, email: string) => {

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/client-assignment.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/client-assignment.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
+import { Eye, X } from "lucide-react";
+import { Tooltip } from "@/components/tooltip";
 
 interface ClientMember {
   id: string;
@@ -13,12 +15,18 @@ export function ClientAssignment({
   assignedIds,
   onToggle,
   onRemove,
+  onPreview,
   disabled,
 }: {
   clients: ClientMember[];
   assignedIds: Set<string>;
   onToggle: (userId: string) => void;
   onRemove: (userId: string) => void;
+  onPreview?: (
+    userId: string,
+    clientName: string,
+    clientEmail: string,
+  ) => void;
   disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
@@ -61,26 +69,53 @@ export function ClientAssignment({
               inputRef.current?.focus();
             }}
           >
-            {assignedClients.map((c) => (
-              <span
-                key={c.userId}
-                className="inline-flex items-center gap-1 px-2 py-0.5 bg-[var(--muted)] rounded text-xs font-medium"
-              >
-                {c.user.name}
-                {!disabled && (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onRemove(c.userId);
-                    }}
-                    className="ml-0.5 hover:text-red-500"
-                  >
-                    &times;
-                  </button>
-                )}
-              </span>
-            ))}
+            {assignedClients.map((c) => {
+              const canRemove = !disabled;
+              const canPreview = !!onPreview;
+              const hasActions = canRemove || canPreview;
+              return (
+                <span
+                  key={c.userId}
+                  className="inline-flex items-center gap-1.5 pl-2 pr-1 py-0.5 bg-[var(--muted)] rounded text-xs font-medium"
+                >
+                  <span>{c.user.name}</span>
+                  {hasActions && (
+                    <span className="inline-flex items-center gap-0.5 pl-1.5 border-l border-[var(--border)]">
+                      {canPreview && (
+                        <Tooltip label="View as customer">
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onPreview!(c.userId, c.user.name, c.user.email);
+                            }}
+                            className="inline-flex items-center justify-center p-1 rounded text-[var(--muted-foreground)] hover:text-[var(--primary)] hover:bg-[var(--background)] transition-colors"
+                            aria-label={`View portal as ${c.user.name}`}
+                          >
+                            <Eye size={14} />
+                          </button>
+                        </Tooltip>
+                      )}
+                      {canRemove && (
+                        <Tooltip label="Remove from project">
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onRemove(c.userId);
+                            }}
+                            className="inline-flex items-center justify-center p-1 rounded text-[var(--muted-foreground)] hover:text-red-600 hover:bg-[var(--background)] transition-colors"
+                            aria-label={`Remove ${c.user.name} from project`}
+                          >
+                            <X size={14} />
+                          </button>
+                        </Tooltip>
+                      )}
+                    </span>
+                  )}
+                </span>
+              );
+            })}
             {!disabled && (
               <input
                 ref={inputRef}

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/page.tsx
@@ -9,6 +9,7 @@ import { ProjectDetailSkeleton } from "@/components/skeletons";
 import { useRouter } from "next/navigation";
 import { Archive, ArchiveRestore, Trash2, Calendar, ChevronDown, Tag, Copy } from "lucide-react";
 import { track } from "@/lib/track";
+import { startPreview } from "@/lib/preview-mode";
 import { LabelBadge } from "@/components/label-badge";
 import { LabelPicker } from "@/components/label-picker";
 import { StatusPipeline } from "./components/status-pipeline";
@@ -213,6 +214,16 @@ export default function ProjectDetailPage() {
 
   const handleRemoveClient = async (userId: string) => {
     if (!project || isArchived) return;
+    const client = clients.find((c) => c.userId === userId);
+    const ok = await confirm({
+      title: "Remove client from project?",
+      message: client
+        ? `${client.user.name} will no longer see this project in their portal. You can re-add them at any time.`
+        : "This client will no longer see this project in their portal. You can re-add them at any time.",
+      confirmLabel: "Remove client",
+      variant: "danger",
+    });
+    if (!ok) return;
     const newIds = (project.clients ?? [])
       .map((c) => c.userId)
       .filter((cid) => cid !== userId);
@@ -221,6 +232,15 @@ export default function ProjectDetailPage() {
       body: JSON.stringify({ clientUserIds: newIds }),
     });
     loadProject();
+  };
+
+  const handlePreviewAsClient = (
+    clientUserId: string,
+    clientName: string,
+    clientEmail: string,
+  ) => {
+    track("client_viewed_as", { from: "project" });
+    startPreview(clientUserId, clientName, clientEmail);
   };
 
   const handleDateChange = async (field: "startDate" | "endDate", value: string) => {
@@ -372,6 +392,11 @@ export default function ProjectDetailPage() {
         assignedIds={assignedIds}
         onToggle={handleClientToggle}
         onRemove={handleRemoveClient}
+        onPreview={
+          currentRole === "owner" || currentRole === "admin"
+            ? handlePreviewAsClient
+            : undefined
+        }
         disabled={isArchived}
       />
 

--- a/apps/web/src/app/(portal)/layout.tsx
+++ b/apps/web/src/app/(portal)/layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import Link from "next/link";
@@ -5,6 +6,8 @@ import { SignOutButton } from "./sign-out-button";
 import { getSession } from "@/lib/auth";
 import { NotificationBell } from "@/components/notification-bell";
 import { DynamicFavicon } from "@/components/dynamic-favicon";
+import { PreviewModeProvider } from "@/lib/preview-mode";
+import { PreviewBanner } from "@/components/preview-banner";
 
 const API_URL = process.env.API_URL || "http://localhost:3001";
 
@@ -71,37 +74,42 @@ export default async function PortalLayout({
   const logoSrc = getLogoSrc(branding);
 
   return (
-    <div
-      style={
-        {
-          "--primary": branding?.primaryColor || "#006b68",
-          "--accent": branding?.accentColor || "#ff6b5c",
-        } as React.CSSProperties
-      }
-    >
-      <DynamicFavicon href={logoSrc || "/icon.png"} />
-      <header className="border-b border-[var(--border)] px-6 py-4 flex items-center gap-3">
-        {!branding?.hideLogo && (
-          /* eslint-disable-next-line @next/next/no-img-element */
-          <img src={logoSrc || "/icon.png"} alt="Logo" className="h-8 w-8 object-contain" />
-        )}
-        <span className="font-semibold flex-1">{orgName || "Atrium"}</span>
-        <Link
-          href="/portal"
-          className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+    <Suspense fallback={null}>
+      <PreviewModeProvider>
+        <div
+          style={
+            {
+              "--primary": branding?.primaryColor || "#006b68",
+              "--accent": branding?.accentColor || "#ff6b5c",
+            } as React.CSSProperties
+          }
         >
-          Projects
-        </Link>
-        <Link
-          href="/portal/settings"
-          className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-        >
-          Settings
-        </Link>
-        <NotificationBell />
-        <SignOutButton />
-      </header>
-      <main className="max-w-6xl mx-auto p-4 sm:p-6 lg:p-8">{children}</main>
-    </div>
+          <DynamicFavicon href={logoSrc || "/icon.png"} />
+          <PreviewBanner />
+          <header className="border-b border-[var(--border)] px-6 py-4 flex items-center gap-3">
+            {!branding?.hideLogo && (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img src={logoSrc || "/icon.png"} alt="Logo" className="h-8 w-8 object-contain" />
+            )}
+            <span className="font-semibold flex-1">{orgName || "Atrium"}</span>
+            <Link
+              href="/portal"
+              className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            >
+              Projects
+            </Link>
+            <Link
+              href="/portal/settings"
+              className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            >
+              Settings
+            </Link>
+            <NotificationBell />
+            <SignOutButton />
+          </header>
+          <main className="max-w-6xl mx-auto p-4 sm:p-6 lg:p-8">{children}</main>
+        </div>
+      </PreviewModeProvider>
+    </Suspense>
   );
 }

--- a/apps/web/src/app/(portal)/portal/projects/[id]/components/portal-invoices-section.tsx
+++ b/apps/web/src/app/(portal)/portal/projects/[id]/components/portal-invoices-section.tsx
@@ -7,6 +7,7 @@ import { useToast } from "@/components/toast";
 import { Pagination } from "@/components/pagination";
 import { Receipt, Download, CreditCard } from "lucide-react";
 import { downloadFile } from "@/lib/download";
+import { usePreviewMode } from "@/lib/preview-mode";
 
 interface LineItem {
   id: string;
@@ -56,6 +57,7 @@ export function PortalInvoicesSection({
   const [stripeEnabled, setStripeEnabled] = useState(false);
   const [payingInvoiceId, setPayingInvoiceId] = useState<string | null>(null);
   const { success, info, error: showError } = useToast();
+  const { preview } = usePreviewMode();
 
   useEffect(() => {
     apiFetch<{ paymentInstructions: string | null; stripeConnectEnabled: boolean }>("/settings/payment-instructions")
@@ -220,8 +222,9 @@ export function PortalInvoicesSection({
                   {stripeEnabled && isPayable(inv.status) && (
                     <button
                       onClick={(e) => handlePayNow(e, inv.id)}
-                      disabled={payingInvoiceId === inv.id}
-                      className="flex items-center gap-1.5 text-xs px-3 py-1.5 mr-3 bg-[var(--primary)] text-white rounded-lg font-medium hover:opacity-90 transition-opacity shrink-0"
+                      disabled={!!preview || payingInvoiceId === inv.id}
+                      title={preview ? "Disabled in preview mode" : undefined}
+                      className="flex items-center gap-1.5 text-xs px-3 py-1.5 mr-3 bg-[var(--primary)] text-white rounded-lg font-medium hover:opacity-90 transition-opacity shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <CreditCard size={12} />
                       {payingInvoiceId === inv.id ? "..." : "Pay"}
@@ -241,8 +244,9 @@ export function PortalInvoicesSection({
                         {stripeEnabled && isPayable(inv.status) && (
                           <button
                             onClick={(e) => handlePayNow(e, inv.id)}
-                            disabled={payingInvoiceId === inv.id}
-                            className="flex items-center gap-1.5 text-sm px-3 py-1.5 bg-[var(--primary)] text-white rounded-lg font-medium hover:opacity-90 transition-opacity"
+                            disabled={!!preview || payingInvoiceId === inv.id}
+                            title={preview ? "Disabled in preview mode" : undefined}
+                            className="flex items-center gap-1.5 text-sm px-3 py-1.5 bg-[var(--primary)] text-white rounded-lg font-medium hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
                           >
                             <CreditCard size={14} />
                             {payingInvoiceId === inv.id ? "Redirecting..." : "Pay Now"}

--- a/apps/web/src/components/preview-banner.tsx
+++ b/apps/web/src/components/preview-banner.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Eye, X } from "lucide-react";
+import { usePreviewMode } from "@/lib/preview-mode";
+
+export function PreviewBanner() {
+  const { preview, exitPreview } = usePreviewMode();
+  if (!preview) return null;
+
+  return (
+    <div
+      className="sticky top-0 z-40 w-full border-b border-amber-300 bg-amber-100 text-amber-900"
+      role="status"
+      aria-label="Preview mode banner"
+    >
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-2 text-sm sm:px-6 lg:px-8">
+        <div className="flex items-center gap-2 min-w-0">
+          <Eye size={16} className="shrink-0" />
+          <span className="truncate">
+            Previewing as <strong>{preview.clientName}</strong> — read-only
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={exitPreview}
+          className="flex shrink-0 items-center gap-1 rounded-md bg-amber-200 px-2.5 py-1 text-xs font-semibold hover:bg-amber-300"
+        >
+          <X size={12} />
+          Exit preview
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/signing-viewer.tsx
+++ b/apps/web/src/components/signing-viewer.tsx
@@ -6,6 +6,7 @@ import { PdfViewer } from "./pdf-viewer";
 import { SignaturePad } from "./signature-pad";
 import { apiFetch } from "@/lib/api";
 import { downloadFile } from "@/lib/download";
+import { usePreviewMode } from "@/lib/preview-mode";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
@@ -90,6 +91,7 @@ export function SigningViewer({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pdfVersion, setPdfVersion] = useState(0);
+  const { preview } = usePreviewMode();
 
   const closeFieldCapture = useCallback(() => {
     setActiveFieldId(null);
@@ -158,6 +160,7 @@ export function SigningViewer({
   };
 
   const handleFieldClick = (field: SignatureField) => {
+    if (preview) return;
     if (signingInfo?.signedFieldIds.includes(field.id)) return;
     if (isFieldLocked(field)) return;
 
@@ -474,10 +477,12 @@ export function SigningViewer({
               <button
                 onClick={handleApplyField}
                 disabled={
+                  !!preview ||
                   submitting ||
                   (isImageField && !signatureDataUrl) ||
                   (isTextBasedField && !textValue.trim())
                 }
+                title={preview ? "Disabled in preview mode" : undefined}
                 className="px-4 py-1.5 bg-[var(--primary)] text-white rounded-lg text-sm hover:opacity-90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
               >
                 {submitting ? "Applying..." : "Apply"}

--- a/apps/web/src/components/tooltip.tsx
+++ b/apps/web/src/components/tooltip.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+type Side = "top" | "bottom";
+
+const SIDE_CLASS: Record<Side, string> = {
+  top: "bottom-full left-1/2 -translate-x-1/2 mb-1.5",
+  bottom: "top-full left-1/2 -translate-x-1/2 mt-1.5",
+};
+
+export function Tooltip({
+  label,
+  side = "top",
+  children,
+}: {
+  label: string;
+  side?: Side;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <span
+      className="relative inline-flex"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onFocus={() => setOpen(true)}
+      onBlur={() => setOpen(false)}
+    >
+      {children}
+      {open && (
+        <span
+          role="tooltip"
+          className={`absolute z-50 whitespace-nowrap rounded-md bg-[var(--muted)] border border-[var(--border)] px-2 py-1 text-[11px] font-medium text-[var(--foreground)] shadow-md pointer-events-none ${SIDE_CLASS[side]}`}
+        >
+          {label}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { getStoredPreviewClientId } from "./preview-mode";
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
 function getCsrfToken(): string | undefined {
@@ -27,6 +29,14 @@ async function doFetch(
     if (csrfToken) {
       headers["x-csrf-token"] = csrfToken;
     }
+  }
+
+  const previewClientId = getStoredPreviewClientId();
+  if (previewClientId) {
+    if (MUTATING_METHODS.has(method)) {
+      throw new Error("Read-only preview mode");
+    }
+    headers["X-Preview-As"] = previewClientId;
   }
 
   return fetch(`${API_URL}/api${path}`, {

--- a/apps/web/src/lib/preview-mode.tsx
+++ b/apps/web/src/lib/preview-mode.tsx
@@ -29,19 +29,6 @@ const PreviewModeContext = createContext<PreviewModeContextValue>({
   exitPreview: () => {},
 });
 
-interface MemberRecord {
-  id: string;
-  userId: string;
-  role: string;
-  user: { id: string; name: string; email: string };
-}
-
-interface PaginatedResponse<T> {
-  data: T[];
-}
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
-
 function readStored(): PreviewModeState | null {
   if (typeof window === "undefined") return null;
   try {
@@ -76,54 +63,30 @@ export function PreviewModeProvider({ children }: { children: ReactNode }) {
     const requestedId = searchParams.get("previewAs");
     if (!requestedId) return;
 
-    let cancelled = false;
-    (async () => {
-      try {
-        // The server will validate role + org membership via the X-Preview-As
-        // header below; we just need the client's name/email for the banner.
-        const res = await fetch(`${API_URL}/api/clients?page=1&limit=100`, {
-          credentials: "include",
-        });
-        if (!res.ok) throw new Error("Failed to load clients");
-        const body = (await res.json()) as PaginatedResponse<MemberRecord>;
-        const match = body.data.find((m) => m.userId === requestedId);
-        if (!match) throw new Error("Client not found");
-        if (cancelled) return;
-        const state: PreviewModeState = {
-          clientId: match.userId,
-          clientName: match.user.name,
-          clientEmail: match.user.email,
-        };
-        writeStored(state);
-        setPreview(state);
-      } catch (err) {
-        console.error("preview-mode init failed", err);
-        writeStored(null);
-        setPreview(null);
-      } finally {
-        if (!cancelled) {
-          // Strip ?previewAs= from the URL.
-          router.replace("/portal");
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
+    const clientName = searchParams.get("previewName") || "Client";
+    const clientEmail = searchParams.get("previewEmail") || "";
+    const state: PreviewModeState = {
+      clientId: requestedId,
+      clientName,
+      clientEmail,
     };
-  }, [router, searchParams]);
+    writeStored(state);
+    setPreview(state);
+
+    if (typeof window !== "undefined") {
+      window.history.replaceState(null, "", "/portal");
+    }
+  }, [searchParams]);
 
   const exitPreview = useCallback(() => {
     writeStored(null);
     setPreview(null);
-    if (typeof window !== "undefined") {
-      // Try to close the tab (works when opened via window.open).
-      window.close();
-      // Fallback if the browser blocks close().
-      setTimeout(() => {
-        if (!window.closed) router.push("/dashboard/clients");
-      }, 100);
-    }
+    if (typeof window === "undefined") return;
+    // Opened via window.open from dashboard; close if allowed, else navigate back.
+    window.close();
+    setTimeout(() => {
+      if (!window.closed) router.push("/dashboard/clients");
+    }, 100);
   }, [router]);
 
   const value = useMemo(

--- a/apps/web/src/lib/preview-mode.tsx
+++ b/apps/web/src/lib/preview-mode.tsx
@@ -81,7 +81,7 @@ export function PreviewModeProvider({ children }: { children: ReactNode }) {
       try {
         // The server will validate role + org membership via the X-Preview-As
         // header below; we just need the client's name/email for the banner.
-        const res = await fetch(`${API_URL}/api/clients?page=1&limit=200`, {
+        const res = await fetch(`${API_URL}/api/clients?page=1&limit=100`, {
           credentials: "include",
         });
         if (!res.ok) throw new Error("Failed to load clients");

--- a/apps/web/src/lib/preview-mode.tsx
+++ b/apps/web/src/lib/preview-mode.tsx
@@ -12,11 +12,57 @@ import {
 import { useRouter, useSearchParams } from "next/navigation";
 
 const STORAGE_KEY = "atrium:previewAs";
+const HANDOFF_PREFIX = "atrium:previewPending:";
+const HANDOFF_TTL_MS = 60_000;
 
 export interface PreviewModeState {
   clientId: string;
   clientName: string;
   clientEmail: string;
+}
+
+interface PreviewHandoff {
+  name: string;
+  email: string;
+  ts: number;
+}
+
+export function startPreview(
+  clientUserId: string,
+  clientName: string,
+  clientEmail: string,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    const handoff: PreviewHandoff = {
+      name: clientName,
+      email: clientEmail,
+      ts: Date.now(),
+    };
+    window.localStorage.setItem(
+      HANDOFF_PREFIX + clientUserId,
+      JSON.stringify(handoff),
+    );
+  } catch (err) {
+    console.error("preview-mode handoff write failed", err);
+  }
+  const params = new URLSearchParams({ previewAs: clientUserId });
+  window.open(`/portal?${params.toString()}`, "_blank", "noopener");
+}
+
+function readHandoff(clientUserId: string): PreviewHandoff | null {
+  if (typeof window === "undefined") return null;
+  const key = HANDOFF_PREFIX + clientUserId;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    window.localStorage.removeItem(key);
+    const parsed = JSON.parse(raw) as PreviewHandoff;
+    if (Date.now() - parsed.ts > HANDOFF_TTL_MS) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
 }
 
 interface PreviewModeContextValue {
@@ -63,12 +109,11 @@ export function PreviewModeProvider({ children }: { children: ReactNode }) {
     const requestedId = searchParams.get("previewAs");
     if (!requestedId) return;
 
-    const clientName = searchParams.get("previewName") || "Client";
-    const clientEmail = searchParams.get("previewEmail") || "";
+    const handoff = readHandoff(requestedId);
     const state: PreviewModeState = {
       clientId: requestedId,
-      clientName,
-      clientEmail,
+      clientName: handoff?.name || "Client",
+      clientEmail: handoff?.email || "",
     };
     writeStored(state);
     setPreview(state);

--- a/apps/web/src/lib/preview-mode.tsx
+++ b/apps/web/src/lib/preview-mode.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+const STORAGE_KEY = "atrium:previewAs";
+
+export interface PreviewModeState {
+  clientId: string;
+  clientName: string;
+  clientEmail: string;
+}
+
+interface PreviewModeContextValue {
+  preview: PreviewModeState | null;
+  exitPreview: () => void;
+}
+
+const PreviewModeContext = createContext<PreviewModeContextValue>({
+  preview: null,
+  exitPreview: () => {},
+});
+
+interface MemberRecord {
+  id: string;
+  userId: string;
+  role: string;
+  user: { id: string; name: string; email: string };
+}
+
+interface PaginatedResponse<T> {
+  data: T[];
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+
+function readStored(): PreviewModeState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as PreviewModeState) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStored(state: PreviewModeState | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (state) {
+      window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } else {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+    }
+  } catch (err) {
+    console.error("preview-mode storage write failed", err);
+  }
+}
+
+export function PreviewModeProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [preview, setPreview] = useState<PreviewModeState | null>(() =>
+    readStored(),
+  );
+
+  useEffect(() => {
+    const requestedId = searchParams.get("previewAs");
+    if (!requestedId) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        // The server will validate role + org membership via the X-Preview-As
+        // header below; we just need the client's name/email for the banner.
+        const res = await fetch(`${API_URL}/api/clients?page=1&limit=200`, {
+          credentials: "include",
+        });
+        if (!res.ok) throw new Error("Failed to load clients");
+        const body = (await res.json()) as PaginatedResponse<MemberRecord>;
+        const match = body.data.find((m) => m.userId === requestedId);
+        if (!match) throw new Error("Client not found");
+        if (cancelled) return;
+        const state: PreviewModeState = {
+          clientId: match.userId,
+          clientName: match.user.name,
+          clientEmail: match.user.email,
+        };
+        writeStored(state);
+        setPreview(state);
+      } catch (err) {
+        console.error("preview-mode init failed", err);
+        writeStored(null);
+        setPreview(null);
+      } finally {
+        if (!cancelled) {
+          // Strip ?previewAs= from the URL.
+          router.replace("/portal");
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router, searchParams]);
+
+  const exitPreview = useCallback(() => {
+    writeStored(null);
+    setPreview(null);
+    if (typeof window !== "undefined") {
+      // Try to close the tab (works when opened via window.open).
+      window.close();
+      // Fallback if the browser blocks close().
+      setTimeout(() => {
+        if (!window.closed) router.push("/dashboard/clients");
+      }, 100);
+    }
+  }, [router]);
+
+  const value = useMemo(
+    () => ({ preview, exitPreview }),
+    [preview, exitPreview],
+  );
+
+  return (
+    <PreviewModeContext.Provider value={value}>
+      {children}
+    </PreviewModeContext.Provider>
+  );
+}
+
+export function usePreviewMode(): PreviewModeContextValue {
+  return useContext(PreviewModeContext);
+}
+
+export function getStoredPreviewClientId(): string | null {
+  return readStored()?.clientId ?? null;
+}

--- a/docs/superpowers/plans/2026-04-29-view-as-customer.md
+++ b/docs/superpowers/plans/2026-04-29-view-as-customer.md
@@ -1,0 +1,1220 @@
+# View as Customer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let owners and admins click "View as customer" on a client row to open a read-only preview of the portal scoped to that client's data.
+
+**Architecture:** Server-side `PreviewModeMiddleware` reads an `X-Preview-As` header, validates the requester is owner/admin and the target is a `member` of the same org, then substitutes `req.user.id` with the target's id. A global `PreviewModeGuard` blocks all non-GET/HEAD requests when preview mode is active. Client-side `PreviewModeProvider` reads `?previewAs=` on mount, stores the target client in sessionStorage, and `apiFetch` attaches the header automatically. A sticky banner sits atop all portal pages, and mutation buttons are disabled.
+
+**Tech Stack:** NestJS 11 (middleware + guards), Bun test runner, Next.js 15 + React 19 (provider/context), Playwright (e2e).
+
+---
+
+## File Structure
+
+**Created:**
+- `apps/api/src/auth/preview-mode.middleware.ts`
+- `apps/api/src/auth/preview-mode.middleware.spec.ts`
+- `apps/api/src/auth/preview-mode.guard.ts`
+- `apps/api/src/auth/preview-mode.guard.spec.ts`
+- `apps/web/src/lib/preview-mode.tsx`
+- `apps/web/src/components/preview-banner.tsx`
+- `e2e/tests/view-as-customer.e2e.ts`
+
+**Modified:**
+- `apps/api/src/common/types/authenticated-request.ts` (add `previewMode?: boolean` flag)
+- `apps/api/src/auth/auth.module.ts` (provide middleware + guard)
+- `apps/api/src/app.module.ts` (apply middleware + register guard globally)
+- `apps/web/src/lib/api.ts` (attach `X-Preview-As` header from sessionStorage)
+- `apps/web/src/app/(portal)/layout.tsx` (wrap with `PreviewModeProvider` and render banner)
+- `apps/web/src/app/(dashboard)/dashboard/clients/page.tsx` (add `<Eye />` button on each client row)
+- `apps/web/src/app/(portal)/portal/sign/[token]/page.tsx` (disable Sign button in preview)
+- `apps/web/src/app/(portal)/portal/projects/[id]/components/portal-invoices-section.tsx` (disable pay/accept actions in preview)
+
+---
+
+## Task 1: Add `previewMode` flag to AuthenticatedRequest type
+
+**Files:**
+- Modify: `apps/api/src/common/types/authenticated-request.ts`
+
+- [ ] **Step 1: Add the optional flag**
+
+Open `apps/api/src/common/types/authenticated-request.ts` and update the `AuthenticatedRequest` interface to include `previewMode`:
+
+```ts
+export interface AuthenticatedRequest extends Request {
+  user: AuthUser;
+  session: AuthSession;
+  organization: FullOrganization;
+  member: OrgMember;
+  previewMode?: boolean;
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd apps/api && bunx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/common/types/authenticated-request.ts
+git commit -m "feat(api): add previewMode flag to AuthenticatedRequest"
+```
+
+---
+
+## Task 2: PreviewModeMiddleware (TDD)
+
+**Files:**
+- Create: `apps/api/src/auth/preview-mode.middleware.spec.ts`
+- Create: `apps/api/src/auth/preview-mode.middleware.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/auth/preview-mode.middleware.spec.ts`:
+
+```ts
+import { describe, expect, it, mock } from "bun:test";
+import { PreviewModeMiddleware } from "./preview-mode.middleware";
+import type { Request, Response, NextFunction } from "express";
+
+interface MockReq extends Partial<Request> {
+  headers: Record<string, string>;
+  user?: { id: string; name: string; email: string };
+  member?: { role: string; organizationId: string };
+  organization?: { id: string };
+  previewMode?: boolean;
+}
+
+function buildReq(overrides: Partial<MockReq> = {}): MockReq {
+  return {
+    headers: {},
+    user: { id: "owner-1", name: "Owner", email: "owner@test.com" },
+    member: { role: "owner", organizationId: "org-1" },
+    organization: { id: "org-1" },
+    ...overrides,
+  };
+}
+
+function buildPrismaMock(member: { userId: string; role: string; organizationId: string } | null) {
+  return {
+    member: { findFirst: mock(() => Promise.resolve(member)) },
+  };
+}
+
+describe("PreviewModeMiddleware", () => {
+  it("passes through unchanged when X-Preview-As header is absent", async () => {
+    const prisma = buildPrismaMock(null);
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq();
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await mw.use(req as Request, {} as Response, next);
+
+    expect(req.user?.id).toBe("owner-1");
+    expect(req.previewMode).toBeUndefined();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("overrides user.id when owner previews a valid client", async () => {
+    const prisma = buildPrismaMock({
+      userId: "client-9",
+      role: "member",
+      organizationId: "org-1",
+    });
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({ headers: { "x-preview-as": "client-9" } });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await mw.use(req as Request, {} as Response, next);
+
+    expect(req.user?.id).toBe("client-9");
+    expect(req.previewMode).toBe(true);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("overrides user.id when admin previews a valid client", async () => {
+    const prisma = buildPrismaMock({
+      userId: "client-9",
+      role: "member",
+      organizationId: "org-1",
+    });
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({
+      headers: { "x-preview-as": "client-9" },
+      member: { role: "admin", organizationId: "org-1" },
+    });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await mw.use(req as Request, {} as Response, next);
+
+    expect(req.user?.id).toBe("client-9");
+    expect(req.previewMode).toBe(true);
+  });
+
+  it("rejects with 401 when requester is not owner or admin", async () => {
+    const prisma = buildPrismaMock({
+      userId: "client-9",
+      role: "member",
+      organizationId: "org-1",
+    });
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({
+      headers: { "x-preview-as": "client-9" },
+      member: { role: "member", organizationId: "org-1" },
+    });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await expect(mw.use(req as Request, {} as Response, next)).rejects.toThrow(
+      "Preview unavailable",
+    );
+  });
+
+  it("rejects with 401 when target is not a member of the active org", async () => {
+    const prisma = buildPrismaMock(null);
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({ headers: { "x-preview-as": "client-9" } });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await expect(mw.use(req as Request, {} as Response, next)).rejects.toThrow(
+      "Preview unavailable",
+    );
+  });
+
+  it("rejects with 401 when target is owner or admin (not a client)", async () => {
+    const prisma = buildPrismaMock({
+      userId: "other-admin",
+      role: "admin",
+      organizationId: "org-1",
+    });
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({ headers: { "x-preview-as": "other-admin" } });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await expect(mw.use(req as Request, {} as Response, next)).rejects.toThrow(
+      "Preview unavailable",
+    );
+  });
+
+  it("does not mutate the original cached user object", async () => {
+    const cachedUser = { id: "owner-1", name: "Owner", email: "owner@test.com" };
+    const prisma = buildPrismaMock({
+      userId: "client-9",
+      role: "member",
+      organizationId: "org-1",
+    });
+    const mw = new PreviewModeMiddleware(prisma as any);
+    const req = buildReq({
+      headers: { "x-preview-as": "client-9" },
+      user: cachedUser,
+    });
+    const next = mock(() => {}) as unknown as NextFunction;
+
+    await mw.use(req as Request, {} as Response, next);
+
+    expect(cachedUser.id).toBe("owner-1");
+    expect(req.user?.id).toBe("client-9");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && bun test src/auth/preview-mode.middleware.spec.ts`
+Expected: FAIL with `Cannot find module './preview-mode.middleware'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/api/src/auth/preview-mode.middleware.ts`:
+
+```ts
+import {
+  Injectable,
+  NestMiddleware,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { Request, Response, NextFunction } from "express";
+import { PrismaService } from "../prisma/prisma.service";
+import type { AuthenticatedRequest } from "../common";
+
+const HEADER_NAME = "x-preview-as";
+const PRIVILEGED_ROLES = new Set(["owner", "admin"]);
+
+@Injectable()
+export class PreviewModeMiddleware implements NestMiddleware {
+  constructor(private prisma: PrismaService) {}
+
+  async use(req: Request, _res: Response, next: NextFunction) {
+    const authReq = req as AuthenticatedRequest;
+    const headerValue = req.headers[HEADER_NAME];
+    const targetUserId = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+
+    if (!targetUserId) {
+      next();
+      return;
+    }
+
+    const requesterRole = authReq.member?.role;
+    const orgId = authReq.organization?.id;
+
+    if (!requesterRole || !orgId || !PRIVILEGED_ROLES.has(requesterRole)) {
+      throw new UnauthorizedException("Preview unavailable");
+    }
+
+    const targetMember = await this.prisma.member.findFirst({
+      where: { userId: targetUserId, organizationId: orgId },
+      select: { userId: true, role: true, organizationId: true },
+    });
+
+    if (!targetMember || targetMember.role !== "member") {
+      throw new UnauthorizedException("Preview unavailable");
+    }
+
+    // Shallow-clone so we never mutate the SessionMiddleware cache.
+    authReq.user = { ...authReq.user, id: targetMember.userId };
+    authReq.previewMode = true;
+    next();
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && bun test src/auth/preview-mode.middleware.spec.ts`
+Expected: all 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/auth/preview-mode.middleware.ts apps/api/src/auth/preview-mode.middleware.spec.ts
+git commit -m "feat(api): add PreviewModeMiddleware for view-as-customer"
+```
+
+---
+
+## Task 3: PreviewModeGuard (TDD)
+
+**Files:**
+- Create: `apps/api/src/auth/preview-mode.guard.spec.ts`
+- Create: `apps/api/src/auth/preview-mode.guard.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/auth/preview-mode.guard.spec.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { PreviewModeGuard } from "./preview-mode.guard";
+import { ExecutionContext, ForbiddenException } from "@nestjs/common";
+
+function buildContext(method: string, previewMode: boolean): ExecutionContext {
+  const request = { method, previewMode };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => ({}),
+      getNext: () => () => {},
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe("PreviewModeGuard", () => {
+  const guard = new PreviewModeGuard();
+
+  it("allows GET when previewMode is true", () => {
+    expect(guard.canActivate(buildContext("GET", true))).toBe(true);
+  });
+
+  it("allows HEAD when previewMode is true", () => {
+    expect(guard.canActivate(buildContext("HEAD", true))).toBe(true);
+  });
+
+  it("rejects POST when previewMode is true", () => {
+    expect(() => guard.canActivate(buildContext("POST", true))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it("rejects PUT when previewMode is true", () => {
+    expect(() => guard.canActivate(buildContext("PUT", true))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it("rejects PATCH when previewMode is true", () => {
+    expect(() => guard.canActivate(buildContext("PATCH", true))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it("rejects DELETE when previewMode is true", () => {
+    expect(() => guard.canActivate(buildContext("DELETE", true))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it("allows POST when previewMode is false", () => {
+    expect(guard.canActivate(buildContext("POST", false))).toBe(true);
+  });
+
+  it("allows POST when previewMode flag is missing", () => {
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({ method: "POST" }),
+        getResponse: () => ({}),
+        getNext: () => () => {},
+      }),
+    } as unknown as ExecutionContext;
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && bun test src/auth/preview-mode.guard.spec.ts`
+Expected: FAIL with `Cannot find module './preview-mode.guard'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/api/src/auth/preview-mode.guard.ts`:
+
+```ts
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from "@nestjs/common";
+import type { AuthenticatedRequest } from "../common";
+
+const SAFE_METHODS = new Set(["GET", "HEAD"]);
+
+@Injectable()
+export class PreviewModeGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context
+      .switchToHttp()
+      .getRequest<AuthenticatedRequest>();
+
+    if (request.previewMode && !SAFE_METHODS.has(request.method)) {
+      throw new ForbiddenException("Read-only preview mode");
+    }
+
+    return true;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api && bun test src/auth/preview-mode.guard.spec.ts`
+Expected: all 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/auth/preview-mode.guard.ts apps/api/src/auth/preview-mode.guard.spec.ts
+git commit -m "feat(api): add PreviewModeGuard blocking mutations in preview"
+```
+
+---
+
+## Task 4: Wire middleware + guard into AppModule
+
+**Files:**
+- Modify: `apps/api/src/auth/auth.module.ts`
+- Modify: `apps/api/src/app.module.ts`
+
+- [ ] **Step 1: Export PreviewModeMiddleware from AuthModule**
+
+Open `apps/api/src/auth/auth.module.ts` and add the new middleware to providers/exports:
+
+```ts
+import { Module } from "@nestjs/common";
+import { AuthController } from "./auth.controller";
+import { AuthService } from "./auth.service";
+import { SessionMiddleware } from "./session.middleware";
+import { PreviewModeMiddleware } from "./preview-mode.middleware";
+import { MailModule } from "../mail/mail.module";
+import { BillingModule } from "../billing/billing.module";
+
+@Module({
+  imports: [MailModule, BillingModule],
+  controllers: [AuthController],
+  providers: [AuthService, SessionMiddleware, PreviewModeMiddleware],
+  exports: [AuthService, SessionMiddleware, PreviewModeMiddleware],
+})
+export class AuthModule {}
+```
+
+- [ ] **Step 2: Apply middleware after SessionMiddleware and register guard**
+
+Open `apps/api/src/app.module.ts`. Add imports near the other auth imports:
+
+```ts
+import { SessionMiddleware } from "./auth/session.middleware";
+import { PreviewModeMiddleware } from "./auth/preview-mode.middleware";
+import { PreviewModeGuard } from "./auth/preview-mode.guard";
+```
+
+Add the guard to the providers array (after `PlanGuard`):
+
+```ts
+    {
+      provide: APP_GUARD,
+      useClass: PlanGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: PreviewModeGuard,
+    },
+```
+
+Replace the `configure` method to chain both middlewares (order matters — `SessionMiddleware` first so `req.user`/`req.member`/`req.organization` are populated):
+
+```ts
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(SessionMiddleware, PreviewModeMiddleware)
+      .forRoutes("*");
+  }
+```
+
+- [ ] **Step 3: Verify the API still builds and existing tests pass**
+
+Run: `cd apps/api && bunx tsc --noEmit && bun test`
+Expected: TypeScript compiles, all existing tests still pass plus the new middleware/guard tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/auth/auth.module.ts apps/api/src/app.module.ts
+git commit -m "feat(api): wire PreviewModeMiddleware and Guard into AppModule"
+```
+
+---
+
+## Task 5: PreviewModeProvider + sessionStorage
+
+**Files:**
+- Create: `apps/web/src/lib/preview-mode.tsx`
+
+- [ ] **Step 1: Create the provider and hook**
+
+Create `apps/web/src/lib/preview-mode.tsx`:
+
+```tsx
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+const STORAGE_KEY = "atrium:previewAs";
+
+export interface PreviewModeState {
+  clientId: string;
+  clientName: string;
+  clientEmail: string;
+}
+
+interface PreviewModeContextValue {
+  preview: PreviewModeState | null;
+  exitPreview: () => void;
+}
+
+const PreviewModeContext = createContext<PreviewModeContextValue>({
+  preview: null,
+  exitPreview: () => {},
+});
+
+interface MemberRecord {
+  id: string;
+  userId: string;
+  role: string;
+  user: { id: string; name: string; email: string };
+}
+
+interface PaginatedResponse<T> {
+  data: T[];
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+
+function readStored(): PreviewModeState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as PreviewModeState) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStored(state: PreviewModeState | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (state) {
+      window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } else {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+    }
+  } catch (err) {
+    console.error("preview-mode storage write failed", err);
+  }
+}
+
+export function PreviewModeProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [preview, setPreview] = useState<PreviewModeState | null>(() =>
+    readStored(),
+  );
+
+  useEffect(() => {
+    const requestedId = searchParams.get("previewAs");
+    if (!requestedId) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        // The server will validate role + org membership via the X-Preview-As
+        // header below; we just need the client's name/email for the banner.
+        const res = await fetch(`${API_URL}/api/clients?page=1&limit=200`, {
+          credentials: "include",
+        });
+        if (!res.ok) throw new Error("Failed to load clients");
+        const body = (await res.json()) as PaginatedResponse<MemberRecord>;
+        const match = body.data.find((m) => m.userId === requestedId);
+        if (!match) throw new Error("Client not found");
+        if (cancelled) return;
+        const state: PreviewModeState = {
+          clientId: match.userId,
+          clientName: match.user.name,
+          clientEmail: match.user.email,
+        };
+        writeStored(state);
+        setPreview(state);
+      } catch (err) {
+        console.error("preview-mode init failed", err);
+        writeStored(null);
+        setPreview(null);
+      } finally {
+        if (!cancelled) {
+          // Strip ?previewAs= from the URL.
+          router.replace("/portal");
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router, searchParams]);
+
+  const exitPreview = useCallback(() => {
+    writeStored(null);
+    setPreview(null);
+    if (typeof window !== "undefined") {
+      // Try to close the tab (works when opened via window.open).
+      window.close();
+      // Fallback if the browser blocks close().
+      setTimeout(() => {
+        if (!window.closed) router.push("/dashboard/clients");
+      }, 100);
+    }
+  }, [router]);
+
+  const value = useMemo(
+    () => ({ preview, exitPreview }),
+    [preview, exitPreview],
+  );
+
+  return (
+    <PreviewModeContext.Provider value={value}>
+      {children}
+    </PreviewModeContext.Provider>
+  );
+}
+
+export function usePreviewMode(): PreviewModeContextValue {
+  return useContext(PreviewModeContext);
+}
+
+export function getStoredPreviewClientId(): string | null {
+  return readStored()?.clientId ?? null;
+}
+```
+
+- [ ] **Step 2: Verify the web app type-checks**
+
+Run: `cd apps/web && bunx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/preview-mode.tsx
+git commit -m "feat(web): add PreviewModeProvider and usePreviewMode hook"
+```
+
+---
+
+## Task 6: apiFetch attaches X-Preview-As header
+
+**Files:**
+- Modify: `apps/web/src/lib/api.ts`
+
+- [ ] **Step 1: Import the helper and attach the header**
+
+Open `apps/web/src/lib/api.ts`. At the top, add the import:
+
+```ts
+import { getStoredPreviewClientId } from "./preview-mode";
+```
+
+Replace the `doFetch` function so it attaches the preview header and short-circuits mutations:
+
+```ts
+async function doFetch(
+  path: string,
+  options: RequestInit,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    ...(options.headers as Record<string, string>),
+  };
+  if (!(options.body instanceof FormData)) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const method = (options.method || "GET").toUpperCase();
+  if (MUTATING_METHODS.has(method)) {
+    const csrfToken = getCsrfToken();
+    if (csrfToken) {
+      headers["x-csrf-token"] = csrfToken;
+    }
+  }
+
+  const previewClientId = getStoredPreviewClientId();
+  if (previewClientId) {
+    if (MUTATING_METHODS.has(method)) {
+      throw new Error("Read-only preview mode");
+    }
+    headers["X-Preview-As"] = previewClientId;
+  }
+
+  return fetch(`${API_URL}/api${path}`, {
+    ...options,
+    credentials: "include",
+    headers,
+  });
+}
+```
+
+- [ ] **Step 2: Verify the web app type-checks**
+
+Run: `cd apps/web && bunx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/api.ts
+git commit -m "feat(web): attach X-Preview-As header and block mutations in preview"
+```
+
+---
+
+## Task 7: PreviewBanner component
+
+**Files:**
+- Create: `apps/web/src/components/preview-banner.tsx`
+
+- [ ] **Step 1: Create the banner**
+
+Create `apps/web/src/components/preview-banner.tsx`:
+
+```tsx
+"use client";
+
+import { Eye, X } from "lucide-react";
+import { usePreviewMode } from "@/lib/preview-mode";
+
+export function PreviewBanner() {
+  const { preview, exitPreview } = usePreviewMode();
+  if (!preview) return null;
+
+  return (
+    <div
+      className="sticky top-0 z-40 w-full border-b border-amber-300 bg-amber-100 text-amber-900"
+      role="status"
+      aria-label="Preview mode banner"
+    >
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-2 text-sm sm:px-6 lg:px-8">
+        <div className="flex items-center gap-2 min-w-0">
+          <Eye size={16} className="shrink-0" />
+          <span className="truncate">
+            Previewing as <strong>{preview.clientName}</strong> — read-only
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={exitPreview}
+          className="flex shrink-0 items-center gap-1 rounded-md bg-amber-200 px-2.5 py-1 text-xs font-semibold hover:bg-amber-300"
+        >
+          <X size={12} />
+          Exit preview
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify the web app type-checks**
+
+Run: `cd apps/web && bunx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/preview-banner.tsx
+git commit -m "feat(web): add PreviewBanner component"
+```
+
+---
+
+## Task 8: Wire provider and banner into portal layout
+
+**Files:**
+- Modify: `apps/web/src/app/(portal)/layout.tsx`
+
+- [ ] **Step 1: Wrap the portal subtree with the provider and render the banner**
+
+Open `apps/web/src/app/(portal)/layout.tsx`. Add imports near the existing imports:
+
+```ts
+import { Suspense } from "react";
+import { PreviewModeProvider } from "@/lib/preview-mode";
+import { PreviewBanner } from "@/components/preview-banner";
+```
+
+Wrap the returned JSX with the provider (replace the existing top-level `<div>` block):
+
+```tsx
+  return (
+    <Suspense fallback={null}>
+      <PreviewModeProvider>
+        <div
+          style={
+            {
+              "--primary": branding?.primaryColor || "#006b68",
+              "--accent": branding?.accentColor || "#ff6b5c",
+            } as React.CSSProperties
+          }
+        >
+          <DynamicFavicon href={logoSrc || "/icon.png"} />
+          <PreviewBanner />
+          <header className="border-b border-[var(--border)] px-6 py-4 flex items-center gap-3">
+            {!branding?.hideLogo && (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img src={logoSrc || "/icon.png"} alt="Logo" className="h-8 w-8 object-contain" />
+            )}
+            <span className="font-semibold flex-1">{orgName || "Atrium"}</span>
+            <Link
+              href="/portal"
+              className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            >
+              Projects
+            </Link>
+            <Link
+              href="/portal/settings"
+              className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            >
+              Settings
+            </Link>
+            <NotificationBell />
+            <SignOutButton />
+          </header>
+          <main className="max-w-6xl mx-auto p-4 sm:p-6 lg:p-8">{children}</main>
+        </div>
+      </PreviewModeProvider>
+    </Suspense>
+  );
+```
+
+The `Suspense` wrapper is required because `PreviewModeProvider` calls `useSearchParams()`, which Next.js 15 streams via Suspense.
+
+- [ ] **Step 2: Verify the web app type-checks**
+
+Run: `cd apps/web && bunx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/app/\(portal\)/layout.tsx
+git commit -m "feat(web): wrap portal layout with PreviewModeProvider"
+```
+
+---
+
+## Task 9: "View as customer" button on clients page
+
+**Files:**
+- Modify: `apps/web/src/app/(dashboard)/dashboard/clients/page.tsx`
+
+- [ ] **Step 1: Add the Eye icon to the existing lucide import**
+
+Open `apps/web/src/app/(dashboard)/dashboard/clients/page.tsx`. Update the lucide-react import to include `Eye`:
+
+```ts
+import { UserPlus, Copy, Check, Trash2, ChevronDown, ChevronRight, UsersRound, Download, Sparkles, ExternalLink, KeyRound, X, Eye } from "lucide-react";
+```
+
+- [ ] **Step 2: Add a click handler near the existing handlers**
+
+Inside `PeoplePage`, near `handleResetPassword`, add:
+
+```ts
+  const handleViewAsClient = (clientUserId: string) => {
+    track("client_viewed_as");
+    window.open(`/portal?previewAs=${clientUserId}`, "_blank", "noopener");
+  };
+```
+
+- [ ] **Step 3: Render the button on each client row**
+
+In the client row JSX (the inner `<div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>` block, which currently contains the `KeyRound` and `Trash2` buttons), insert the new button as the first child so it appears left of the reset-password icon:
+
+```tsx
+                        <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+                          {(currentRole === "owner" || currentRole === "admin") && (
+                            <button
+                              onClick={() => handleViewAsClient(member.userId)}
+                              className="p-1.5 text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors"
+                              title="View as customer"
+                              aria-label={`View portal as ${member.user.name}`}
+                            >
+                              <Eye size={14} />
+                            </button>
+                          )}
+                          <button
+                            onClick={() => handleResetPassword(member.id, member.user.email)}
+                            disabled={resettingMemberId === member.id}
+                            className="p-1.5 text-[var(--muted-foreground)] hover:text-[var(--primary)] transition-colors disabled:opacity-50"
+                            title="Send password reset link"
+                          >
+                            <KeyRound size={14} />
+                          </button>
+                          <button
+                            onClick={() => handleRemoveMember(member.id, member.user.name, false)}
+                            className="p-1.5 text-[var(--muted-foreground)] hover:text-red-500 transition-colors"
+                            title="Remove client"
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        </div>
+```
+
+- [ ] **Step 4: Verify the web app type-checks**
+
+Run: `cd apps/web && bunx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/\(dashboard\)/dashboard/clients/page.tsx
+git commit -m "feat(web): add View as customer button on client rows"
+```
+
+---
+
+## Task 10: Disable mutation buttons in portal pages
+
+**Files:**
+- Modify: `apps/web/src/app/(portal)/portal/sign/[token]/page.tsx`
+- Modify: `apps/web/src/app/(portal)/portal/projects/[id]/components/portal-invoices-section.tsx`
+
+- [ ] **Step 1: Inspect the sign page's primary action**
+
+Run: `grep -n "button\|onClick" apps/web/src/app/\(portal\)/portal/sign/\[token\]/page.tsx | head -20`
+Expected: identifies the Sign / Submit button(s).
+
+- [ ] **Step 2: Disable the Sign action in preview**
+
+Open `apps/web/src/app/(portal)/portal/sign/[token]/page.tsx`. At the top of the file, near the other imports:
+
+```ts
+import { usePreviewMode } from "@/lib/preview-mode";
+```
+
+Inside the page component, near the top of the body:
+
+```ts
+  const { preview } = usePreviewMode();
+```
+
+For each button that submits/signs the document (typically labeled "Sign", "Accept", or "Submit"), add `disabled={!!preview || existingDisabled}` (combining with any existing disabled state) and a `title` attribute:
+
+```tsx
+<button
+  type="submit"
+  disabled={!!preview /* combine with any existing disabled expression */}
+  title={preview ? "Disabled in preview mode" : undefined}
+  className="..."
+>
+  Sign
+</button>
+```
+
+If the page has multiple action buttons, apply the same pattern to each.
+
+- [ ] **Step 3: Disable invoice pay/accept actions in preview**
+
+Open `apps/web/src/app/(portal)/portal/projects/[id]/components/portal-invoices-section.tsx`. Add the import:
+
+```ts
+import { usePreviewMode } from "@/lib/preview-mode";
+```
+
+Inside the component, near the top:
+
+```ts
+  const { preview } = usePreviewMode();
+```
+
+For each pay/accept/submit button in the file, add:
+
+```tsx
+disabled={!!preview /* combine with any existing disabled */}
+title={preview ? "Disabled in preview mode" : undefined}
+```
+
+- [ ] **Step 4: Verify the web app type-checks**
+
+Run: `cd apps/web && bunx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/\(portal\)/portal/sign/\[token\]/page.tsx apps/web/src/app/\(portal\)/portal/projects/\[id\]/components/portal-invoices-section.tsx
+git commit -m "feat(web): disable portal mutation buttons in preview mode"
+```
+
+---
+
+## Task 11: E2E test
+
+**Files:**
+- Create: `e2e/tests/view-as-customer.e2e.ts`
+
+- [ ] **Step 1: Write the test**
+
+Create `e2e/tests/view-as-customer.e2e.ts`:
+
+```ts
+import { test, expect } from "@playwright/test";
+import type { Browser, Page } from "@playwright/test";
+
+const API_URL = "http://localhost:3001";
+const WEB_URL = "http://localhost:3000";
+
+async function createOwner(browser: Browser, prefix = "vac-owner") {
+  const context = await browser.newContext({ storageState: undefined });
+  const page = await context.newPage();
+  const orgName = `${prefix} Org ${Date.now().toString(36)}`;
+  const email = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
+  const password = "ViewAs123!";
+
+  const res = await page.request.post(`${API_URL}/api/onboarding/signup`, {
+    data: { name: "VAC Owner", email, password, orgName },
+  });
+  if (!res.ok()) {
+    throw new Error(`Owner signup failed: ${res.status()} ${await res.text()}`);
+  }
+
+  await page.goto(`${WEB_URL}/login`);
+  await page.getByLabel(/email/i).fill(email);
+  await page.getByLabel(/password/i).fill(password);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await page.waitForURL(/\/(setup|dashboard)/, { timeout: 15000 });
+
+  if (page.url().includes("/setup")) {
+    const cookies = await context.cookies();
+    const csrfToken = cookies.find((c) => c.name === "csrf-token")?.value || "";
+    await page.request.post(`${API_URL}/api/setup/complete`, {
+      headers: { "x-csrf-token": csrfToken },
+    });
+    await page.goto(`${WEB_URL}/dashboard`, { waitUntil: "networkidle" });
+  }
+
+  return { context, page, email, password };
+}
+
+async function inviteAndAcceptClient(
+  browser: Browser,
+  ownerPage: Page,
+  prefix: string,
+) {
+  const clientEmail = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
+  const password = "Client123!";
+
+  const cookies = await ownerPage.context().cookies();
+  const csrfToken = cookies.find((c) => c.name === "csrf-token")?.value || "";
+
+  const inviteRes = await ownerPage.request.post(
+    `${API_URL}/api/auth/organization/invite-member`,
+    {
+      data: { email: clientEmail, role: "member" },
+      headers: { Origin: WEB_URL, "x-csrf-token": csrfToken },
+    },
+  );
+  if (!inviteRes.ok()) {
+    throw new Error(`Invite failed: ${inviteRes.status()} ${await inviteRes.text()}`);
+  }
+
+  // Find the invitation link from the invitations list
+  const invitesRes = await ownerPage.request.get(
+    `${API_URL}/api/clients/invitations`,
+  );
+  const invitations = (await invitesRes.json()) as Array<{
+    email: string;
+    inviteLink: string;
+  }>;
+  const link = invitations.find(
+    (i) => i.email.toLowerCase() === clientEmail.toLowerCase(),
+  )?.inviteLink;
+  if (!link) throw new Error("Invitation link not found");
+
+  // Accept in a fresh context
+  const clientCtx = await browser.newContext({ storageState: undefined });
+  const clientPage = await clientCtx.newPage();
+  await clientPage.goto(link);
+  await clientPage.getByLabel(/name/i).fill("Test Client");
+  await clientPage.getByLabel(/^password/i).fill(password);
+  await clientPage.getByRole("button", { name: /accept|create account/i }).click();
+  await clientPage.waitForURL(/\/portal/, { timeout: 15000 });
+  await clientCtx.close();
+
+  return { clientEmail, password };
+}
+
+test.describe("View as customer", () => {
+  test("owner can preview portal as a client and mutations are blocked", async ({
+    browser,
+  }) => {
+    const { context, page: ownerPage } = await createOwner(browser);
+    const { clientEmail } = await inviteAndAcceptClient(
+      browser,
+      ownerPage,
+      "vac-client",
+    );
+
+    // Owner navigates to clients tab
+    await ownerPage.goto(`${WEB_URL}/dashboard/clients`);
+    await ownerPage.getByRole("button", { name: /clients/i }).click();
+    await expect(ownerPage.getByText(clientEmail)).toBeVisible({ timeout: 10000 });
+
+    // Click View as customer (opens new tab)
+    const viewButton = ownerPage.getByRole("button", {
+      name: /view portal as/i,
+    });
+    await expect(viewButton).toBeVisible();
+    const [previewPage] = await Promise.all([
+      ownerPage.context().waitForEvent("page"),
+      viewButton.click(),
+    ]);
+
+    await previewPage.waitForLoadState("networkidle");
+    await expect(previewPage.getByText(/previewing as/i)).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(previewPage).toHaveURL(/\/portal/);
+
+    // Banner should advertise read-only and an exit affordance
+    await expect(previewPage.getByText(/read-only/i)).toBeVisible();
+    await expect(
+      previewPage.getByRole("button", { name: /exit preview/i }),
+    ).toBeVisible();
+
+    // Mutation API call should be blocked client-side
+    const mutationResult = await previewPage.evaluate(async () => {
+      try {
+        const res = await fetch("/api/clients/me/profile", {
+          method: "PUT",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ company: "should-not-save" }),
+        });
+        return { ok: res.ok, status: res.status };
+      } catch (err) {
+        return { error: String(err) };
+      }
+    });
+    // Either the apiFetch helper short-circuits (we're calling fetch directly
+    // in the eval, so the server-side guard catches it) or the server returns 403.
+    expect(mutationResult.ok).not.toBe(true);
+
+    // Exit preview returns to dashboard (or closes tab)
+    await previewPage.getByRole("button", { name: /exit preview/i }).click();
+    // Either tab closed, or it routed back to dashboard/clients
+    await previewPage
+      .waitForURL(/\/dashboard\/clients/, { timeout: 5000 })
+      .catch(() => {
+        // Tab may have closed instead
+      });
+
+    await context.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run the e2e test**
+
+Run: `bun run test:e2e -- view-as-customer`
+Expected: the test passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/tests/view-as-customer.e2e.ts
+git commit -m "test(e2e): view-as-customer preview flow"
+```
+
+---
+
+## Task 12: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `bun run test`
+Expected: all unit tests pass.
+
+- [ ] **Step 2: Build everything**
+
+Run: `bun run build`
+Expected: clean build, no type errors.
+
+- [ ] **Step 3: Run e2e suite**
+
+Run: `bun run test:e2e`
+Expected: all e2e tests pass (including the new one).
+
+- [ ] **Step 4: Manual smoke**
+
+Start dev (`bun run dev`), sign in as an owner, invite + accept a client, navigate to `/dashboard/clients`, click the eye icon on the client row, verify a new tab opens with the portal showing that client's data and the read-only banner.

--- a/docs/superpowers/specs/2026-04-29-view-as-customer-design.md
+++ b/docs/superpowers/specs/2026-04-29-view-as-customer-design.md
@@ -1,0 +1,152 @@
+# View as Customer — Design
+
+## Background
+
+GitHub issue [#42](https://github.com/Vibra-Labs/Atrium/issues/42) requests a "View as customer" affordance so an agency owner or admin can preview the portal experience for a specific client. Today, the only way to see what a client sees is to log in as that client (which requires their credentials and breaks audit trails). New users especially want to verify what their clients will see before inviting them.
+
+## Goals
+
+- Owners and admins can launch a read-only preview of the portal scoped to a specific client's data.
+- The preview faithfully renders the portal layout, navigation, and project visibility for that client.
+- Mutations (signing documents, posting comments, etc.) are blocked during the preview to avoid accidentally acting on the client's behalf.
+- No new credentials, tokens, or session swaps are issued — the requester remains authenticated as themselves.
+
+## Non-goals
+
+- Full impersonation (acquiring a session as the client). This is out of scope due to the audit-trail and footgun risks.
+- Previewing as a team member (admin/owner). Only `member`-role users (clients) can be previewed.
+- Persisting preview state across browser sessions or sharing preview URLs with others.
+
+## User flow
+
+1. Owner navigates to `/dashboard/clients`, opens the **Clients** tab.
+2. Each client row shows a **View as customer** icon button (Lucide `Eye`).
+3. Clicking the button opens `/portal?previewAs=<clientUserId>` in a new tab.
+4. The portal renders normally, scoped to that client's data, with a sticky banner at the top: *"Previewing as Ben Carter — read-only · Exit preview"*.
+5. Mutation buttons in the portal (sign document, etc.) are disabled with tooltip *"Disabled in preview mode"*.
+6. Clicking **Exit preview** closes the tab (with `router.push("/dashboard/clients")` as fallback).
+
+## Architecture
+
+### Server side (`apps/api`)
+
+**`apps/api/src/auth/preview-mode.middleware.ts`** — new
+
+- Reads `X-Preview-As` header from incoming requests.
+- If absent: passes through unchanged.
+- If present:
+  - Validates the requester's role in the active org is `owner` or `admin`. If not, responds 401.
+  - Validates the target user exists, is a `member` in the same org. If not, responds 401.
+  - Overrides `req.user.id = <targetUserId>` and sets `req.previewMode = true`.
+
+**`apps/api/src/auth/preview-mode.guard.ts`** — new
+
+- Registered globally via `APP_GUARD`.
+- If `req.previewMode === true` and request method is not `GET` or `HEAD`, throws `ForbiddenException("Read-only preview mode")`.
+- Otherwise allows the request to proceed (downstream guards still apply).
+
+**`apps/api/src/app.module.ts`** — modified
+
+- Apply `PreviewModeMiddleware` after the existing `SessionMiddleware` so `req.user` is populated first.
+- Register `PreviewModeGuard` with `APP_GUARD` provider.
+
+The middleware works because all client-scoped controllers already read the user id from `@CurrentUser("id")`. By substituting `req.user.id` upstream, every existing endpoint (e.g., `/projects/mine`, `/projects/mine/:id`, file downloads, updates) returns the target client's data without per-controller changes.
+
+### Client side (`apps/web`)
+
+**`apps/web/src/lib/preview-mode.tsx`** — new
+
+- Exports `PreviewModeProvider` and `usePreviewMode()` hook.
+- On mount, reads `previewAs` query param. If present:
+  - Fetches `/clients/<id>/profile` to get the client's name/email for the banner.
+  - Stores `{ clientId, clientName, clientEmail }` in React context and `sessionStorage` under key `atrium:previewAs`.
+  - Calls `router.replace("/portal")` to remove the query param from the URL.
+- On subsequent mounts, hydrates from `sessionStorage` if present.
+- Exposes `exitPreview()` which clears state and attempts `window.close()` with `router.push("/dashboard/clients")` fallback.
+
+**`apps/web/src/lib/api.ts`** — modified
+
+- Reads `atrium:previewAs` from `sessionStorage` on each call.
+- If present:
+  - Attaches `X-Preview-As: <clientId>` header to the request.
+  - For non-`GET`/`HEAD` requests, short-circuits with a thrown `Error("Read-only preview")` before hitting the network. (Defense-in-depth — the server will also reject.)
+
+**`apps/web/src/app/(portal)/layout.tsx`** — modified
+
+- Wrap the portal subtree with `PreviewModeProvider`.
+- Render `<PreviewBanner />` immediately above the existing portal content.
+
+**`apps/web/src/components/preview-banner.tsx`** — new
+
+- Sticky banner at the top of the viewport, amber background, full width.
+- Shows "Previewing as {clientName} — read-only".
+- Right side: "Exit preview" button calling `exitPreview()`.
+- Hidden when `usePreviewMode()` returns null.
+
+**`apps/web/src/app/(dashboard)/dashboard/clients/page.tsx`** — modified
+
+- In the clients list (the `clients.map(...)` block), add an `<Eye />` icon button to each client row, positioned alongside the existing reset-password and remove buttons.
+- Visible only when `currentRole === "owner" || currentRole === "admin"`.
+- onClick: `window.open(\`/portal?previewAs=${member.userId}\`, "_blank")`.
+- Tooltip: "View as customer".
+
+### Mutation UX in portal pages
+
+Existing portal components that perform mutations should consult `usePreviewMode()` and disable their action buttons when preview is active. At minimum:
+
+- `apps/web/src/app/(portal)/portal/projects/[id]/components/portal-invoices-section.tsx` (any pay/accept actions)
+- `apps/web/src/app/(portal)/portal/sign/[token]/page.tsx` (sign button)
+- Any update/comment composer in portal project detail pages
+
+If a mutation slips through, the server still rejects it with 403, and the toast layer surfaces the error. The disabled state is a UX nicety, not a security boundary.
+
+## Data flow
+
+1. Owner clicks **View as customer** on Ben's row → new tab opens at `/portal?previewAs=<benUserId>`.
+2. `PreviewModeProvider` mounts, fetches Ben's profile (with `X-Preview-As` header set), stores `{ clientId: benUserId, clientName: "Ben Carter", ... }`, and replaces the URL with `/portal`.
+3. The portal layout renders. `<PreviewBanner />` shows "Previewing as Ben Carter — read-only".
+4. The portal pages call `/projects/mine`, `/projects/mine/:id`, etc. via `apiFetch`. Each request now carries `X-Preview-As: <benUserId>`.
+5. `PreviewModeMiddleware` validates owner/admin role + target membership, sets `req.user.id = benUserId`, sets `req.previewMode = true`.
+6. `PreviewModeGuard` allows GET requests through; controllers return Ben's data scope.
+7. Owner clicks **Exit preview** → state cleared → tab closes (or routes back to dashboard).
+
+## Error handling
+
+| Scenario | Behavior |
+|---|---|
+| Requester is a `member` (not owner/admin) | Middleware returns 401. Front-end shows toast "Preview unavailable", routes to `/dashboard/clients`. |
+| Target user is in a different org or is owner/admin | Middleware returns 401. Same handling. |
+| Target user has been deleted mid-preview | Next API call returns 401. Banner stays; user clicks Exit. |
+| `X-Preview-As` header is malformed | Middleware ignores the header, request proceeds as the actual user. Banner won't render because context never initialized successfully. |
+| Mutation attempted in preview mode | Client `apiFetch` short-circuits with `Error("Read-only preview")`. If it bypasses, server returns 403 `"Read-only preview mode"`. |
+| `window.close()` blocked by browser | `exitPreview()` falls back to `router.push("/dashboard/clients")`. |
+
+## Testing
+
+**Unit (Bun, `apps/api/src/**/*.spec.ts`):**
+
+- `preview-mode.middleware.spec.ts`
+  - Owner with valid client target → `req.user.id` overridden, `req.previewMode = true`.
+  - Admin with valid client target → same.
+  - Member trying to preview → 401.
+  - Target in a different org → 401.
+  - Target is owner/admin (not a client) → 401.
+  - Missing header → passes through, no override.
+- `preview-mode.guard.spec.ts`
+  - GET with `previewMode = true` → allowed.
+  - POST/PUT/PATCH/DELETE with `previewMode = true` → 403.
+  - POST without `previewMode` → allowed.
+
+**E2E (Playwright, `e2e/tests/`):**
+
+- `preview-as-client.e2e.ts`
+  - Owner logs in, creates a project assigned to client A, creates a second project assigned only to client B.
+  - Owner navigates to `/dashboard/clients`, clicks **View as customer** on client A.
+  - New tab opens; portal lists client A's project but not client B's.
+  - Banner is visible with client A's name.
+  - Attempting a mutation (e.g., updating profile via the portal settings page) is blocked / button is disabled.
+  - Clicking **Exit preview** returns to the dashboard.
+
+## Rollout
+
+This is purely additive — no schema changes, no breaking API changes. Behind no feature flag; ships as a normal feature.

--- a/e2e/tests/view-as-customer.e2e.ts
+++ b/e2e/tests/view-as-customer.e2e.ts
@@ -85,7 +85,6 @@ async function inviteAndAcceptClient(
     timeout: 30000,
   });
   await clientPage.waitForSelector("#name", { state: "visible", timeout: 30000 });
-  // Allow React to hydrate before interacting.
   await clientPage.waitForLoadState("networkidle", { timeout: 30000 });
   await clientPage.locator("#name").fill(clientName);
   await clientPage.locator("#email").fill(clientEmail);

--- a/e2e/tests/view-as-customer.e2e.ts
+++ b/e2e/tests/view-as-customer.e2e.ts
@@ -1,0 +1,161 @@
+import { test, expect } from "@playwright/test";
+import type { Browser, Page } from "@playwright/test";
+
+const API_URL = "http://localhost:3001";
+const WEB_URL = "http://localhost:3000";
+
+async function createOwner(browser: Browser, prefix = "vac-owner"): Promise<{
+  context: import("@playwright/test").BrowserContext;
+  page: Page;
+  email: string;
+  password: string;
+}> {
+  const context = await browser.newContext({ storageState: undefined });
+  const page = await context.newPage();
+  const orgName = `${prefix} Org ${Date.now().toString(36)}`;
+  const email = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
+  const password = "ViewAs123!";
+
+  const res = await page.request.post(`${API_URL}/api/onboarding/signup`, {
+    data: { name: "VAC Owner", email, password, orgName },
+  });
+  if (!res.ok()) {
+    throw new Error(`Owner signup failed (${res.status()}): ${await res.text()}`);
+  }
+
+  await page.goto(`${WEB_URL}/login`, { waitUntil: "networkidle", timeout: 15000 });
+  await page.getByLabel(/email/i).fill(email);
+  await page.getByLabel(/password/i).fill(password);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await page.waitForURL(/\/(setup|dashboard)/, { timeout: 15000 });
+
+  if (page.url().includes("/setup")) {
+    const cookies = await context.cookies();
+    const csrfToken = cookies.find((c) => c.name === "csrf-token")?.value || "";
+    await page.request.post(`${API_URL}/api/setup/complete`, {
+      headers: { "x-csrf-token": csrfToken },
+    });
+    await page.goto(`${WEB_URL}/dashboard`, {
+      waitUntil: "networkidle",
+      timeout: 15000,
+    });
+  }
+
+  return { context, page, email, password };
+}
+
+async function inviteAndAcceptClient(
+  browser: Browser,
+  ownerPage: Page,
+  prefix: string,
+): Promise<{ clientEmail: string; clientName: string; password: string }> {
+  const clientEmail = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@test.local`;
+  const password = "Client123!";
+  const clientName = "Test Client VAC";
+
+  const inviteRes = await ownerPage.request.post(
+    `${API_URL}/api/auth/organization/invite-member`,
+    {
+      data: { email: clientEmail, role: "member" },
+      headers: { Origin: WEB_URL },
+    },
+  );
+  if (!inviteRes.ok()) {
+    throw new Error(`Invite failed (${inviteRes.status()}): ${await inviteRes.text()}`);
+  }
+  const inviteBody = await inviteRes.json();
+  const invitationId: string = inviteBody?.id || inviteBody?.invitation?.id;
+  if (!invitationId) {
+    throw new Error(`Could not extract invitation id from: ${JSON.stringify(inviteBody)}`);
+  }
+
+  const clientCtx = await browser.newContext({ storageState: undefined });
+  const clientPage = await clientCtx.newPage();
+  await clientPage.goto(`${WEB_URL}/accept-invite?id=${invitationId}`, {
+    waitUntil: "networkidle",
+    timeout: 15000,
+  });
+  await clientPage.getByLabel(/your name/i).fill(clientName);
+  await clientPage.getByLabel(/email/i).fill(clientEmail);
+  await clientPage.getByLabel(/password/i).fill(password);
+  await clientPage.getByRole("button", { name: /create account & join/i }).click();
+  await expect(clientPage).toHaveURL(/\/portal/, { timeout: 20000 });
+  await clientCtx.close();
+
+  return { clientEmail, clientName, password };
+}
+
+test.describe("View as customer", () => {
+  test("owner can preview portal as a client and mutations are blocked", async ({
+    browser,
+  }) => {
+    const { context: ownerCtx, page: ownerPage } = await createOwner(browser);
+    const { clientEmail, clientName } = await inviteAndAcceptClient(
+      browser,
+      ownerPage,
+      "vac-client",
+    );
+
+    await ownerPage.goto(`${WEB_URL}/dashboard/clients`, {
+      waitUntil: "networkidle",
+      timeout: 15000,
+    });
+    await ownerPage.getByRole("button", { name: /^clients/i }).click();
+
+    const clientRow = ownerPage
+      .locator("div")
+      .filter({ hasText: clientEmail })
+      .first();
+    await expect(clientRow).toBeVisible({ timeout: 10000 });
+
+    const viewButton = clientRow.getByTitle("View as customer");
+    await expect(viewButton).toBeVisible();
+
+    const [previewPage] = await Promise.all([
+      ownerCtx.waitForEvent("page"),
+      viewButton.click(),
+    ]);
+
+    await previewPage.waitForLoadState("networkidle");
+    await previewPage.waitForURL(/\/portal/, { timeout: 15000 });
+
+    await expect(previewPage.getByText(/previewing as/i)).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(previewPage.getByText(clientName)).toBeVisible();
+    await expect(previewPage.getByText(/read-only/i)).toBeVisible();
+    await expect(
+      previewPage.getByRole("button", { name: /exit preview/i }),
+    ).toBeVisible();
+
+    const mutationResult = await previewPage.evaluate(async () => {
+      try {
+        const res = await fetch("http://localhost:3001/api/clients/me/profile", {
+          method: "PUT",
+          credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Preview-As": JSON.parse(
+              window.sessionStorage.getItem("atrium:previewAs") || "{}",
+            ).clientId || "",
+          },
+          body: JSON.stringify({ company: "should-not-save" }),
+        });
+        return { ok: res.ok, status: res.status };
+      } catch (err) {
+        return { error: String(err), ok: false, status: 0 };
+      }
+    });
+    expect(mutationResult.ok).not.toBe(true);
+    expect([401, 403]).toContain(mutationResult.status);
+
+    await previewPage.getByRole("button", { name: /exit preview/i }).click();
+    await previewPage
+      .waitForURL(/\/dashboard\/clients/, { timeout: 5000 })
+      .catch(() => {
+        // Tab may have closed via window.close() instead of navigating.
+      });
+
+    await ownerCtx.close();
+  });
+});

--- a/e2e/tests/view-as-customer.e2e.ts
+++ b/e2e/tests/view-as-customer.e2e.ts
@@ -23,13 +23,22 @@ async function createOwner(browser: Browser, prefix = "vac-owner"): Promise<{
     throw new Error(`Owner signup failed (${res.status()}): ${await res.text()}`);
   }
 
-  await page.goto(`${WEB_URL}/login`, { waitUntil: "networkidle", timeout: 15000 });
-  await page.getByLabel(/email/i).fill(email);
-  await page.getByLabel(/password/i).fill(password);
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await page.waitForURL(/\/(setup|dashboard)/, { timeout: 15000 });
+  await page.goto(`${WEB_URL}/dashboard`, {
+    waitUntil: "networkidle",
+    timeout: 15000,
+  });
 
-  if (page.url().includes("/setup")) {
+  let url = page.url();
+  if (url.includes("/login")) {
+    await page.goto(`${WEB_URL}/login`);
+    await page.getByLabel(/email/i).fill(email);
+    await page.getByLabel(/password/i).fill(password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await page.waitForURL(/\/(setup|dashboard)/, { timeout: 15000 });
+    url = page.url();
+  }
+
+  if (url.includes("/setup")) {
     const cookies = await context.cookies();
     const csrfToken = cookies.find((c) => c.name === "csrf-token")?.value || "";
     await page.request.post(`${API_URL}/api/setup/complete`, {
@@ -72,12 +81,15 @@ async function inviteAndAcceptClient(
   const clientCtx = await browser.newContext({ storageState: undefined });
   const clientPage = await clientCtx.newPage();
   await clientPage.goto(`${WEB_URL}/accept-invite?id=${invitationId}`, {
-    waitUntil: "networkidle",
-    timeout: 15000,
+    waitUntil: "domcontentloaded",
+    timeout: 30000,
   });
-  await clientPage.getByLabel(/your name/i).fill(clientName);
-  await clientPage.getByLabel(/email/i).fill(clientEmail);
-  await clientPage.getByLabel(/password/i).fill(password);
+  await clientPage.waitForSelector("#name", { state: "visible", timeout: 30000 });
+  // Allow React to hydrate before interacting.
+  await clientPage.waitForLoadState("networkidle", { timeout: 30000 });
+  await clientPage.locator("#name").fill(clientName);
+  await clientPage.locator("#email").fill(clientEmail);
+  await clientPage.locator("#password").fill(password);
   await clientPage.getByRole("button", { name: /create account & join/i }).click();
   await expect(clientPage).toHaveURL(/\/portal/, { timeout: 20000 });
   await clientCtx.close();
@@ -86,6 +98,7 @@ async function inviteAndAcceptClient(
 }
 
 test.describe("View as customer", () => {
+  test.setTimeout(120000);
   test("owner can preview portal as a client and mutations are blocked", async ({
     browser,
   }) => {

--- a/e2e/tests/view-as-customer.e2e.ts
+++ b/e2e/tests/view-as-customer.e2e.ts
@@ -170,4 +170,93 @@ test.describe("View as customer", () => {
 
     await ownerCtx.close();
   });
+
+  test("query params are stripped from URL after preview mode initializes", async ({
+    browser,
+  }) => {
+    const { context: ownerCtx, page: ownerPage } = await createOwner(
+      browser,
+      "vac-strip",
+    );
+    const { clientEmail } = await inviteAndAcceptClient(
+      browser,
+      ownerPage,
+      "vac-strip-client",
+    );
+
+    await ownerPage.goto(`${WEB_URL}/dashboard/clients`, {
+      waitUntil: "networkidle",
+      timeout: 15000,
+    });
+    await ownerPage.getByRole("button", { name: /^clients/i }).click();
+
+    const clientRow = ownerPage
+      .locator("div")
+      .filter({ hasText: clientEmail })
+      .first();
+    await expect(clientRow).toBeVisible({ timeout: 10000 });
+
+    const viewButton = clientRow.getByTitle("View as customer");
+    const [previewPage] = await Promise.all([
+      ownerCtx.waitForEvent("page"),
+      viewButton.click(),
+    ]);
+
+    await previewPage.waitForLoadState("networkidle");
+    // After replaceState the URL must contain no previewAs/previewName/previewEmail
+    // query params. The portal may internally redirect /portal -> /portal/projects.
+    await expect(previewPage).toHaveURL(
+      /^http:\/\/localhost:3000\/portal(\/.*)?$/,
+      { timeout: 10000 },
+    );
+    expect(new URL(previewPage.url()).search).toBe("");
+
+    await ownerCtx.close();
+  });
+
+  test("banner shows fallback name 'Client' when previewName param is absent", async ({
+    browser,
+  }) => {
+    // Navigate directly to /portal?previewAs=<id> without previewName/previewEmail.
+    // The provider must fall back to "Client" / "" instead of crashing.
+    const { context: ownerCtx, page: ownerPage } = await createOwner(
+      browser,
+      "vac-fallback",
+    );
+    const { } = await inviteAndAcceptClient(
+      browser,
+      ownerPage,
+      "vac-fallback-client",
+    );
+
+    // Fetch the client's userId directly via the API so we can craft the URL.
+    const membersRes = await ownerPage.request.get(
+      `${API_URL}/api/clients?page=1&limit=100`,
+      { headers: { Origin: WEB_URL } },
+    );
+    const membersBody = await membersRes.json();
+    const clientMember = (membersBody.data as Array<{
+      role: string;
+      userId: string;
+    }>).find((m) => m.role === "member");
+
+    if (!clientMember) {
+      throw new Error("Could not find a member-role member to preview as");
+    }
+
+    // Open /portal with only previewAs — deliberately omit previewName/previewEmail.
+    const portalPage = await ownerCtx.newPage();
+    await portalPage.goto(
+      `${WEB_URL}/portal?previewAs=${clientMember.userId}`,
+      { waitUntil: "networkidle", timeout: 20000 },
+    );
+
+    await expect(portalPage.getByText(/previewing as/i)).toBeVisible({
+      timeout: 10000,
+    });
+    // Fallback name must render as "Client", not throw or show undefined/null.
+    await expect(portalPage.getByText("Client")).toBeVisible();
+
+    await ownerCtx.close();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a **View as customer** preview that lets owners/admins see the portal exactly as a chosen client sees it. Mutations are blocked on both the API and the UI while in preview, and a banner makes the mode unmistakable.
- Available from the Clients list and from each project's client chips. Includes role/org checks server-side, header isolation from the auth proxy, and PII kept out of the URL.

## What ships
- `PreviewModeMiddleware` + `PreviewModeGuard` (NestJS): validates the `X-Preview-As` header, requires owner/admin requester, target must be a member of the active org, blocks all non-GET when in preview.
- `PreviewModeProvider` + `usePreviewMode` (web): tab-scoped sessionStorage state; portal pages disable mutation buttons via the hook.
- Preview launch: from `/dashboard/clients` and from project chips on `/dashboard/projects/[id]` (eye icon, with tooltip; remove now confirms).
- `PreviewBanner` shown across the portal in preview mode with an exit action.

## Security hardening included
- `X-Preview-As` is skipped on `/api/auth/*` so it can't slip through the Better Auth proxy.
- Client name/email handed off via short-lived `localStorage` instead of URL params (avoids Referer-leak of PII during SSR).

## Test plan
- [x] Unit: `apps/api/src/auth/preview-mode.middleware.spec.ts` (11 tests) — covers header skip, role/org checks, header-array, mutation guard, no-mutation cache.
- [x] Unit: `PreviewModeGuard` spec.
- [x] E2E: `e2e/tests/view-as-customer.e2e.ts` — happy path, fallback banner, URL strip after handoff.
- [ ] Manual: launch from clients list and project page; verify portal banner, mutation buttons disabled, exit returns to dashboard.


Closes #42
