### PR TITLE
ci(deploy): publish multi-arch Docker image (amd64 + arm64)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -27,7 +30,7 @@ jobs:
           context: .
           file: docker/unified.Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             NEXT_PUBLIC_API_URL=${{ vars.PUBLIC_URL }}
             NEXT_PUBLIC_BILLING_ENABLED=true


### PR DESCRIPTION
## Summary
- Adds `linux/arm64` to the buildx `platforms` list and wires up `docker/setup-qemu-action` so the deploy workflow publishes a multi-arch manifest at `vibralabs/atrium:latest`.
- ARM hosts (Apple Silicon Mac minis, Raspberry Pi, ARM VMs) will pull the native arm64 variant automatically instead of failing or running under slow QEMU emulation.

Fixes #47.

## Notes
- The Dockerfile is already arch-neutral — `oven/bun:1`, `caddy:2-alpine`, `postgres:16-alpine`, and the PostgreSQL apt repo all ship arm64 builds, and nothing is pinned to x86.
- Build time will increase since arm64 is cross-built via QEMU on the amd64 runner. If that becomes a bottleneck, the follow-up is a matrix with a native `ubuntu-24.04-arm` runner + manifest merge step.

## Test plan
- [ ] Merge to `main`, watch the Deploy workflow finish both `linux/amd64` and `linux/arm64` build steps
- [ ] Verify the manifest: `docker buildx imagetools inspect vibralabs/atrium:latest` shows two platforms
- [ ] Pull on an ARM host (`docker pull vibralabs/atrium:latest`) and confirm it starts without `--platform` overrides