### PR TITLE
fix: point notification links at the right portal tab (#56)

### DIFF
--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -15,9 +15,12 @@ mock.module("@atrium/email", () => ({
   ProjectUpdateEmail: (props: Record<string, unknown>) => props,
   TaskAssignedEmail: (props: Record<string, unknown>) => props,
   InvoiceSentEmail: (props: Record<string, unknown>) => props,
+  InvoicePaidEmail: (props: Record<string, unknown>) => props,
   DecisionClosedEmail: (props: Record<string, unknown>) => props,
   DocumentUploadedEmail: (props: Record<string, unknown>) => props,
   DocumentRespondedEmail: (props: Record<string, unknown>) => props,
+  DocumentReminderEmail: (props: Record<string, unknown>) => props,
+  DocumentSigningTurnEmail: (props: Record<string, unknown>) => props,
 }));
 
 mock.module("@react-email/render", () => ({
@@ -477,6 +480,68 @@ describe("NotificationsService", () => {
       title: "Invoice INV-0001",
     });
     expect(createCall[0].message).toContain("$130.00");
+  });
+
+  // --- dashboard-side deep links ---
+
+  test("notifyInvoicePaid points admins at the invoices tab", async () => {
+    prisma.invoice.findUnique.mockImplementation(() =>
+      Promise.resolve({
+        id: "inv-1",
+        invoiceNumber: "INV-0001",
+        organizationId: "org-1",
+        project: { id: "proj-1", name: "Test Project" },
+        lineItems: [{ quantity: 1, unitPrice: 5000 }],
+      }),
+    );
+    (prisma as any).member = {
+      findMany: mock(() =>
+        Promise.resolve([
+          { userId: "admin-1", user: { name: "Ada", email: "ada@example.com" } },
+        ]),
+      ),
+    };
+    const done = new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    service.notifyInvoicePaid("inv-1");
+
+    await done;
+
+    expect(render).toHaveBeenCalled();
+    expect(emailProps<{ dashboardUrl: string }>().dashboardUrl).toBe(
+      "http://localhost:3000/dashboard/projects/proj-1?tab=invoices",
+    );
+    expect(inApp.createMany.mock.calls[0][0][0]).toMatchObject({
+      link: "/dashboard/projects/proj-1?tab=invoices",
+    });
+  });
+
+  test("notifyTaskAssigned points the assignee at the tasks tab", async () => {
+    const done = new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    service.notifyTaskAssigned("Design hero", "proj-1", "org-1", "member-1");
+
+    await done;
+
+    expect(inApp.createMany.mock.calls[0][0][0]).toMatchObject({
+      userId: "member-1",
+      link: "/dashboard/projects/proj-1?tab=tasks",
+    });
+  });
+
+  test("notifyClientRequestCreated points admins at the tasks tab", async () => {
+    (prisma as any).member = {
+      findMany: mock(() => Promise.resolve([{ userId: "admin-1" }])),
+    };
+    const done = new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    service.notifyClientRequestCreated("proj-1", "org-1", "New request", "Alice");
+
+    await done;
+
+    expect(inApp.createMany.mock.calls[0][0][0]).toMatchObject({
+      link: "/dashboard/projects/proj-1?tab=tasks",
+    });
   });
 
   // --- notifyComment ---

--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -38,13 +38,25 @@ function makeMailService() {
   };
 }
 
-function makeConfig() {
+function makeConfig(webUrl = "http://localhost:3000") {
   return {
     get: (key: string, fallback?: string) => {
-      if (key === "WEB_URL") return "http://localhost:3000";
+      if (key === "WEB_URL") return webUrl;
       return fallback;
     },
   };
+}
+
+/**
+ * Props the service passed to the most recent email render.
+ *
+ * The `@atrium/email` mock above makes each template an identity function over
+ * its props, so `render`'s first argument is the props object under test.
+ */
+function emailProps<T>(): T {
+  const calls = (render as unknown as { mock: { calls: unknown[][] } }).mock
+    .calls;
+  return calls[calls.length - 1]?.[0] as T;
 }
 
 function makeInAppService() {
@@ -112,6 +124,8 @@ describe("NotificationsService", () => {
   let push: ReturnType<typeof makePushService>;
 
   beforeEach(() => {
+    // render is mocked at module scope, so its call log outlives each test
+    (render as unknown as { mockClear: () => void }).mockClear();
     mail = makeMailService();
     prisma = makePrisma();
     inApp = makeInAppService();
@@ -324,21 +338,50 @@ describe("NotificationsService", () => {
     expect(sendCount).toBe(2);
   });
 
-  test("notifyInvoiceSent links the email to the project page, not /portal/invoices", async () => {
-    // render is mocked at module scope and shared across tests
-    (render as unknown as { mockClear: () => void }).mockClear();
-
+  test("notifyInvoiceSent links the email to the invoices tab, not /portal/invoices", async () => {
     const done = new Promise<void>((resolve) => setTimeout(resolve, 50));
 
     service.notifyInvoiceSent("inv-1");
 
     await done;
 
-    // The InvoiceSentEmail mock returns its props, so render's first argument
-    // is the props object the service built.
-    const props = (render as unknown as { mock: { calls: unknown[][] } }).mock
-      .calls[0]?.[0] as { portalUrl: string };
-    expect(props.portalUrl).toBe("http://localhost:3000/portal/projects/proj-1");
+    expect(render).toHaveBeenCalled();
+    expect(emailProps<{ portalUrl: string }>().portalUrl).toBe(
+      "http://localhost:3000/portal/projects/proj-1?tab=invoices",
+    );
+  });
+
+  test("notifyInvoiceSent points the in-app notification at the invoices tab", async () => {
+    const done = new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    service.notifyInvoiceSent("inv-1");
+
+    await done;
+
+    expect(inApp.createMany.mock.calls[0][0][0]).toMatchObject({
+      link: "/portal/projects/proj-1?tab=invoices",
+    });
+  });
+
+  test("notifyInvoiceSent does not double the slash when WEB_URL has a trailing one", async () => {
+    service = new NotificationsService(
+      mail as unknown as MailService,
+      prisma as unknown as PrismaService,
+      makeConfig("https://app.example.com/") as unknown as ConfigService,
+      inApp as unknown as InAppNotificationsService,
+      push as unknown as PushService,
+      mockLogger as unknown as PinoLogger,
+    );
+    const done = new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    service.notifyInvoiceSent("inv-1");
+
+    await done;
+
+    expect(render).toHaveBeenCalled();
+    expect(emailProps<{ portalUrl: string }>().portalUrl).toBe(
+      "https://app.example.com/portal/projects/proj-1?tab=invoices",
+    );
   });
 
   test("notifyInvoiceSent is fire-and-forget — does not throw on failure", async () => {
@@ -416,7 +459,7 @@ describe("NotificationsService", () => {
       type: "task_created",
       title: "New task on Test Project",
       message: "Design hero section",
-      link: "/portal/projects/proj-1",
+      link: "/portal/projects/proj-1?tab=tasks",
     });
   });
 

--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { render } from "@react-email/render";
 import { NotificationsService } from "./notifications.service";
 import type { MailService } from "../mail/mail.service";
 import type { PrismaService } from "../prisma/prisma.service";
@@ -321,6 +322,23 @@ describe("NotificationsService", () => {
 
     // Both were attempted (Promise.allSettled ensures non-blocking)
     expect(sendCount).toBe(2);
+  });
+
+  test("notifyInvoiceSent links the email to the project page, not /portal/invoices", async () => {
+    // render is mocked at module scope and shared across tests
+    (render as unknown as { mockClear: () => void }).mockClear();
+
+    const done = new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    service.notifyInvoiceSent("inv-1");
+
+    await done;
+
+    // The InvoiceSentEmail mock returns its props, so render's first argument
+    // is the props object the service built.
+    const props = (render as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[0] as { portalUrl: string };
+    expect(props.portalUrl).toBe("http://localhost:3000/portal/projects/proj-1");
   });
 
   test("notifyInvoiceSent is fire-and-forget — does not throw on failure", async () => {

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -20,8 +20,14 @@ import { InAppNotificationsService } from "./in-app-notifications.service";
 import { PushService } from "./push.service";
 import { calculateInvoiceTotal } from "../payments/invoice-total";
 
-/** Tab ids on the portal project page (apps/web .../portal/projects/[id]). */
+/**
+ * Tab ids on the two project pages in apps/web. These mirror the `tabs` arrays
+ * in `(portal)/portal/projects/[id]/page.tsx` and
+ * `(dashboard)/dashboard/projects/[id]/page.tsx`; an id that no longer exists
+ * there is ignored by the page and the visitor lands on Updates.
+ */
 type PortalTab = "updates" | "tasks" | "files" | "invoices";
+type DashboardTab = PortalTab | "time" | "notes";
 
 @Injectable()
 export class NotificationsService {
@@ -52,6 +58,12 @@ export class NotificationsService {
    */
   private portalProjectPath(projectId: string, tab?: PortalTab): string {
     const path = `/portal/projects/${projectId}`;
+    return tab ? `${path}?tab=${tab}` : path;
+  }
+
+  /** Dashboard equivalent of {@link portalProjectPath}, for agency recipients. */
+  private dashboardProjectPath(projectId: string, tab?: DashboardTab): string {
+    const path = `/dashboard/projects/${projectId}`;
     return tab ? `${path}?tab=${tab}` : path;
   }
 
@@ -186,12 +198,10 @@ export class NotificationsService {
     const admins = await this.getOrgAdmins(invoice.organizationId, true);
     if (admins.length === 0) return;
 
-    const dashboardUrl = invoice.project
-      ? `${this.webUrl}/dashboard/projects/${invoice.project.id}`
-      : `${this.webUrl}/dashboard`;
     const link = invoice.project
-      ? `/dashboard/projects/${invoice.project.id}`
+      ? this.dashboardProjectPath(invoice.project.id, "invoices")
       : `/dashboard`;
+    const dashboardUrl = `${this.webUrl}${link}`;
 
     // In-app + push
     this.createInAppAndPush(
@@ -661,8 +671,8 @@ export class NotificationsService {
     const admins = await this.getOrgAdmins(doc.organizationId, true);
     if (admins.length === 0) return;
 
-    const dashboardUrl = `${this.webUrl}/dashboard/projects/${doc.projectId}`;
-    const link = `/dashboard/projects/${doc.projectId}`;
+    const link = this.dashboardProjectPath(doc.projectId, "files");
+    const dashboardUrl = `${this.webUrl}${link}`;
 
     // In-app + push
     this.createInAppAndPush(
@@ -1086,7 +1096,7 @@ export class NotificationsService {
   ): Promise<void> {
     const admins = await this.getOrgAdmins(orgId);
     if (admins.length === 0) return;
-    const link = `/dashboard/projects/${projectId}`;
+    const link = this.dashboardProjectPath(projectId, "tasks");
     this.createInAppAndPush(
       admins.map((a) => a.userId),
       orgId,
@@ -1130,7 +1140,7 @@ export class NotificationsService {
       const isClient = !memberUserIds.has(userId);
       const link = isClient
         ? this.portalProjectPath(projectId, "tasks")
-        : `/dashboard/projects/${projectId}?tab=tasks`;
+        : this.dashboardProjectPath(projectId, "tasks");
       this.createInAppAndPush(
         [userId],
         orgId,
@@ -1148,7 +1158,7 @@ export class NotificationsService {
     orgId: string,
     assigneeId: string,
   ): Promise<void> {
-    const link = `/dashboard/projects/${projectId}`;
+    const link = this.dashboardProjectPath(projectId, "tasks");
     this.createInAppAndPush(
       [assigneeId],
       orgId,

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -20,6 +20,9 @@ import { InAppNotificationsService } from "./in-app-notifications.service";
 import { PushService } from "./push.service";
 import { calculateInvoiceTotal } from "../payments/invoice-total";
 
+/** Tab ids on the portal project page (apps/web .../portal/projects/[id]). */
+type PortalTab = "updates" | "tasks" | "files" | "invoices";
+
 @Injectable()
 export class NotificationsService {
   private webUrl: string;
@@ -33,7 +36,23 @@ export class NotificationsService {
     @InjectPinoLogger(NotificationsService.name)
     private readonly logger: PinoLogger,
   ) {
-    this.webUrl = this.config.get("WEB_URL", "http://localhost:3000");
+    // Every link here is built as `${webUrl}${path}`, so a configured trailing
+    // slash would produce a double slash in every notification URL.
+    this.webUrl = this.config
+      .get("WEB_URL", "http://localhost:3000")
+      .replace(/\/+$/, "");
+  }
+
+  /**
+   * Build a portal project path, optionally deep-linking to a tab.
+   *
+   * The portal project page renders invoices, files/documents and tasks as
+   * tabs, so a notification about one of those has to say which tab it means
+   * or the recipient lands on Updates and has to go hunting.
+   */
+  private portalProjectPath(projectId: string, tab?: PortalTab): string {
+    const path = `/portal/projects/${projectId}`;
+    return tab ? `${path}?tab=${tab}` : path;
   }
 
   /**
@@ -255,8 +274,8 @@ export class NotificationsService {
     const clients = await this.getProjectClients(projectId);
     if (clients.length === 0) return;
 
-    const portalUrl = `${this.webUrl}/portal/projects/${projectId}`;
-    const link = `/portal/projects/${projectId}`;
+    const link = this.portalProjectPath(projectId);
+    const portalUrl = `${this.webUrl}${link}`;
 
     // In-app + push (fire-and-forget)
     this.createInAppAndPush(
@@ -310,8 +329,8 @@ export class NotificationsService {
     const clients = await this.getProjectClients(projectId);
     if (clients.length === 0) return;
 
-    const portalUrl = `${this.webUrl}/portal/projects/${projectId}`;
-    const link = `/portal/projects/${projectId}`;
+    const link = this.portalProjectPath(projectId, "tasks");
+    const portalUrl = `${this.webUrl}${link}`;
     const formattedDueDate = dueDate
       ? dueDate.toLocaleDateString("en-US", {
           year: "numeric",
@@ -407,8 +426,8 @@ export class NotificationsService {
       }
     }
 
-    const portalUrl = `${this.webUrl}/portal/projects/${task.projectId}`;
-    const link = `/portal/projects/${task.projectId}`;
+    const link = this.portalProjectPath(task.projectId, "tasks");
+    const portalUrl = `${this.webUrl}${link}`;
 
     // In-app + push
     this.createInAppAndPush(
@@ -470,7 +489,7 @@ export class NotificationsService {
           day: "numeric",
         })
       : "upon receipt";
-    const link = `/portal/projects/${invoice.projectId}`;
+    const link = this.portalProjectPath(invoice.projectId, "invoices");
     const portalUrl = `${this.webUrl}${link}`;
 
     // In-app + push
@@ -567,8 +586,8 @@ export class NotificationsService {
     const clients = await this.getProjectClients(doc.projectId);
     if (clients.length === 0) return;
 
-    const portalUrl = `${this.webUrl}/portal/projects/${doc.projectId}`;
-    const link = `/portal/projects/${doc.projectId}`;
+    const link = this.portalProjectPath(doc.projectId, "files");
+    const portalUrl = `${this.webUrl}${link}`;
 
     // In-app + push
     this.createInAppAndPush(
@@ -729,8 +748,8 @@ export class NotificationsService {
     );
     if (unrespondedClients.length === 0) return;
 
-    const portalUrl = `${this.webUrl}/portal/projects/${doc.projectId}`;
-    const link = `/portal/projects/${doc.projectId}`;
+    const link = this.portalProjectPath(doc.projectId, "files");
+    const portalUrl = `${this.webUrl}${link}`;
     const expiresAt = doc.expiresAt
       ? doc.expiresAt.toLocaleDateString("en-US", {
           year: "numeric",
@@ -819,8 +838,8 @@ export class NotificationsService {
     ]);
     if (!project || !user) return;
 
-    const portalUrl = `${this.webUrl}/portal/projects/${doc.projectId}`;
-    const link = `/portal/projects/${doc.projectId}`;
+    const link = this.portalProjectPath(doc.projectId, "files");
+    const portalUrl = `${this.webUrl}${link}`;
 
     // In-app + push
     this.createInAppAndPush(
@@ -1110,8 +1129,8 @@ export class NotificationsService {
     for (const userId of userIds) {
       const isClient = !memberUserIds.has(userId);
       const link = isClient
-        ? `/portal/projects/${projectId}`
-        : `/dashboard/projects/${projectId}`;
+        ? this.portalProjectPath(projectId, "tasks")
+        : `/dashboard/projects/${projectId}?tab=tasks`;
       this.createInAppAndPush(
         [userId],
         orgId,

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -470,8 +470,8 @@ export class NotificationsService {
           day: "numeric",
         })
       : "upon receipt";
-    const portalUrl = `${this.webUrl}/portal/invoices`;
     const link = `/portal/projects/${invoice.projectId}`;
+    const portalUrl = `${this.webUrl}${link}`;
 
     // In-app + push
     this.createInAppAndPush(

--- a/apps/web/src/app/(portal)/portal/projects/[id]/page.tsx
+++ b/apps/web/src/app/(portal)/portal/projects/[id]/page.tsx
@@ -203,13 +203,23 @@ export default function PortalProjectDetailPage() {
   const [docsPage, setDocsPage] = useState(1);
   const [docsTotalPages, setDocsTotalPages] = useState(1);
   const [error, setError] = useState("");
-  const [activeTab, setActiveTab] = useState<TabId>(() =>
-    searchParams.get("task") ? "tasks" : "updates",
-  );
+  const [activeTab, setActiveTab] = useState<TabId>(() => {
+    const tabParam = searchParams.get("tab");
+    if (tabParam && tabs.some((t) => t.id === tabParam)) return tabParam as TabId;
+    if (searchParams.get("task")) return "tasks";
+    return "updates";
+  });
 
   // When a ?task=<id> deep link is set, jump to the Tasks tab so the detail
   // modal can open (it's rendered inside the tasks tab).
+  // When a ?tab=<id> deep link is set (e.g. from a notification email), jump to
+  // it so the client lands on what the notification was about.
   useEffect(() => {
+    const tabParam = searchParams.get("tab");
+    if (tabParam && tabs.some((t) => t.id === tabParam)) {
+      setActiveTab(tabParam as TabId);
+      return;
+    }
     if (searchParams.get("task")) setActiveTab("tasks");
   }, [searchParams]);
   const [uploading, setUploading] = useState(false);

--- a/e2e/tests/portal-tab-deeplink.e2e.ts
+++ b/e2e/tests/portal-tab-deeplink.e2e.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Notification emails and in-app notifications deep-link into a specific tab of
+ * the portal project page (?tab=invoices, ?tab=files, ?tab=tasks). Without that
+ * the recipient lands on Updates and has to find what the notification was
+ * about — see issue #56.
+ *
+ * No clicking here: the tab comes from the URL, so these assertions only wait
+ * for hydration rather than racing a click against it.
+ */
+test.describe("Portal project tab deep links", () => {
+  async function firstProjectPath(
+    page: import("@playwright/test").Page,
+  ): Promise<string | null> {
+    await page.goto("/portal/projects");
+    const link = page.locator("a[href*='/portal/projects/']").first();
+    if (!(await link.isVisible({ timeout: 10000 }).catch(() => false))) {
+      return null;
+    }
+    return link.getAttribute("href");
+  }
+
+  test("?tab=invoices opens the Invoices tab", async ({ page }) => {
+    const path = await firstProjectPath(page);
+    test.skip(!path, "no portal project available for this account");
+
+    await page.goto(`${path}?tab=invoices`);
+
+    // The panel heading, not the tab button of the same name.
+    await expect(
+      page.getByRole("heading", { name: "Invoices" }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("?tab=files opens the Files tab", async ({ page }) => {
+    const path = await firstProjectPath(page);
+    test.skip(!path, "no portal project available for this account");
+
+    await page.goto(`${path}?tab=files`);
+
+    // Upload is a <label> wrapping a hidden file input, not a button.
+    await expect(page.getByText(/upload file/i).first()).toBeVisible({
+      timeout: 15000,
+    });
+  });
+
+  test("an unknown ?tab= value falls back to Updates", async ({ page }) => {
+    const path = await firstProjectPath(page);
+    test.skip(!path, "no portal project available for this account");
+
+    await page.goto(`${path}?tab=not-a-tab`);
+
+    await expect(
+      page.getByRole("button", { name: /add update/i }),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.getByRole("heading", { name: "Invoices" }),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Fixes #56.

The invoice email pointed at `/portal/invoices`, which is not a route — the portal only has `projects/`, `settings/`, `changelog/`, `sign/`. Recipients got a 404.

Invoices, files and tasks all render as tabs on the portal project page, so the fix routes to `/portal/projects/:id?tab=invoices` rather than the bare project page — otherwise the recipient lands on Updates and has to go hunting. Same treatment applied to the other portal and dashboard notification links.

Diagnosis and the 404/200 verification came from @rara-cyber on #56.

Covered by unit tests in `notifications.service.spec.ts` and `e2e/tests/portal-tab-deeplink.e2e.ts`.