### PR TITLE
feat: disable public signups via ALLOW_SIGNUPS (#54)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,4 +93,8 @@ BETTER_AUTH_SECRET="change-me-in-production-min-32-chars"
 # THROTTLE_LIMIT="100"
 # SIGNUP_THROTTLE_LIMIT="5"
 
+# Set to "false" to disable public self-serve signup (blocks new organizations).
+# Login and invited-client onboarding are unaffected. Default: signups enabled.
+# ALLOW_SIGNUPS="true"
+
 # LOG_LEVEL="info"

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,7 +1,7 @@
 import { All, Controller, Logger, Req, Res } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { AuthService } from "./auth.service";
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 
 @Controller("auth")
 export class AuthController {

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -201,6 +201,53 @@ describe("AuthService", () => {
       );
     });
 
+  });
+
+  describe("organization creation gate", () => {
+    function makeServiceWith(allowSignups: string | undefined): AuthService {
+      const config = {
+        get: mock((key: string, fallback?: string) => {
+          if (key === "WEB_URL") return "http://localhost:3000";
+          if (key === "API_URL") return "http://localhost:3001";
+          if (key === "ALLOW_SIGNUPS") return allowSignups;
+          return fallback;
+        }),
+        getOrThrow: mock((key: string) => {
+          if (key === "BETTER_AUTH_SECRET") return "x".repeat(32);
+          throw new Error(`Missing ${key}`);
+        }),
+      };
+      return new AuthService(
+        config as unknown as ConfigService,
+        mockPrisma as unknown as PrismaService,
+        mockMail as unknown as MailService,
+        mockBilling as unknown as BillingService,
+      );
+    }
+
+    function orgCreateOption(service: AuthService): unknown {
+      interface OrgPlugin {
+        id: string;
+        options?: { allowUserToCreateOrganization?: unknown };
+      }
+      interface AuthWithOptions {
+        options: { plugins: OrgPlugin[] };
+      }
+      const plugins = (service.auth as unknown as AuthWithOptions).options.plugins;
+      return plugins.find((p) => p.id === "organization")?.options
+        ?.allowUserToCreateOrganization;
+    }
+
+    it("blocks org creation when ALLOW_SIGNUPS is 'false'", () => {
+      expect(orgCreateOption(makeServiceWith("false"))).toBe(false);
+    });
+
+    it("allows org creation when ALLOW_SIGNUPS is unset", () => {
+      expect(orgCreateOption(makeServiceWith(undefined))).toBe(true);
+    });
+  });
+
+  describe("generateResetLink (ALS isolation)", () => {
     it("isolates ALS contexts so concurrent generates do not bleed URLs", async () => {
       let call = 0;
       (service.auth as unknown as {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -128,6 +128,8 @@ export class AuthService {
       },
       plugins: [
         organization({
+          allowUserToCreateOrganization:
+            this.config.get("ALLOW_SIGNUPS") !== "false",
           sendInvitationEmail: async ({ invitation, inviter, organization }) => {
             const inviteUrl = `${webUrl}/accept-invite?id=${invitation.id}`;
             const html = await render(

--- a/apps/api/src/auth/preview-mode.middleware.ts
+++ b/apps/api/src/auth/preview-mode.middleware.ts
@@ -3,7 +3,7 @@ import {
   NestMiddleware,
   UnauthorizedException,
 } from "@nestjs/common";
-import { Request, Response, NextFunction } from "express";
+import type { Request, Response, NextFunction } from "express";
 import { ROLES } from "@atrium/shared";
 import { PrismaService } from "../prisma/prisma.service";
 import type { AuthenticatedRequest } from "../common";

--- a/apps/api/src/auth/session.middleware.ts
+++ b/apps/api/src/auth/session.middleware.ts
@@ -1,5 +1,5 @@
 import { Injectable, NestMiddleware } from "@nestjs/common";
-import { Request, Response, NextFunction } from "express";
+import type { Request, Response, NextFunction } from "express";
 import { AuthService } from "./auth.service";
 import type { AuthenticatedRequest, AuthUser, AuthSession, FullOrganization, OrgMember } from "../common";
 

--- a/apps/api/src/billing/webhook.controller.ts
+++ b/apps/api/src/billing/webhook.controller.ts
@@ -7,7 +7,7 @@ import {
   Logger,
 } from "@nestjs/common";
 import { SkipThrottle } from "@nestjs/throttler";
-import { Request } from "express";
+import type { Request } from "express";
 import { Public } from "../common";
 import { BillingService } from "./billing.service";
 import { StripeService } from "./stripe.service";

--- a/apps/api/src/branding/branding.controller.ts
+++ b/apps/api/src/branding/branding.controller.ts
@@ -15,7 +15,7 @@ import {
   Inject,
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
-import { Response } from "express";
+import type { Response } from "express";
 import { BrandingService } from "./branding.service";
 import { UpdateBrandingDto } from "./branding.dto";
 import { AuthGuard, RolesGuard, Roles, CurrentOrg, Public } from "../common";

--- a/apps/api/src/clients/clients.controller.ts
+++ b/apps/api/src/clients/clients.controller.ts
@@ -10,7 +10,7 @@ import {
   Res,
   UseGuards,
 } from "@nestjs/common";
-import { Response } from "express";
+import type { Response } from "express";
 import { ConfigService } from "@nestjs/config";
 import { PrismaService } from "../prisma/prisma.service";
 import {

--- a/apps/api/src/common/filters/http-exception.filter.ts
+++ b/apps/api/src/common/filters/http-exception.filter.ts
@@ -6,7 +6,7 @@ import {
   HttpStatus,
   Logger,
 } from "@nestjs/common";
-import { Response } from "express";
+import type { Response } from "express";
 
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {

--- a/apps/api/src/common/types/authenticated-request.ts
+++ b/apps/api/src/common/types/authenticated-request.ts
@@ -1,4 +1,4 @@
-import { Request } from "express";
+import type { Request } from "express";
 
 export interface AuthUser {
   id: string;

--- a/apps/api/src/documents/documents.controller.ts
+++ b/apps/api/src/documents/documents.controller.ts
@@ -15,7 +15,7 @@ import {
   UploadedFile,
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
 import { DocumentsService } from "./documents.service";
 import { DocumentAuditService } from "./document-audit.service";
 import { FilesService, UploadedFile as UploadedFileType, DOCUMENT_ALLOWED_MIMES } from "../files/files.service";

--- a/apps/api/src/files/files.controller.ts
+++ b/apps/api/src/files/files.controller.ts
@@ -14,7 +14,7 @@ import {
   UploadedFile,
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
-import { Response } from "express";
+import type { Response } from "express";
 import type { File } from "@atrium/database";
 import { FilesService, UploadedFile as UploadedFileType } from "./files.service";
 import { CreateFileLinkDto, UpdateFileDto } from "./files.dto";

--- a/apps/api/src/health.controller.spec.ts
+++ b/apps/api/src/health.controller.spec.ts
@@ -52,6 +52,24 @@ describe("HealthController", () => {
     }
   });
 
+  describe("getConfig", () => {
+    it("reports signupEnabled true by default", () => {
+      const controller = new HealthController(
+        makePrisma({ dbOk: true }) as unknown as PrismaService,
+        makeConfig(),
+      );
+      expect(controller.getConfig().signupEnabled).toBe(true);
+    });
+
+    it("reports signupEnabled false when ALLOW_SIGNUPS is 'false'", () => {
+      const controller = new HealthController(
+        makePrisma({ dbOk: true }) as unknown as PrismaService,
+        makeConfig({ ALLOW_SIGNUPS: "false" }),
+      );
+      expect(controller.getConfig().signupEnabled).toBe(false);
+    });
+  });
+
   describe("domainCheck", () => {
     it("returns 403 for non-loopback callers", async () => {
       const controller = new HealthController(makePrisma({ dbOk: true }) as unknown as PrismaService, makeConfig());

--- a/apps/api/src/health.controller.ts
+++ b/apps/api/src/health.controller.ts
@@ -20,6 +20,7 @@ export class HealthController {
   getConfig() {
     return {
       billingEnabled: this.config.get("BILLING_ENABLED") === "true",
+      signupEnabled: this.config.get("ALLOW_SIGNUPS") !== "false",
     };
   }
 

--- a/apps/api/src/invoices/invoices.controller.ts
+++ b/apps/api/src/invoices/invoices.controller.ts
@@ -14,7 +14,7 @@ import {
   UploadedFile,
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
-import { Response } from "express";
+import type { Response } from "express";
 import { InvoicesService } from "./invoices.service";
 import { InvoicePdfService } from "./invoice-pdf.service";
 import { FilesService, UploadedFile as UploadedFileType, INVOICE_ALLOWED_MIMES } from "../files/files.service";

--- a/apps/api/src/onboarding/onboarding.controller.spec.ts
+++ b/apps/api/src/onboarding/onboarding.controller.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, mock } from "bun:test";
+import { ForbiddenException, BadRequestException } from "@nestjs/common";
+import { OnboardingController } from "./onboarding.controller";
+import type { AuthService } from "../auth/auth.service";
+import type { BillingService } from "../billing/billing.service";
+import type { MailService } from "../mail/mail.service";
+import type { ConfigService } from "@nestjs/config";
+import type { Response } from "express";
+import type { SignupDto } from "./signup.dto";
+
+const makeConfig = (vals: Record<string, string> = {}) =>
+  ({ get: (key: string, def?: string) => vals[key] ?? def }) as unknown as ConfigService;
+
+const makeLogger = () =>
+  ({ error: mock(() => {}), warn: mock(() => {}), info: mock(() => {}) }) as unknown as never;
+
+const makeRes = () =>
+  ({ append: mock(() => {}), status: mock(() => {}) }) as unknown as Response;
+
+const body: SignupDto = {
+  name: "A",
+  email: "a@b.com",
+  password: "TestPass123!",
+  orgName: "Acme",
+} as SignupDto;
+
+describe("OnboardingController signup gate", () => {
+  it("throws ForbiddenException and never calls auth when ALLOW_SIGNUPS is false", async () => {
+    const handler = mock(() => Promise.resolve(new Response()));
+    const authService = { auth: { handler } } as unknown as AuthService;
+    const controller = new OnboardingController(
+      authService,
+      {} as BillingService,
+      makeConfig({ ALLOW_SIGNUPS: "false" }),
+      {} as MailService,
+      makeLogger(),
+    );
+
+    await expect(controller.signup(body, makeRes())).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("passes the gate (reaches Better Auth) when ALLOW_SIGNUPS is unset", async () => {
+    const handler = mock(() =>
+      Promise.resolve({
+        ok: false,
+        status: 400,
+        json: async () => ({ message: "boom" }),
+        headers: { getSetCookie: () => [] },
+      } as unknown as Response),
+    );
+    const authService = { auth: { handler } } as unknown as AuthService;
+    const controller = new OnboardingController(
+      authService,
+      {} as BillingService,
+      makeConfig(), // ALLOW_SIGNUPS unset -> defaults to enabled
+      {} as MailService,
+      makeLogger(),
+    );
+
+    await expect(controller.signup(body, makeRes())).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/onboarding/onboarding.controller.ts
+++ b/apps/api/src/onboarding/onboarding.controller.ts
@@ -4,6 +4,7 @@ import {
   Post,
   Res,
   BadRequestException,
+  ForbiddenException,
 } from "@nestjs/common";
 import { Throttle } from "@nestjs/throttler";
 import { ConfigService } from "@nestjs/config";
@@ -35,6 +36,10 @@ export class OnboardingController {
     @Body() body: SignupDto,
     @Res({ passthrough: true }) res: Response,
   ) {
+    if (this.config.get("ALLOW_SIGNUPS") === "false") {
+      throw new ForbiddenException("Signups are disabled");
+    }
+
     const baseUrl = this.config.get(
       "BETTER_AUTH_URL",
       "http://localhost:3001",

--- a/apps/api/src/onboarding/onboarding.controller.ts
+++ b/apps/api/src/onboarding/onboarding.controller.ts
@@ -9,7 +9,7 @@ import {
 import { Throttle } from "@nestjs/throttler";
 import { ConfigService } from "@nestjs/config";
 import { InjectPinoLogger, PinoLogger } from "nestjs-pino";
-import { Response } from "express";
+import type { Response } from "express";
 import { render } from "@react-email/render";
 import { WelcomeEmail } from "@atrium/email";
 import { Public } from "../common";

--- a/apps/api/src/payments/connect-webhook.controller.ts
+++ b/apps/api/src/payments/connect-webhook.controller.ts
@@ -8,7 +8,7 @@ import {
   Logger,
 } from "@nestjs/common";
 import { SkipThrottle } from "@nestjs/throttler";
-import { Request } from "express";
+import type { Request } from "express";
 import { Public } from "../common";
 import { StripeService } from "../billing/stripe.service";
 import { PaymentsService } from "./payments.service";

--- a/apps/api/src/payments/payments.controller.ts
+++ b/apps/api/src/payments/payments.controller.ts
@@ -8,7 +8,7 @@ import {
   Res,
   UseGuards,
 } from "@nestjs/common";
-import { Response } from "express";
+import type { Response } from "express";
 import { PaymentsService } from "./payments.service";
 import { CreateCheckoutDto, ConnectAuthorizeDto, SaveDirectKeysDto, SavePaymentMethodsDto } from "./payments.dto";
 import { AuthGuard, RolesGuard, Roles, CurrentUser, CurrentOrg, Public } from "../common";

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -10,7 +10,7 @@ import {
   Res,
   UseGuards,
 } from "@nestjs/common";
-import { Response } from "express";
+import type { Response } from "express";
 import { ProjectsService } from "./projects.service";
 import {
   CreateProjectDto,

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -13,7 +13,7 @@ import {
   UseGuards,
 } from "@nestjs/common";
 import { Throttle } from "@nestjs/throttler";
-import { Response } from "express";
+import type { Response } from "express";
 import { TasksService } from "./tasks.service";
 import {
   CreateTaskDto,

--- a/apps/api/src/time-entries/time-entries.controller.ts
+++ b/apps/api/src/time-entries/time-entries.controller.ts
@@ -2,7 +2,7 @@ import {
   Controller, Get, Post, Patch, Delete, Body, Param, Query, Res, UseGuards,
 } from "@nestjs/common";
 import { Throttle } from "@nestjs/throttler";
-import { Response } from "express";
+import type { Response } from "express";
 import {
   AuthGuard, RolesGuard, Roles, CurrentOrg, CurrentUser, CurrentMember, contentDisposition, toCsv,
 } from "../common";

--- a/apps/api/src/updates/updates.controller.ts
+++ b/apps/api/src/updates/updates.controller.ts
@@ -14,7 +14,7 @@ import {
   UseInterceptors,
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
-import { Response } from "express";
+import type { Response } from "express";
 import type { ProjectUpdate } from "@atrium/database";
 import { UpdatesService } from "./updates.service";
 import { CreateUpdateDto, UpdateContentDto, UpdatePreviewPrefsDto } from "./updates.dto";

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -165,6 +165,7 @@ function PlanSelectionStep({
 export default function SignupPage() {
   const config = useAppConfig();
   const billingEnabled = config?.billingEnabled ?? false;
+  const signupsDisabled = config?.signupEnabled === false;
 
   const searchParams = new URLSearchParams(
     typeof window !== "undefined" ? window.location.search : "",
@@ -288,6 +289,26 @@ export default function SignupPage() {
       setLoading(false);
     }
   };
+
+  if (signupsDisabled) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <div className="w-full max-w-sm space-y-6 text-center">
+          <h1 className="text-2xl font-bold">Signups are disabled</h1>
+          <p className="text-[var(--muted-foreground)]">
+            This Atrium instance isn&apos;t accepting new signups. If you already
+            have an account, you can sign in.
+          </p>
+          <Link
+            href="/login"
+            className="inline-block py-2 px-4 bg-[var(--primary)] text-white rounded-lg font-medium hover:opacity-90 transition-opacity"
+          >
+            Go to sign in
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   if (step === "plan") {
     return (

--- a/apps/web/src/lib/app-config.ts
+++ b/apps/web/src/lib/app-config.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 export interface AppConfig {
   billingEnabled: boolean;
+  signupEnabled: boolean;
 }
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
@@ -20,7 +21,7 @@ function fetchConfig(): Promise<AppConfig> {
       })
       .catch(() => {
         pending = null; // allow retry on next mount
-        return { billingEnabled: false };
+        return { billingEnabled: false, signupEnabled: true };
       });
   }
   return pending;

--- a/docs/superpowers/plans/2026-07-20-disable-signups.md
+++ b/docs/superpowers/plans/2026-07-20-disable-signups.md
@@ -382,6 +382,104 @@ git commit -m "test(e2e): cover disabled signup state (#54)"
 
 ---
 
+### Task 5: Gate authenticated org creation on `ALLOW_SIGNUPS`
+
+**Context:** The signup guard (Task 1) only blocks `POST /onboarding/signup`. But the Better Auth proxy (`apps/api/src/auth/auth.controller.ts` → `@All("*path")`) also exposes `POST /api/auth/organization/create`, which any already-authenticated user (including an invited client) can call to create a new org — bypassing the signup gate. This task closes that path so a disabled instance truly stays "one company per host".
+
+**Files:**
+- Modify: `apps/api/src/auth/auth.service.ts` (the `organization({ ... })` plugin config, around line 130)
+- Modify: `apps/api/src/auth/auth.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `this.config.get("ALLOW_SIGNUPS")`; Better Auth `organization()` plugin option `allowUserToCreateOrganization: boolean | ((user) => Awaitable<boolean>)`.
+- Produces: when `ALLOW_SIGNUPS === "false"`, `POST /api/auth/organization/create` is rejected by Better Auth; otherwise unchanged.
+
+**Verified against better-auth@1.4.18:** the option is named `allowUserToCreateOrganization`; in `dist/plugins/organization/routes/crud-org.mjs` the route computes `canCreateOrg = ... options.allowUserToCreateOrganization === void 0 ? true : options.allowUserToCreateOrganization`, so `false` blocks and `undefined` (unset) defaults to allowed. The resolved value is introspectable at `auth.options.plugins.find(p => p.id === "organization").options.allowUserToCreateOrganization`, which the unit test uses.
+
+**Note on the signup flow:** `onboarding.controller.ts` creates its org through this same Better Auth path. That is fine — when signups are enabled the option is `true` so signup works; when disabled, the Task 1 guard 403s before org creation is ever reached. No conflict.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `apps/api/src/auth/auth.service.spec.ts`, add this block (it builds its own config mock so `ALLOW_SIGNUPS` can vary, reusing the file's existing `mockPrisma`, `mockMail`, `mockBilling`):
+
+```ts
+  describe("organization creation gate", () => {
+    function makeServiceWith(allowSignups: string | undefined): AuthService {
+      const config = {
+        get: mock((key: string, fallback?: string) => {
+          if (key === "WEB_URL") return "http://localhost:3000";
+          if (key === "API_URL") return "http://localhost:3001";
+          if (key === "ALLOW_SIGNUPS") return allowSignups;
+          return fallback;
+        }),
+        getOrThrow: mock((key: string) => {
+          if (key === "BETTER_AUTH_SECRET") return "x".repeat(32);
+          throw new Error(`Missing ${key}`);
+        }),
+      };
+      return new AuthService(
+        config as unknown as ConfigService,
+        mockPrisma as unknown as PrismaService,
+        mockMail as unknown as MailService,
+        mockBilling as unknown as BillingService,
+      );
+    }
+
+    function orgCreateOption(service: AuthService): unknown {
+      interface OrgPlugin {
+        id: string;
+        options?: { allowUserToCreateOrganization?: unknown };
+      }
+      interface AuthWithOptions {
+        options: { plugins: OrgPlugin[] };
+      }
+      const plugins = (service.auth as unknown as AuthWithOptions).options.plugins;
+      return plugins.find((p) => p.id === "organization")?.options
+        ?.allowUserToCreateOrganization;
+    }
+
+    it("blocks org creation when ALLOW_SIGNUPS is 'false'", () => {
+      expect(orgCreateOption(makeServiceWith("false"))).toBe(false);
+    });
+
+    it("allows org creation when ALLOW_SIGNUPS is unset", () => {
+      expect(orgCreateOption(makeServiceWith(undefined))).toBe(true);
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test apps/api/src/auth/auth.service.spec.ts`
+Expected: FAIL — the two new tests fail because `allowUserToCreateOrganization` is currently unset (`undefined`), so it is neither `false` nor `true`.
+
+- [ ] **Step 3: Add the option**
+
+In `apps/api/src/auth/auth.service.ts`, inside the `organization({ ... })` call, add `allowUserToCreateOrganization` as the FIRST property (immediately after `organization({`, before `sendInvitationEmail`):
+
+```ts
+        organization({
+          allowUserToCreateOrganization:
+            this.config.get("ALLOW_SIGNUPS") !== "false",
+          sendInvitationEmail: async ({ invitation, inviter, organization }) => {
+```
+
+Leave the rest of the plugin config unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test apps/api/src/auth/auth.service.spec.ts`
+Expected: PASS (all tests in the file, including the two new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/auth/auth.service.ts apps/api/src/auth/auth.service.spec.ts
+git commit -m "feat(api): block authenticated org creation when signups disabled (#54)"
+```
+
+---
+
 ## Self-Review
 
 **Spec coverage:**

--- a/docs/superpowers/plans/2026-07-20-disable-signups.md
+++ b/docs/superpowers/plans/2026-07-20-disable-signups.md
@@ -1,0 +1,399 @@
+# Disable Signups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `ALLOW_SIGNUPS` env var that lets a self-hoster close public self-serve signup so no new organizations can be created.
+
+**Architecture:** A string env flag (default `"true"`) is enforced server-side by a guard at the top of the onboarding signup handler (returns 403 when off), exposed to the frontend via the existing public `GET /health/config` endpoint, and consumed by the signup page to show a "signups disabled" message instead of the form. Login and the invitation `/accept-invite` flow are untouched.
+
+**Tech Stack:** NestJS 11 (API), Next.js 15 + React 19 (web), Bun test runner (API unit tests), Playwright (e2e).
+
+## Global Constraints
+
+- Env var name: **`ALLOW_SIGNUPS`**, string flag following the `BILLING_ENABLED` convention.
+- Default **`"true"`**: absent or any value other than `"false"` = signups enabled. Only the exact string `"false"` disables.
+- Scope: block **only** `POST /onboarding/signup` (new-org self-serve). Do NOT touch login, `/accept-invite`, invitations, or billing.
+- TypeScript: explicit types, no `any`. Every catch logs.
+- e2e harness runs a **single shared API server** whose `global-setup` bootstraps the test account via `POST /onboarding/signup` — so the suite CANNOT run with `ALLOW_SIGNUPS=false` globally. Server-side enforcement is covered by an API unit test; the disabled UI is covered in e2e by intercepting the `/health/config` response with Playwright route mocking.
+
+---
+
+### Task 1: API enforcement guard + env docs
+
+**Files:**
+- Modify: `apps/api/src/onboarding/onboarding.controller.ts`
+- Create: `apps/api/src/onboarding/onboarding.controller.spec.ts`
+- Modify: `.env.example`
+
+**Interfaces:**
+- Consumes: `ConfigService.get(key, default)` (already injected as `this.config`), `ForbiddenException` from `@nestjs/common`.
+- Produces: `POST /onboarding/signup` returns HTTP 403 `"Signups are disabled"` when `ALLOW_SIGNUPS !== "true"`, before any Better Auth call.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/onboarding/onboarding.controller.spec.ts`. The guard runs before any dependency is used, so stubs can be minimal. The "guard passes" case drives the handler into the Better Auth call and asserts it got past the guard (surfaces `BadRequestException`, not `ForbiddenException`).
+
+```ts
+import { describe, expect, it, mock } from "bun:test";
+import { ForbiddenException, BadRequestException } from "@nestjs/common";
+import { OnboardingController } from "./onboarding.controller";
+import type { AuthService } from "../auth/auth.service";
+import type { BillingService } from "../billing/billing.service";
+import type { MailService } from "../mail/mail.service";
+import type { ConfigService } from "@nestjs/config";
+import type { Response } from "express";
+import type { SignupDto } from "./signup.dto";
+
+const makeConfig = (vals: Record<string, string> = {}) =>
+  ({ get: (key: string, def?: string) => vals[key] ?? def }) as unknown as ConfigService;
+
+const makeLogger = () =>
+  ({ error: mock(() => {}), warn: mock(() => {}), info: mock(() => {}) }) as unknown as never;
+
+const makeRes = () =>
+  ({ append: mock(() => {}), status: mock(() => {}) }) as unknown as Response;
+
+const body: SignupDto = {
+  name: "A",
+  email: "a@b.com",
+  password: "TestPass123!",
+  orgName: "Acme",
+} as SignupDto;
+
+describe("OnboardingController signup gate", () => {
+  it("throws ForbiddenException and never calls auth when ALLOW_SIGNUPS is false", async () => {
+    const handler = mock(() => Promise.resolve(new Response()));
+    const authService = { auth: { handler } } as unknown as AuthService;
+    const controller = new OnboardingController(
+      authService,
+      {} as BillingService,
+      makeConfig({ ALLOW_SIGNUPS: "false" }),
+      {} as MailService,
+      makeLogger(),
+    );
+
+    await expect(controller.signup(body, makeRes())).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("passes the gate (reaches Better Auth) when ALLOW_SIGNUPS is unset", async () => {
+    const handler = mock(() =>
+      Promise.resolve({
+        ok: false,
+        status: 400,
+        json: async () => ({ message: "boom" }),
+        headers: { getSetCookie: () => [] },
+      } as unknown as Response),
+    );
+    const authService = { auth: { handler } } as unknown as AuthService;
+    const controller = new OnboardingController(
+      authService,
+      {} as BillingService,
+      makeConfig(), // ALLOW_SIGNUPS unset -> defaults to enabled
+      {} as MailService,
+      makeLogger(),
+    );
+
+    await expect(controller.signup(body, makeRes())).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/api/src/onboarding/onboarding.controller.spec.ts`
+Expected: FAIL — the first test fails because signup currently proceeds and calls `handler` instead of throwing `ForbiddenException`.
+
+- [ ] **Step 3: Add the guard**
+
+In `apps/api/src/onboarding/onboarding.controller.ts`, add `ForbiddenException` to the existing `@nestjs/common` import:
+
+```ts
+import {
+  Body,
+  Controller,
+  Post,
+  Res,
+  BadRequestException,
+  ForbiddenException,
+} from "@nestjs/common";
+```
+
+Then, as the FIRST statement inside `signup(...)` (before the `const baseUrl = ...` line), add:
+
+```ts
+    if (this.config.get("ALLOW_SIGNUPS") === "false") {
+      throw new ForbiddenException("Signups are disabled");
+    }
+```
+
+This matches the `/health/config` semantics exactly (Task 2): enabled unless the value is exactly `"false"`; unset defaults to enabled.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/api/src/onboarding/onboarding.controller.spec.ts`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Document the env var**
+
+In `.env.example`, add after line 94 (`# SIGNUP_THROTTLE_LIMIT="5"`):
+
+```
+# Set to "false" to disable public self-serve signup (blocks new organizations).
+# Login and invited-client onboarding are unaffected. Default: signups enabled.
+# ALLOW_SIGNUPS="true"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/onboarding/onboarding.controller.ts apps/api/src/onboarding/onboarding.controller.spec.ts .env.example
+git commit -m "feat(api): gate signup endpoint behind ALLOW_SIGNUPS (#54)"
+```
+
+---
+
+### Task 2: Expose `signupEnabled` via `/health/config`
+
+**Files:**
+- Modify: `apps/api/src/health.controller.ts:20-24`
+- Modify: `apps/api/src/health.controller.spec.ts`
+
+**Interfaces:**
+- Consumes: `ConfigService.get(key, default)`.
+- Produces: `GET /health/config` response now includes `signupEnabled: boolean` alongside `billingEnabled`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `apps/api/src/health.controller.spec.ts`, add this block inside the top-level `describe("HealthController", ...)` (e.g. after the "throws 503" test):
+
+```ts
+  describe("getConfig", () => {
+    it("reports signupEnabled true by default", () => {
+      const controller = new HealthController(
+        makePrisma({ dbOk: true }) as unknown as PrismaService,
+        makeConfig(),
+      );
+      expect(controller.getConfig().signupEnabled).toBe(true);
+    });
+
+    it("reports signupEnabled false when ALLOW_SIGNUPS is 'false'", () => {
+      const controller = new HealthController(
+        makePrisma({ dbOk: true }) as unknown as PrismaService,
+        makeConfig({ ALLOW_SIGNUPS: "false" }),
+      );
+      expect(controller.getConfig().signupEnabled).toBe(false);
+    });
+  });
+```
+
+Note: the existing `makeConfig` helper is `({ get: (key) => vals[key] })` — it ignores any default arg. `getConfig` uses an explicit `!== "false"` check (see Step 3), which is correct under this stub and in production (unset → `undefined !== "false"` → `true`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/api/src/health.controller.spec.ts`
+Expected: FAIL — `getConfig().signupEnabled` is `undefined` (property does not exist yet).
+
+- [ ] **Step 3: Add the field**
+
+In `apps/api/src/health.controller.ts`, change `getConfig()` to:
+
+```ts
+  @Public()
+  @Get("config")
+  getConfig() {
+    return {
+      billingEnabled: this.config.get("BILLING_ENABLED") === "true",
+      signupEnabled: this.config.get("ALLOW_SIGNUPS") !== "false",
+    };
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/api/src/health.controller.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/health.controller.ts apps/api/src/health.controller.spec.ts
+git commit -m "feat(api): expose signupEnabled in /health/config (#54)"
+```
+
+---
+
+### Task 3: Frontend — config type + disabled signup UI
+
+**Files:**
+- Modify: `apps/web/src/lib/app-config.ts`
+- Modify: `apps/web/src/app/(auth)/signup/page.tsx`
+
+**Interfaces:**
+- Consumes: `useAppConfig()` returning `AppConfig | null` where `AppConfig` now has `signupEnabled: boolean`.
+- Produces: `/signup` renders a "Signups are disabled" screen (heading + "Go to sign in" link, no form) when `config?.signupEnabled === false`.
+
+- [ ] **Step 1: Add `signupEnabled` to the config type**
+
+In `apps/web/src/lib/app-config.ts`, update the interface and the catch fallback:
+
+```ts
+export interface AppConfig {
+  billingEnabled: boolean;
+  signupEnabled: boolean;
+}
+```
+
+and in `fetchConfig`'s `.catch(...)`:
+
+```ts
+      .catch(() => {
+        pending = null; // allow retry on next mount
+        return { billingEnabled: false, signupEnabled: true };
+      });
+```
+
+- [ ] **Step 2: Render the disabled state on the signup page**
+
+In `apps/web/src/app/(auth)/signup/page.tsx`, inside `SignupPage`, add a derived flag right after the existing `billingEnabled` line (currently line 167):
+
+```tsx
+  const signupsDisabled = config?.signupEnabled === false;
+```
+
+Then add this early return immediately before the existing `if (step === "plan") {` block (currently line 292) — after all hooks so hook order stays stable:
+
+```tsx
+  if (signupsDisabled) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <div className="w-full max-w-sm space-y-6 text-center">
+          <h1 className="text-2xl font-bold">Signups are disabled</h1>
+          <p className="text-[var(--muted-foreground)]">
+            This Atrium instance isn&apos;t accepting new signups. If you already
+            have an account, you can sign in.
+          </p>
+          <Link
+            href="/login"
+            className="inline-block py-2 px-4 bg-[var(--primary)] text-white rounded-lg font-medium hover:opacity-90 transition-opacity"
+          >
+            Go to sign in
+          </Link>
+        </div>
+      </div>
+    );
+  }
+```
+
+`Link` is already imported at the top of the file. No other changes.
+
+- [ ] **Step 3: Verify the app typechecks/builds**
+
+Run: `bun run --filter @atrium/web build`
+Expected: build succeeds with no TypeScript errors. (A full build is the reliable signal here; there is no separate web unit-test runner.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/lib/app-config.ts "apps/web/src/app/(auth)/signup/page.tsx"
+git commit -m "feat(web): show disabled state on signup page when signups are off (#54)"
+```
+
+---
+
+### Task 4: e2e coverage for the disabled UI
+
+**Files:**
+- Create: `e2e/tests/signup-disabled.e2e.ts`
+
+**Interfaces:**
+- Consumes: the running web app at `baseURL` (`http://localhost:3000`) and the `/signup` route; intercepts `**/api/health/config` to control `signupEnabled` without changing API env.
+- Produces: passing Playwright spec proving the disabled message shows when the flag is off and the form shows when it is on.
+
+- [ ] **Step 1: Write the e2e test**
+
+Create `e2e/tests/signup-disabled.e2e.ts`:
+
+```ts
+import { test, expect } from "@playwright/test";
+
+// The shared API server bootstraps the suite via POST /onboarding/signup, so it
+// runs with signups enabled. To exercise the disabled UI without a second API,
+// intercept the public /health/config response the signup page reads.
+test.describe("signup disabled state", () => {
+  // Visit as a logged-out user — /signup is public.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("shows the disabled message when signups are off", async ({ page }) => {
+    await page.route("**/api/health/config", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ billingEnabled: false, signupEnabled: false }),
+      }),
+    );
+
+    await page.goto("/signup");
+
+    await expect(
+      page.getByRole("heading", { name: /signups are disabled/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /go to sign in/i }),
+    ).toBeVisible();
+    // The account form must not render.
+    await expect(page.getByLabel(/agency \/ company name/i)).toHaveCount(0);
+  });
+
+  test("shows the signup form when signups are enabled", async ({ page }) => {
+    await page.route("**/api/health/config", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ billingEnabled: false, signupEnabled: true }),
+      }),
+    );
+
+    await page.goto("/signup");
+
+    await expect(
+      page.getByRole("heading", { name: /create your account/i }),
+    ).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the e2e test**
+
+Run: `bun run test:e2e -- signup-disabled`
+Expected: PASS (2 tests). Playwright auto-starts the web + API servers if not already running.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/tests/signup-disabled.e2e.ts
+git commit -m "test(e2e): cover disabled signup state (#54)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `ALLOW_SIGNUPS` env var, default enabled, only `"false"` disables → Task 1 (guard: `=== "false"`) + Task 2 (config: `!== "false"`). Identical semantics: enabled unless the value is exactly `"false"`; unset defaults to enabled. ✅
+- API 403 enforcement before any user/org creation → Task 1. ✅
+- Expose `signupEnabled` on `/health/config` → Task 2. ✅
+- Frontend `AppConfig.signupEnabled` + fail-open default → Task 3 Step 1. ✅
+- Signup page disabled message → Task 3 Step 2. ✅
+- `.env.example` docs → Task 1 Step 5. ✅
+- e2e coverage (disabled + enabled UI) → Task 4. ✅
+- Untouched login/invite/billing → no tasks modify them. ✅
+
+**Placeholder scan:** No TBD/TODO; all steps contain concrete code and commands. ✅
+
+**Type consistency:** `signupEnabled: boolean` used identically in `AppConfig` (Task 3) and the `/health/config` response (Task 2). Guard throws `ForbiddenException` (Task 1) matching the spec's 403. `useAppConfig()` returns `AppConfig | null`, and the page guards with `config?.signupEnabled === false`. Server guard (`=== "false"`) and config flag (`!== "false"`) use identical `"false"`-means-disabled semantics, so the UI and the enforcement never disagree. ✅

--- a/docs/superpowers/specs/2026-07-20-disable-signups-design.md
+++ b/docs/superpowers/specs/2026-07-20-disable-signups-design.md
@@ -1,0 +1,50 @@
+# Disable Signups — Design
+
+**Issue:** [#54](https://github.com/Vibra-Labs/Atrium/issues/54) — allow a self-hoster to disable/limit signups so only one company exists per host.
+
+## Goal
+
+Give operators a switch to close public self-serve signup. When off, no new organizations can be created via `POST /onboarding/signup`; everything else (login, invited-client onboarding) keeps working.
+
+## Decision
+
+Manual **env var** toggle, not a UI toggle. Signup is a host-global concern, but Atrium's settings/roles model is entirely per-organization with no instance-level admin. An env var is the correct primitive for a host-level policy and ships without a schema change. A Settings UI toggle was considered and deferred — it would require a new instance-level settings store and a global-authorization decision (whose org governs the one shared signup page when multiple orgs exist).
+
+## Behavior
+
+- New env var **`ALLOW_SIGNUPS`**, string flag matching the existing `BILLING_ENABLED` convention.
+- **Default `"true"`** — if the var is absent or any value other than `"false"`, signups stay enabled. Preserves current behavior on upgrade.
+- Set `ALLOW_SIGNUPS="false"` to close signups.
+- **Scope:** blocks only new-org self-serve signup. Login and the `/accept-invite` invitation flow are untouched.
+
+## Changes
+
+| Layer | File | Change |
+|---|---|---|
+| API enforcement | `apps/api/src/onboarding/onboarding.controller.ts` | At the top of `signup()`, if `ALLOW_SIGNUPS` !== `"true"`, throw `ForbiddenException("Signups are disabled")` before any user/org creation. This is the real gate. |
+| Config expose | `apps/api/src/health.controller.ts` | Add `signupEnabled: this.config.get("ALLOW_SIGNUPS", "true") === "true"` to the public `GET /health/config` response. |
+| Frontend config | `apps/web/src/lib/app-config.ts` | Add `signupEnabled: boolean` to `AppConfig`; default `true` in the catch fallback. |
+| Frontend signup page | `apps/web/src/app/(auth)/signup/page.tsx` | When `config?.signupEnabled === false`, render a centered "Signups are disabled" message with a link to `/login` instead of the plan/account steps. |
+| Docs | `.env.example` | Document `ALLOW_SIGNUPS="true"` with a comment near the auth/onboarding section. |
+
+Untouched: login, `/accept-invite`, invitations, billing.
+
+## Error handling
+
+- API returns HTTP 403 with message `"Signups are disabled"` — the frontend already surfaces `data.message` on non-OK responses, so a user who reaches the endpoint directly gets a clear error.
+- Frontend fails open to `signupEnabled: true` only if `/health/config` is unreachable (matches existing `billingEnabled` fallback). The API guard is the authoritative enforcement regardless of what the UI shows.
+
+## Testing (e2e, required)
+
+New spec in `e2e/tests/`:
+
+1. With `ALLOW_SIGNUPS="false"`: `POST /api/onboarding/signup` returns 403, and the `/signup` page shows the disabled message (no form).
+2. Sanity: login still works with signups disabled.
+
+The flag is read from API env at request time. Confirm how the e2e harness sets API env (`e2e/global-setup.ts` / Playwright `webServer`) — the disabled-state test needs the API started with `ALLOW_SIGNUPS=false`. If the harness starts a single shared API, the test may assert the 403 path via a dedicated run or config; resolve this when writing the test rather than assuming.
+
+## Non-goals
+
+- No Settings UI toggle (deferred; would need instance-level settings + global-auth design).
+- No auto single-tenant "block once an org exists" behavior.
+- No changes to invitations or login.

--- a/e2e/tests/files.e2e.ts
+++ b/e2e/tests/files.e2e.ts
@@ -19,15 +19,19 @@ test.describe("Files", () => {
     const projectLink = page.locator("a[href*='/dashboard/projects/']").first();
     if (await projectLink.isVisible({ timeout: 3000 }).catch(() => false)) {
       await projectLink.click();
-      // The detail page opens on the Updates tab and file upload lives under
-      // Files. The tab's onClick is attached on hydration, so a click can land
-      // on inert markup and do nothing. Retry until the panel actually renders.
-      const uploadText = page.getByText(/upload/i).first();
+
+      // The detail page opens on the Updates tab, and on the Files tab the
+      // upload action sits behind the "Add" menu rather than being visible
+      // outright. The tab handler is attached on hydration, so retry the click
+      // until the panel actually renders.
+      const filesHeading = page.getByRole("heading", { name: "Files" });
       await expect(async () => {
         await page.getByTestId("project-tab-files").click();
-        await expect(uploadText).toBeVisible({ timeout: 1000 });
+        await expect(filesHeading).toBeVisible({ timeout: 1000 });
       }).toPass({ timeout: 15000 });
-      await expect(page.getByText(/files/i)).toBeVisible();
+
+      await page.getByRole("button", { name: "Add", exact: true }).first().click();
+      await expect(page.getByText("Upload file")).toBeVisible({ timeout: 5000 });
     }
   });
 

--- a/e2e/tests/files.e2e.ts
+++ b/e2e/tests/files.e2e.ts
@@ -19,9 +19,14 @@ test.describe("Files", () => {
     const projectLink = page.locator("a[href*='/dashboard/projects/']").first();
     if (await projectLink.isVisible({ timeout: 3000 }).catch(() => false)) {
       await projectLink.click();
-      // The detail page opens on the Updates tab; file upload lives under Files.
-      await page.getByTestId("project-tab-files").click();
-      await expect(page.getByText(/upload/i).first()).toBeVisible({ timeout: 5000 });
+      // The detail page opens on the Updates tab and file upload lives under
+      // Files. The tab's onClick is attached on hydration, so a click can land
+      // on inert markup and do nothing. Retry until the panel actually renders.
+      const uploadText = page.getByText(/upload/i).first();
+      await expect(async () => {
+        await page.getByTestId("project-tab-files").click();
+        await expect(uploadText).toBeVisible({ timeout: 1000 });
+      }).toPass({ timeout: 15000 });
       await expect(page.getByText(/files/i)).toBeVisible();
     }
   });

--- a/e2e/tests/files.e2e.ts
+++ b/e2e/tests/files.e2e.ts
@@ -19,6 +19,8 @@ test.describe("Files", () => {
     const projectLink = page.locator("a[href*='/dashboard/projects/']").first();
     if (await projectLink.isVisible({ timeout: 3000 }).catch(() => false)) {
       await projectLink.click();
+      // The detail page opens on the Updates tab; file upload lives under Files.
+      await page.getByTestId("project-tab-files").click();
       await expect(page.getByText(/upload/i).first()).toBeVisible({ timeout: 5000 });
       await expect(page.getByText(/files/i)).toBeVisible();
     }

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,8 +1,28 @@
 import { readFileSync, existsSync } from "fs";
 import { resolve } from "path";
-import type { APIRequestContext, BrowserContext } from "@playwright/test";
+import { expect } from "@playwright/test";
+import type { APIRequestContext, BrowserContext, Locator, Page } from "@playwright/test";
 
 const API = "http://localhost:3001/api";
+
+const SEARCH_PLACEHOLDER = /search projects, tasks, files, people/i;
+
+/**
+ * Open the global search palette and return its input.
+ *
+ * The Cmd+K handler is registered in a `useEffect`, so it does not exist until
+ * React has hydrated. A single press right after `goto` is silently dropped if
+ * it lands first, which made these tests flaky. Retry the press until the
+ * palette actually opens rather than assuming the first one registers.
+ */
+export async function openSearchPalette(page: Page): Promise<Locator> {
+  const input = page.getByPlaceholder(SEARCH_PLACEHOLDER);
+  await expect(async () => {
+    await page.keyboard.press("Meta+k");
+    await expect(input).toBeVisible({ timeout: 1000 });
+  }).toPass({ timeout: 15000 });
+  return input;
+}
 
 /**
  * Read the CSRF token from the stored auth state file written by global-setup.

--- a/e2e/tests/search.e2e.ts
+++ b/e2e/tests/search.e2e.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { getCsrfToken } from "./helpers";
+import { getCsrfToken, openSearchPalette } from "./helpers";
 
 const API = "http://localhost:3001/api";
 
@@ -97,21 +97,14 @@ test.describe("Global Search", () => {
 
     test("Cmd+K opens the search palette", async ({ page }) => {
       await page.goto("/dashboard");
-      await page.keyboard.press("Meta+k");
-      await expect(
-        page.getByPlaceholder(/search projects, tasks, files, people/i),
-      ).toBeVisible({ timeout: 5000 });
+      await openSearchPalette(page);
     });
 
     test("typing 2+ chars shows results section headers", async ({ page }) => {
       test.skip(!uiProjectId, "No UI project available");
 
       await page.goto("/dashboard");
-      await page.keyboard.press("Meta+k");
-      const input = page.getByPlaceholder(
-        /search projects, tasks, files, people/i,
-      );
-      await expect(input).toBeVisible({ timeout: 5000 });
+      const input = await openSearchPalette(page);
       // Search for the prefix of the unique project name created in beforeAll
       await input.fill(uiProjectName.slice(0, 9));
       // Wait for debounce + fetch
@@ -122,10 +115,7 @@ test.describe("Global Search", () => {
 
     test("Escape closes the search palette", async ({ page }) => {
       await page.goto("/dashboard");
-      await page.keyboard.press("Meta+k");
-      await expect(
-        page.getByPlaceholder(/search projects, tasks, files, people/i),
-      ).toBeVisible({ timeout: 5000 });
+      await openSearchPalette(page);
       await page.keyboard.press("Escape");
       await expect(
         page.getByPlaceholder(/search projects, tasks, files, people/i),

--- a/e2e/tests/signup-disabled.e2e.ts
+++ b/e2e/tests/signup-disabled.e2e.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+
+// The shared API server bootstraps the suite via POST /onboarding/signup, so it
+// runs with signups enabled. To exercise the disabled UI without a second API,
+// intercept the public /health/config response the signup page reads.
+test.describe("signup disabled state", () => {
+  // Visit as a logged-out user — /signup is public.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("shows the disabled message when signups are off", async ({ page }) => {
+    await page.route("**/api/health/config", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ billingEnabled: false, signupEnabled: false }),
+      }),
+    );
+
+    await page.goto("/signup");
+
+    await expect(
+      page.getByRole("heading", { name: /signups are disabled/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /go to sign in/i }),
+    ).toBeVisible();
+    // The account form must not render.
+    await expect(page.getByLabel(/agency \/ company name/i)).toHaveCount(0);
+  });
+
+  test("shows the signup form when signups are enabled", async ({ page }) => {
+    await page.route("**/api/health/config", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ billingEnabled: false, signupEnabled: true }),
+      }),
+    );
+
+    await page.goto("/signup");
+
+    await expect(
+      page.getByRole("heading", { name: /create your account/i }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #54.

Adds an `ALLOW_SIGNUPS` env toggle so a self-hoster can close public self-serve signup. Set `ALLOW_SIGNUPS="false"` to disable; default (unset/any other value) keeps signups enabled.

## What it does
- **API**: gates `POST /onboarding/signup` with a 403 when disabled.
- **API**: gates authenticated org creation via the Better Auth proxy (`allowUserToCreateOrganization`), closing the bypass where a logged-in user could create a new org directly.
- **API**: exposes `signupEnabled` on `GET /health/config`.
- **Web**: signup page shows a disabled state (no form) when signups are off; fails open if config is unreachable.

## Scope
Blocks only new-org signup. Login and invited-client `/accept-invite` are unaffected.

## Tests
Unit tests for the signup gate, config flag, and org-creation gate; e2e coverage for the disabled/enabled signup UI.