### PR TITLE
chore: add GitHub Sponsors funding file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [Vibra-Labs]


### PR DESCRIPTION
Adds .github/FUNDING.yml pointing at the Vibra-Labs sponsors profile.