### PR TITLE
Fork-sourced fixes and features: time report, dark mode, portal status, log-time prompt

### DIFF
--- a/apps/api/src/time-entries/time-entries.service.ts
+++ b/apps/api/src/time-entries/time-entries.service.ts
@@ -81,10 +81,21 @@ export type ReportUserBucket = {
   valueCents: number;
 };
 
+export type ReportTaskBucket = {
+  taskId: string;
+  taskTitle: string;
+  projectId: string;
+  projectName: string;
+  seconds: number;
+  billableSeconds: number;
+  valueCents: number;
+};
+
 export type TimeReport = {
   totals: { seconds: number; billableSeconds: number; valueCents: number };
   byProject: ReportProjectBucket[];
   byUser: ReportUserBucket[];
+  byTask: ReportTaskBucket[];
 };
 
 export type GenerateInvoiceResult = { invoiceId: string };
@@ -379,19 +390,21 @@ export class TimeEntriesService {
     // pulling full rows. Two passes — one DB groupBy + a final fold — keeps
     // memory bounded regardless of row count.
     const groups = await this.prisma.timeEntry.groupBy({
-      by: ["projectId", "userId", "billable", "hourlyRateCents"],
+      by: ["projectId", "userId", "taskId", "billable", "hourlyRateCents"],
       where: reportWhere,
       _sum: { durationSec: true },
     });
 
     const projectIds = new Set<string>();
     const userIds = new Set<string>();
+    const taskIds = new Set<string>();
     for (const g of groups) {
       projectIds.add(g.projectId);
       userIds.add(g.userId);
+      if (g.taskId) taskIds.add(g.taskId);
     }
 
-    const [projects, users] = await Promise.all([
+    const [projects, users, tasks] = await Promise.all([
       projectIds.size > 0
         ? this.prisma.project.findMany({
             where: { id: { in: Array.from(projectIds) } },
@@ -404,13 +417,21 @@ export class TimeEntriesService {
             select: { id: true, name: true },
           })
         : Promise.resolve([] as { id: string; name: string }[]),
+      taskIds.size > 0
+        ? this.prisma.task.findMany({
+            where: { id: { in: Array.from(taskIds) } },
+            select: { id: true, title: true },
+          })
+        : Promise.resolve([] as { id: string; title: string }[]),
     ]);
     const projectNameById = new Map(projects.map((p) => [p.id, p.name]));
     const userNameById = new Map(users.map((u) => [u.id, u.name]));
+    const taskTitleById = new Map(tasks.map((t) => [t.id, t.title]));
 
     const totals = { seconds: 0, billableSeconds: 0, valueCents: 0 };
     const byProjectMap = new Map<string, ReportProjectBucket>();
     const byUserMap = new Map<string, ReportUserBucket>();
+    const byTaskMap = new Map<string, ReportTaskBucket>();
 
     for (const g of groups) {
       const sec = g._sum.durationSec ?? 0;
@@ -430,9 +451,23 @@ export class TimeEntriesService {
         billableSeconds: 0,
         valueCents: 0,
       };
+      // Only entries linked to a task contribute to the by-task breakdown.
+      // Untracked-task time still counts toward project/user/totals above.
+      const t = g.taskId
+        ? byTaskMap.get(g.taskId) ?? {
+            taskId: g.taskId,
+            taskTitle: taskTitleById.get(g.taskId) ?? "",
+            projectId: g.projectId,
+            projectName: projectNameById.get(g.projectId) ?? "",
+            seconds: 0,
+            billableSeconds: 0,
+            valueCents: 0,
+          }
+        : null;
 
       p.seconds += sec;
       u.seconds += sec;
+      if (t) t.seconds += sec;
 
       if (g.billable) {
         const value = Math.round((sec / 3600) * (g.hourlyRateCents ?? 0));
@@ -442,16 +477,22 @@ export class TimeEntriesService {
         p.valueCents += value;
         u.billableSeconds += sec;
         u.valueCents += value;
+        if (t) {
+          t.billableSeconds += sec;
+          t.valueCents += value;
+        }
       }
 
       byProjectMap.set(g.projectId, p);
       byUserMap.set(g.userId, u);
+      if (t) byTaskMap.set(g.taskId as string, t);
     }
 
     const report: TimeReport = {
       totals,
       byProject: Array.from(byProjectMap.values()).sort((a, b) => b.seconds - a.seconds),
       byUser: Array.from(byUserMap.values()).sort((a, b) => b.seconds - a.seconds),
+      byTask: Array.from(byTaskMap.values()).sort((a, b) => b.seconds - a.seconds),
     };
 
     // Hide monetary totals from non-rate-visible roles (member). durationSec
@@ -460,6 +501,7 @@ export class TimeEntriesService {
       report.totals.valueCents = 0;
       for (const b of report.byProject) b.valueCents = 0;
       for (const b of report.byUser) b.valueCents = 0;
+      for (const b of report.byTask) b.valueCents = 0;
     }
 
     return report;

--- a/apps/api/src/time-entries/time-entries.service.ts
+++ b/apps/api/src/time-entries/time-entries.service.ts
@@ -382,8 +382,18 @@ export class TimeEntriesService {
         ...(query.to ? { lte: new Date(query.to) } : {}),
       };
     }
-    // Only consider finished entries (durationSec is set).
-    const reportWhere = { ...where, NOT: { durationSec: null } };
+    if (query.invoiced === "false") where.invoiceLineItemId = null;
+
+    // Only consider finished entries (durationSec is set). Keep NOT filters
+    // as separate AND clauses so invoiced=true cannot clobber the finished
+    // entry filter (NOT durationSec null) or collapse into NOT (A AND B).
+    const reportFilters: Record<string, unknown>[] = [
+      { NOT: { durationSec: null } },
+    ];
+    if (query.invoiced === "true") {
+      reportFilters.push({ NOT: { invoiceLineItemId: null } });
+    }
+    const reportWhere = { ...where, AND: reportFilters };
 
     // Aggregate at the database. We group by (projectId, userId, billable,
     // hourlyRateCents) so we can compute value cents per bucket without

--- a/apps/api/test/integration/time-entries.service.integration.spec.ts
+++ b/apps/api/test/integration/time-entries.service.integration.spec.ts
@@ -45,6 +45,20 @@ afterAll(async () => {
   await prisma?.$disconnect();
 });
 
+async function createInvoiceLineItem(description = "time entry") {
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const invoice = await prisma.invoice.create({
+    data: {
+      organizationId: orgId,
+      invoiceNumber: `INV-TE-${stamp}`,
+      status: "draft",
+    },
+  });
+  return prisma.invoiceLineItem.create({
+    data: { invoiceId: invoice.id, description, quantity: 1, unitPrice: 5000 },
+  });
+}
+
 describe("TimeEntriesService.start/stop", () => {
   it("start creates a running entry", async () => {
     const entry = await service.start(userId, orgId, { projectId });
@@ -219,6 +233,125 @@ describe("TimeEntriesService.list/report/generateInvoice", () => {
     expect(r.byProject[0].valueCents).toBe(5000);
     expect(r.byUser[0].seconds).toBe(5400);
     expect(r.byUser[0].valueCents).toBe(5000);
+  });
+
+  it("report with invoiced=false includes only uninvoiced finished entries", async () => {
+    const uninvoiced = await service.create(userId, orgId, {
+      projectId,
+      startedAt: "2026-04-01T09:00:00Z",
+      endedAt: "2026-04-01T10:00:00Z",
+      billable: true,
+    });
+    const invoiced = await service.create(userId, orgId, {
+      projectId,
+      startedAt: "2026-04-01T10:00:00Z",
+      endedAt: "2026-04-01T12:00:00Z",
+      billable: true,
+    });
+    const otherProject = await prisma.project.create({
+      data: { name: "Unfinished", organizationId: orgId },
+    });
+    await prisma.timeEntry.create({
+      data: {
+        organizationId: orgId,
+        projectId: otherProject.id,
+        userId,
+        startedAt: new Date("2026-04-01T12:00:00Z"),
+        billable: true,
+        hourlyRateCents: 5000,
+      },
+    });
+    const lineItem = await createInvoiceLineItem("already invoiced");
+    await prisma.timeEntry.update({ where: { id: invoiced.id }, data: { invoiceLineItemId: lineItem.id } });
+
+    const r = await service.report(orgId, { invoiced: "false" }, "admin");
+    expect(r.totals.seconds).toBe(3600);
+    expect(r.totals.billableSeconds).toBe(3600);
+    expect(r.totals.valueCents).toBe(5000);
+    expect(r.byProject.map((bucket) => bucket.projectId)).toEqual([uninvoiced.projectId]);
+  });
+
+  it("report with invoiced=true includes only invoiced finished entries", async () => {
+    await service.create(userId, orgId, {
+      projectId,
+      startedAt: "2026-04-01T09:00:00Z",
+      endedAt: "2026-04-01T10:00:00Z",
+      billable: true,
+    });
+    const invoiced = await service.create(userId, orgId, {
+      projectId,
+      startedAt: "2026-04-01T10:00:00Z",
+      endedAt: "2026-04-01T12:00:00Z",
+      billable: true,
+    });
+    const lineItem = await createInvoiceLineItem("already invoiced");
+    await prisma.timeEntry.update({ where: { id: invoiced.id }, data: { invoiceLineItemId: lineItem.id } });
+
+    const r = await service.report(orgId, { invoiced: "true" }, "admin");
+    expect(r.totals.seconds).toBe(7200);
+    expect(r.totals.billableSeconds).toBe(7200);
+    expect(r.totals.valueCents).toBe(10000);
+    expect(r.byProject[0].seconds).toBe(7200);
+    expect(r.byProject[0].projectId).toBe(projectId);
+  });
+
+  it("report invoiced=true and invoiced=false totals sum to the unfiltered total", async () => {
+    const uninvoiced = await service.create(userId, orgId, {
+      projectId,
+      startedAt: "2026-04-01T09:00:00Z",
+      endedAt: "2026-04-01T09:30:00Z",
+      billable: true,
+    });
+    const invoiced = await service.create(userId, orgId, {
+      projectId,
+      startedAt: "2026-04-01T10:00:00Z",
+      endedAt: "2026-04-01T11:30:00Z",
+      billable: true,
+    });
+    const lineItem = await createInvoiceLineItem("already invoiced");
+    await prisma.timeEntry.update({ where: { id: invoiced.id }, data: { invoiceLineItemId: lineItem.id } });
+
+    const [unfiltered, withoutInvoice, withInvoice] = await Promise.all([
+      service.report(orgId, {}, "admin"),
+      service.report(orgId, { invoiced: "false" }, "admin"),
+      service.report(orgId, { invoiced: "true" }, "admin"),
+    ]);
+
+    expect(unfiltered.totals.seconds).toBe(7200);
+    expect(withoutInvoice.totals.seconds).toBe(1800);
+    expect(withInvoice.totals.seconds).toBe(5400);
+    expect(withoutInvoice.totals.seconds + withInvoice.totals.seconds).toBe(unfiltered.totals.seconds);
+    expect(withoutInvoice.byProject[0].seconds + withInvoice.byProject[0].seconds).toBe(unfiltered.byProject[0].seconds);
+    expect(uninvoiced.invoiceLineItemId).toBeNull();
+  });
+
+  it("report keeps durationSec=null entries excluded when applying invoiced=true", async () => {
+    const finished = await service.create(userId, orgId, {
+      projectId,
+      startedAt: "2026-04-01T09:00:00Z",
+      endedAt: "2026-04-01T10:00:00Z",
+      billable: true,
+    });
+    const unfinishedProject = await prisma.project.create({
+      data: { name: "Unfinished billed", organizationId: orgId },
+    });
+    const lineItem = await createInvoiceLineItem("already invoiced");
+    await prisma.timeEntry.update({ where: { id: finished.id }, data: { invoiceLineItemId: lineItem.id } });
+    await prisma.timeEntry.create({
+      data: {
+        organizationId: orgId,
+        projectId: unfinishedProject.id,
+        userId,
+        startedAt: new Date("2026-04-01T11:00:00Z"),
+        billable: true,
+        hourlyRateCents: 5000,
+        invoiceLineItemId: lineItem.id,
+      },
+    });
+
+    const r = await service.report(orgId, { invoiced: "true" }, "admin");
+    expect(r.totals.seconds).toBe(3600);
+    expect(r.byProject.map((bucket) => bucket.projectId)).toEqual([projectId]);
   });
 
   it("report breaks down billable time by task (only task-linked entries)", async () => {

--- a/apps/api/test/integration/time-entries.service.integration.spec.ts
+++ b/apps/api/test/integration/time-entries.service.integration.spec.ts
@@ -221,6 +221,54 @@ describe("TimeEntriesService.list/report/generateInvoice", () => {
     expect(r.byUser[0].valueCents).toBe(5000);
   });
 
+  it("report breaks down billable time by task (only task-linked entries)", async () => {
+    const task = await prisma.task.create({
+      data: { title: "Auth refactor", projectId, organizationId: orgId },
+    });
+    // Task-linked billable entry: 1h @ $50 (member rate)
+    await service.create(userId, orgId, {
+      projectId,
+      taskId: task.id,
+      startedAt: "2026-04-01T09:00:00Z",
+      endedAt: "2026-04-01T10:00:00Z",
+      billable: true,
+    });
+    // No-task entry: 30m billable — should count in project totals but NOT byTask
+    await service.create(userId, orgId, {
+      projectId,
+      startedAt: "2026-04-01T11:00:00Z",
+      endedAt: "2026-04-01T11:30:00Z",
+      billable: true,
+    });
+
+    const r = await service.report(orgId, {}, "admin");
+    expect(r.byTask.length).toBe(1);
+    expect(r.byTask[0].taskId).toBe(task.id);
+    expect(r.byTask[0].taskTitle).toBe("Auth refactor");
+    expect(r.byTask[0].projectName).toBe("P");
+    expect(r.byTask[0].seconds).toBe(3600);
+    expect(r.byTask[0].billableSeconds).toBe(3600);
+    expect(r.byTask[0].valueCents).toBe(5000);
+    // Project total still includes the no-task 30m
+    expect(r.byProject[0].seconds).toBe(5400);
+  });
+
+  it("report omits task valueCents for member role", async () => {
+    const task = await prisma.task.create({
+      data: { title: "Billing", projectId, organizationId: orgId },
+    });
+    await service.create(userId, orgId, {
+      projectId,
+      taskId: task.id,
+      startedAt: "2026-04-01T09:00:00Z",
+      endedAt: "2026-04-01T10:00:00Z",
+      billable: true,
+    });
+    const r = await service.report(orgId, {}, "member");
+    expect(r.byTask[0].seconds).toBe(3600);
+    expect(r.byTask[0].valueCents).toBe(0);
+  });
+
   it("report stitches multiple projects and users (groupBy path)", async () => {
     // Two projects, two users — verifies the groupBy + name-stitch path
     // produces correct per-project and per-user buckets.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.474.0",
     "next": "^15.5.14",
+    "next-themes": "^0.4.6",
     "postcss": "^8.5.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/tasks-section.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/components/tasks-section.tsx
@@ -229,7 +229,17 @@ export function TasksSection({
     }
   };
 
-  const openTaskRecord = openTaskId ? tasks.find((t) => t.id === openTaskId) : null;
+  // Keep the open task's record across list refreshes so the detail modal
+  // doesn't unmount when a status change filters the task out of the list.
+  const [openTaskRecord, setOpenTaskRecord] = useState<TaskRecord | null>(null);
+  useEffect(() => {
+    if (!openTaskId) {
+      setOpenTaskRecord(null);
+      return;
+    }
+    const found = tasks.find((t) => t.id === openTaskId);
+    if (found) setOpenTaskRecord(found);
+  }, [openTaskId, tasks]);
 
   return (
     <div>
@@ -596,6 +606,7 @@ export function TasksSection({
         <TaskDetailModal
           task={openTaskRecord}
           viewer="agency"
+          projectId={projectId}
           members={members.map((m) => ({ userId: m.userId, user: m.user }))}
           labels={labels}
           onLabelsChange={setLabels}

--- a/apps/web/src/app/(dashboard)/dashboard/projects/[id]/time-tab.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/[id]/time-tab.tsx
@@ -6,7 +6,7 @@ import { useToast } from "@/components/toast";
 import { useConfirm } from "@/components/confirm-modal";
 import { formatDuration, formatHours } from "@/lib/format-duration";
 import { Play, Square, Plus, Trash2, Lock, Pencil, X } from "lucide-react";
-import { ManualEntryModal, type EditableEntry } from "./manual-entry-modal";
+import { ManualEntryModal, type EditableEntry } from "@/components/manual-entry-modal";
 
 type ModalState = { mode: "closed" } | { mode: "new" } | { mode: "edit"; entry: EditableEntry };
 

--- a/apps/web/src/app/(dashboard)/dashboard/reports/time/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/reports/time/page.tsx
@@ -16,10 +16,21 @@ interface ReportRow {
   valueCents: number;
 }
 
+interface TaskRow {
+  taskId: string;
+  taskTitle: string;
+  projectId: string;
+  projectName: string;
+  seconds: number;
+  billableSeconds: number;
+  valueCents: number;
+}
+
 interface Report {
   totals: { seconds: number; billableSeconds: number; valueCents: number };
   byProject: ReportRow[];
   byUser: ReportRow[];
+  byTask: TaskRow[];
 }
 
 interface Project {
@@ -171,6 +182,37 @@ export default function TimeReportPage() {
               </tbody>
             </table>
           </div>
+
+          {report.byTask.length > 0 && (
+            <div>
+              <h2 className="text-sm font-medium mb-2">By task</h2>
+              <table className="w-full border border-[var(--border)] rounded-lg text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-[var(--muted-foreground)]">
+                    <th className="p-2">Task</th>
+                    <th className="p-2">Project</th>
+                    <th className="p-2">Hours</th>
+                    <th className="p-2">Billable</th>
+                    <th className="p-2">Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.byTask.map((r) => (
+                    <tr
+                      key={r.taskId}
+                      className="border-t border-[var(--border)]"
+                    >
+                      <td className="p-2">{r.taskTitle}</td>
+                      <td className="p-2">{r.projectName}</td>
+                      <td className="p-2">{formatHours(r.seconds)}</td>
+                      <td className="p-2">{formatHours(r.billableSeconds)}</td>
+                      <td className="p-2">{fmtMoney(r.valueCents)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
 
           <div>
             <h2 className="text-sm font-medium mb-2">By user</h2>

--- a/apps/web/src/app/(dashboard)/dashboard/reports/time/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/reports/time/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { apiFetch } from "@/lib/api";
+import { apiFetch, fetchAllPages } from "@/lib/api";
 import { downloadCsv } from "@/lib/download";
 import { formatHours } from "@/lib/format-duration";
 import { Download } from "lucide-react";
@@ -38,8 +38,8 @@ export default function TimeReportPage() {
   const [to, setTo] = useState<string>("");
 
   useEffect(() => {
-    apiFetch<{ data: Project[] } | Project[]>("/projects?limit=200")
-      .then((res) => setProjects(Array.isArray(res) ? res : res.data))
+    fetchAllPages<Project>("/projects")
+      .then(setProjects)
       .catch((err) => console.error(err));
   }, []);
 

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -9,6 +9,7 @@ import { OrgSwitcher, type SwitchableOrg } from "@/components/org-switcher";
 import { NotificationBell } from "@/components/notification-bell";
 import { GlobalSearch } from "@/components/global-search";
 import { DynamicFavicon } from "@/components/dynamic-favicon";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { DEFAULT_BRANDING } from "@atrium/shared";
 
 const API_URL = process.env.API_URL || "http://localhost:3001";
@@ -207,6 +208,7 @@ export default async function DashboardLayout({
         <header className="hidden md:flex items-center justify-end gap-1 px-6 lg:px-8 pt-4">
           <GlobalSearch iconOnly />
           <NotificationBell />
+          <ThemeToggle />
         </header>
 
         {/* pt-[4.5rem] on mobile = h-14 navbar (3.5rem) + 1rem spacing */}

--- a/apps/web/src/app/(dashboard)/mobile-nav.tsx
+++ b/apps/web/src/app/(dashboard)/mobile-nav.tsx
@@ -7,6 +7,7 @@ import { SidebarNav } from "./sidebar-nav";
 import { SignOutButton } from "./sign-out-button";
 import { NotificationBell } from "@/components/notification-bell";
 import { GlobalSearch } from "@/components/global-search";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { OrgSwitcher, type SwitchableOrg } from "@/components/org-switcher";
 
 interface MobileNavProps {
@@ -69,6 +70,7 @@ export function MobileNav({
         <div className="ml-auto flex items-center gap-1">
           <GlobalSearch iconOnly />
           <NotificationBell align="left" />
+          <ThemeToggle />
         </div>
       </div>
 

--- a/apps/web/src/app/(portal)/layout.tsx
+++ b/apps/web/src/app/(portal)/layout.tsx
@@ -8,6 +8,7 @@ import { NotificationBell } from "@/components/notification-bell";
 import { DynamicFavicon } from "@/components/dynamic-favicon";
 import { PreviewModeProvider } from "@/lib/preview-mode";
 import { PreviewBanner } from "@/components/preview-banner";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 const API_URL = process.env.API_URL || "http://localhost:3001";
 
@@ -104,6 +105,7 @@ export default async function PortalLayout({
               Settings
             </Link>
             <NotificationBell />
+            <ThemeToggle />
             <SignOutButton />
           </header>
           <main className="max-w-6xl mx-auto p-4 sm:p-6 lg:p-8">{children}</main>

--- a/apps/web/src/app/(portal)/portal/projects/[id]/page.tsx
+++ b/apps/web/src/app/(portal)/portal/projects/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
   ExternalLink,
   Link as LinkIcon,
   Pencil,
+  ArrowLeft,
 } from "lucide-react";
 import { PortalInvoicesSection } from "./components/portal-invoices-section";
 import { linkify } from "@/lib/linkify";
@@ -513,7 +514,7 @@ export default function PortalProjectDetailPage() {
 
   if (!project) return <ProjectDetailSkeleton />;
 
-  const currentIndex = statuses.findIndex((s) => s.slug === project.status);
+  const currentStatus = statuses.find((s) => s.slug === project.status);
 
   return (
     <div className="flex flex-col lg:flex-row gap-6 lg:gap-8">
@@ -523,6 +524,14 @@ export default function PortalProjectDetailPage() {
 
       {/* Left sidebar */}
       <aside className="w-full lg:w-72 lg:shrink-0 lg:sticky lg:top-8 space-y-4">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="inline-flex items-center gap-1.5 text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors -mb-1"
+        >
+          <ArrowLeft size={14} />
+          Back
+        </button>
         <h1 className="text-lg font-bold leading-tight">{project.name}</h1>
         {project.description && (
           <p className="text-xs text-[var(--muted-foreground)] leading-relaxed -mt-1">
@@ -530,21 +539,18 @@ export default function PortalProjectDetailPage() {
           </p>
         )}
 
-        {/* Progress bar */}
-        <div className="flex gap-1">
-          {statuses.map((s, i) => (
-            <div
-              key={s.id}
-              className="flex-1 text-center py-1.5 text-[10px] font-medium rounded overflow-hidden text-ellipsis whitespace-nowrap px-0.5"
-              style={{
-                backgroundColor: i <= currentIndex ? s.color : "var(--muted)",
-                color: i <= currentIndex ? "#fff" : "var(--muted-foreground)",
-              }}
-            >
-              {s.name}
-            </div>
-          ))}
-        </div>
+        {/* Current status */}
+        {currentStatus && (
+          <div
+            className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium"
+            style={{
+              backgroundColor: currentStatus.color,
+              color: "#fff",
+            }}
+          >
+            {currentStatus.name}
+          </div>
+        )}
 
         {/* Timeline */}
         {(project.startDate || project.endDate) && (

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -12,8 +12,16 @@
   --radius: 0.5rem;
 }
 
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  --muted: #1a1a1a;
+  --muted-foreground: #a3a3a3;
+  --border: #262626;
+}
+
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not(.light) {
     --background: #0a0a0a;
     --foreground: #ededed;
     --muted: #1a1a1a;

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { ThemeProvider } from "next-themes";
 import { ConfirmProvider } from "@/components/confirm-modal";
 import { ToastProvider } from "@/components/toast";
 import { NotificationProvider } from "@/components/notification-bell";
@@ -13,10 +14,12 @@ export function Providers({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <ConfirmProvider>
-      <ToastProvider>
-        <NotificationProvider>{children}</NotificationProvider>
-      </ToastProvider>
-    </ConfirmProvider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+      <ConfirmProvider>
+        <ToastProvider>
+          <NotificationProvider>{children}</NotificationProvider>
+        </ToastProvider>
+      </ConfirmProvider>
+    </ThemeProvider>
   );
 }

--- a/apps/web/src/components/manual-entry-modal.tsx
+++ b/apps/web/src/components/manual-entry-modal.tsx
@@ -15,7 +15,11 @@ export interface EditableEntry {
 
 interface ManualEntryModalProps {
   projectId: string;
+  /** Link the new entry to a task (create only). */
+  taskId?: string;
   entry?: EditableEntry;
+  title?: string;
+  cancelLabel?: string;
   onClose: () => void;
   onSaved: () => void;
 }
@@ -33,7 +37,10 @@ function localDateParts(iso: string): { date: string; time: string } {
 
 export function ManualEntryModal({
   projectId,
+  taskId,
   entry,
+  title,
+  cancelLabel,
   onClose,
   onSaved,
 }: ManualEntryModalProps): React.ReactElement {
@@ -80,6 +87,7 @@ export function ManualEntryModal({
           method: "POST",
           body: JSON.stringify({
             projectId,
+            taskId,
             startedAt: startedAt.toISOString(),
             endedAt: endedAt.toISOString(),
             description: description || undefined,
@@ -107,7 +115,7 @@ export function ManualEntryModal({
         className="bg-[var(--background)] rounded-xl shadow-lg w-full max-w-md p-6 space-y-4"
       >
         <div className="flex items-start justify-between">
-          <h3 className="text-lg font-semibold">{isEdit ? "Edit time entry" : "Add time entry"}</h3>
+          <h3 className="text-lg font-semibold">{title ?? (isEdit ? "Edit time entry" : "Add time entry")}</h3>
           <button
             type="button"
             onClick={onClose}
@@ -199,7 +207,7 @@ export function ManualEntryModal({
             onClick={onClose}
             className="px-3 py-1.5 text-sm border border-[var(--border)] rounded-lg hover:bg-[var(--muted)] transition-colors"
           >
-            Cancel
+            {cancelLabel ?? "Cancel"}
           </button>
           <button
             type="submit"

--- a/apps/web/src/components/task-detail-modal.tsx
+++ b/apps/web/src/components/task-detail-modal.tsx
@@ -10,6 +10,7 @@ import { LabelBadge } from "@/components/label-badge";
 import { Avatar } from "@/components/avatar";
 import { ColorPatchGrid, PRESET_COLORS } from "@/components/color-patch-grid";
 import { TASK_STATUS_OPTIONS } from "@/lib/task-status";
+import { ManualEntryModal } from "@/components/manual-entry-modal";
 
 export interface TaskDetailRecord {
   id: string;
@@ -50,6 +51,7 @@ const STATUS_OPTIONS = TASK_STATUS_OPTIONS;
 export function TaskDetailModal({
   task,
   viewer,
+  projectId,
   currentUserId,
   members,
   labels,
@@ -60,6 +62,8 @@ export function TaskDetailModal({
 }: {
   task: TaskDetailRecord;
   viewer: TaskDetailViewer;
+  /** When set (agency only), marking the task done prompts to log time. */
+  projectId?: string;
   currentUserId?: string | null;
   members?: TaskDetailMember[];
   labels?: TaskDetailLabel[];
@@ -84,6 +88,7 @@ export function TaskDetailModal({
   const [dueDate, setDueDate] = useState(task.dueDate ? task.dueDate.split("T")[0] : "");
   const [dueEditing, setDueEditing] = useState(false);
   const [status, setStatus] = useState(task.status);
+  const [logTimeOpen, setLogTimeOpen] = useState(false);
   const [assigneeId, setAssigneeId] = useState(task.assigneeId ?? "");
   const [assignedLabels, setAssignedLabels] = useState<string[]>(
     task.labels?.map((l) => l.label.id) ?? [],
@@ -98,11 +103,16 @@ export function TaskDetailModal({
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
+      if (e.key !== "Escape") return;
+      if (logTimeOpen) {
+        setLogTimeOpen(false);
+        return;
+      }
+      onClose();
     }
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  }, [onClose, logTimeOpen]);
 
   const patch = useCallback(
     async (body: Record<string, unknown>) => {
@@ -173,7 +183,23 @@ export function TaskDetailModal({
       await patch({ status: next });
     } catch {
       setStatus(prev);
+      return;
     }
+    if (isAgency && projectId && next === "done" && prev !== "done") {
+      await promptLogTime();
+    }
+  };
+
+  // Offer to log time for a just-completed task, unless a timer is already
+  // running on it (that timer will capture the time when stopped).
+  const promptLogTime = async (): Promise<void> => {
+    try {
+      const running = await apiFetch<{ taskId: string | null } | null>("/time-entries/running");
+      if (running?.taskId === task.id) return;
+    } catch (err) {
+      console.error(err);
+    }
+    setLogTimeOpen(true);
   };
 
   const handleAssigneeChange = async (next: string) => {
@@ -828,6 +854,19 @@ export function TaskDetailModal({
           </div>
         </div>
       </div>
+      {logTimeOpen && projectId && (
+        <ManualEntryModal
+          projectId={projectId}
+          taskId={task.id}
+          title="Log time for this task"
+          cancelLabel="Skip"
+          onClose={() => setLogTimeOpen(false)}
+          onSaved={() => {
+            setLogTimeOpen(false);
+            success("Time logged");
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return (
+      <button
+        type="button"
+        className="inline-flex h-9 w-9 items-center justify-center rounded-md text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]"
+        aria-label="Toggle theme"
+        title="Toggle theme"
+      >
+        <span className="h-4 w-4" />
+      </button>
+    );
+  }
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className="inline-flex h-9 w-9 items-center justify-center rounded-md text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]"
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  );
+}

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, mock, afterEach } from "bun:test";
+import { fetchAllPages, MAX_PAGE_LIMIT } from "./api";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockPages(pages: Record<number, unknown[]>, total: number): string[] {
+  const calls: string[] = [];
+  const totalPages = Math.ceil(total / MAX_PAGE_LIMIT);
+  globalThis.fetch = mock(async (url: string | URL | Request) => {
+    const u = String(url);
+    calls.push(u);
+    const page = Number(new URL(u, "http://localhost").searchParams.get("page"));
+    const body = {
+      data: pages[page] ?? [],
+      meta: { total, page, limit: MAX_PAGE_LIMIT, totalPages },
+    };
+    return new Response(JSON.stringify(body), { status: 200 });
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+describe("fetchAllPages", () => {
+  it("never requests more than the API max per page", async () => {
+    const calls = mockPages({ 1: [{ id: 1 }] }, 1);
+    await fetchAllPages("/projects");
+    expect(calls).toHaveLength(1);
+    expect(new URL(calls[0], "http://localhost").searchParams.get("limit")).toBe(String(MAX_PAGE_LIMIT));
+  });
+
+  it("walks every page and flattens rows", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => ({ id: i }));
+    const page2 = [{ id: 100 }, { id: 101 }];
+    const calls = mockPages({ 1: page1, 2: page2 }, 102);
+    const rows = await fetchAllPages<{ id: number }>("/projects");
+    expect(rows).toHaveLength(102);
+    expect(rows[101].id).toBe(101);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("preserves an existing query string", async () => {
+    const calls = mockPages({ 1: [] }, 0);
+    await fetchAllPages("/projects?archived=false");
+    const u = new URL(calls[0], "http://localhost");
+    expect(u.searchParams.get("archived")).toBe("false");
+    expect(u.searchParams.get("page")).toBe("1");
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -74,6 +74,32 @@ export async function apiFetch<T = unknown>(
   return (text ? JSON.parse(text) : undefined) as T;
 }
 
+export interface PaginatedResponse<T> {
+  data: T[];
+  meta: { total: number; page: number; limit: number; totalPages: number };
+}
+
+/** Max `limit` accepted by paginated list endpoints (PaginationQueryDto @Max(100)). */
+export const MAX_PAGE_LIMIT = 100;
+
+/**
+ * Fetch every page of a paginated list endpoint and return the flattened rows.
+ * Use instead of a large `?limit=`, which the API rejects with a 400.
+ */
+export async function fetchAllPages<T>(basePath: string): Promise<T[]> {
+  const separator = basePath.includes("?") ? "&" : "?";
+  const rows: T[] = [];
+  const maxPages = 1000;
+  for (let page = 1; page <= maxPages; page++) {
+    const res = await apiFetch<PaginatedResponse<T>>(
+      `${basePath}${separator}page=${page}&limit=${MAX_PAGE_LIMIT}`,
+    );
+    rows.push(...res.data);
+    if (!res.data.length || page >= (res.meta?.totalPages ?? 1)) break;
+  }
+  return rows;
+}
+
 /**
  * After authentication, sets the active org and returns the redirect path
  * based on the user's role (owner/admin -> /dashboard, member -> /portal).

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: "class",
   content: ["./src/**/*.{ts,tsx}"],
   theme: {
     extend: {},

--- a/bun.lock
+++ b/bun.lock
@@ -77,6 +77,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.474.0",
         "next": "^15.5.14",
+        "next-themes": "^0.4.6",
         "postcss": "^8.5.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1397,6 +1398,8 @@
     "nestjs-pino": ["nestjs-pino@4.6.0", "", { "peerDependencies": { "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0", "pino": "^7.5.0 || ^8.0.0 || ^9.0.0 || ^10.0.0", "pino-http": "^6.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0", "rxjs": "^7.1.0" } }, "sha512-MzSgnOu9MhRT/f7MsvoDnxat11D9JRJYwL1t+tI6J44UrNz9rUVDpceEh9VFsyfiiIJKUri5S+/snMOoaWh7YA=="],
 
     "next": ["next@15.5.14", "", { "dependencies": { "@next/env": "15.5.14", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.14", "@next/swc-darwin-x64": "15.5.14", "@next/swc-linux-arm64-gnu": "15.5.14", "@next/swc-linux-arm64-musl": "15.5.14", "@next/swc-linux-x64-gnu": "15.5.14", "@next/swc-linux-x64-musl": "15.5.14", "@next/swc-win32-arm64-msvc": "15.5.14", "@next/swc-win32-x64-msvc": "15.5.14", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ=="],
+
+    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
 

--- a/e2e/tests/portal-project-status.e2e.ts
+++ b/e2e/tests/portal-project-status.e2e.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Portal project status", () => {
+  test("shows a single pill with the project's current status", async ({ page, request }) => {
+    const statusesRes = await request.get("http://localhost:3001/api/projects/statuses");
+    expect(statusesRes.ok()).toBeTruthy();
+    const statuses: { name: string }[] = await statusesRes.json();
+    const names = statuses.map((s) => s.name);
+
+    await page.goto("/portal/projects");
+    const link = page.locator("a[href*='/portal/projects/']").first();
+    test.skip(
+      !(await link.isVisible({ timeout: 10000 }).catch(() => false)),
+      "no portal project available for this account",
+    );
+    await link.click();
+    await expect(page).toHaveURL(/\/portal\/projects\/[^/]+$/);
+
+    const aside = page.locator("aside").first();
+    await expect(aside.getByRole("button", { name: /^back$/i })).toBeVisible({ timeout: 15000 });
+
+    // Exactly one status name is rendered in the sidebar, not the whole list.
+    let visible = 0;
+    for (const name of names) {
+      visible += await aside.getByText(name, { exact: true }).count();
+    }
+    expect(visible).toBe(1);
+  });
+});

--- a/e2e/tests/task-done-log-time.e2e.ts
+++ b/e2e/tests/task-done-log-time.e2e.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+import { createTask, getOrCreateProject } from "./helpers";
+
+const API = "http://localhost:3001/api";
+
+test.describe("Log time prompt on task completion", () => {
+  test("marking a task done prompts to log time linked to that task", async ({
+    page,
+    request,
+  }) => {
+    const projectId = await getOrCreateProject(request, "Time Tracking E2E");
+    const title = `Done prompt ${Date.now().toString(36)}`;
+    const taskId = await createTask(request, projectId, title, new Date());
+
+    await page.goto(`/dashboard/projects/${projectId}?tab=tasks`);
+    const noThanks = page.getByRole("button", { name: /^no thanks$/i });
+    if (await noThanks.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await noThanks.click();
+    }
+
+    await page.getByTestId(`task-row-${taskId}`).click();
+    await page.getByTestId("task-status-select").selectOption("done");
+
+    await expect(
+      page.getByRole("heading", { name: "Log time for this task" }),
+    ).toBeVisible({ timeout: 10000 });
+    await page.getByRole("button", { name: /^save$/i }).click();
+    await expect(page.getByText("Time logged")).toBeVisible({ timeout: 10000 });
+
+    const res = await request.get(
+      `${API}/time-entries?projectId=${projectId}&limit=100`,
+    );
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    const entries: { taskId: string | null }[] = Array.isArray(body)
+      ? body
+      : body.data;
+    expect(entries.some((e) => e.taskId === taskId)).toBe(true);
+  });
+});

--- a/e2e/tests/theme-toggle.e2e.ts
+++ b/e2e/tests/theme-toggle.e2e.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Theme toggle", () => {
+  test("switches between light and dark and persists across reload", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "light" });
+    await page.goto("/dashboard");
+
+    const html = page.locator("html");
+    await expect(html).not.toHaveClass(/dark/);
+
+    await page.getByRole("button", { name: /switch to dark mode/i }).first().click();
+    await expect(html).toHaveClass(/dark/);
+
+    await page.reload();
+    await expect(html).toHaveClass(/dark/);
+
+    await page.getByRole("button", { name: /switch to light mode/i }).first().click();
+    await expect(html).not.toHaveClass(/dark/);
+  });
+});

--- a/e2e/tests/time-report.e2e.ts
+++ b/e2e/tests/time-report.e2e.ts
@@ -42,4 +42,39 @@ test.describe("Time report", () => {
     });
     await expect(page.getByRole("cell", { name: taskTitle })).toBeVisible();
   });
+
+  test("report honors the invoiced filter", async ({ request }) => {
+    const projectId = await getOrCreateProject(request, "Time Tracking E2E");
+    const end = new Date();
+    end.setDate(end.getDate() - 2);
+    end.setHours(15, 0, 0, 0);
+    const start = new Date(end);
+    start.setHours(14, 0, 0, 0);
+    const created = await request.post(`${API}/time-entries`, {
+      data: {
+        projectId,
+        startedAt: start.toISOString(),
+        endedAt: end.toISOString(),
+        billable: true,
+      },
+      headers: { "x-csrf-token": getCsrfToken() },
+    });
+    expect(created.ok()).toBeTruthy();
+
+    // Fresh entries are un-invoiced: they count under invoiced=false only.
+    const notInvoiced = await request.get(
+      `${API}/time-entries/report?projectId=${projectId}&invoiced=false`,
+    );
+    expect(notInvoiced.ok()).toBeTruthy();
+    const all = await request.get(`${API}/time-entries/report?projectId=${projectId}`);
+    const invoiced = await request.get(
+      `${API}/time-entries/report?projectId=${projectId}&invoiced=true`,
+    );
+    const a = (await all.json()).totals.seconds as number;
+    const n = (await notInvoiced.json()).totals.seconds as number;
+    const i = (await invoiced.json()).totals.seconds as number;
+    expect(n).toBeGreaterThan(0);
+    expect(n + i).toBe(a);
+    expect(i).toBeLessThan(a);
+  });
 });

--- a/e2e/tests/time-report.e2e.ts
+++ b/e2e/tests/time-report.e2e.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+import { createTask, getCsrfToken, getOrCreateProject } from "./helpers";
+
+const API = "http://localhost:3001/api";
+
+test.describe("Time report", () => {
+  test("lists projects in the filter and shows a per-task breakdown", async ({
+    page,
+    request,
+  }) => {
+    const projectName = "Time Tracking E2E";
+    const projectId = await getOrCreateProject(request, projectName);
+    const taskTitle = `Report task ${Date.now().toString(36)}`;
+    const taskId = await createTask(request, projectId, taskTitle, new Date());
+
+    const end = new Date();
+    end.setDate(end.getDate() - 1);
+    end.setHours(10, 0, 0, 0);
+    const start = new Date(end);
+    start.setHours(9, 0, 0, 0);
+    const res = await request.post(`${API}/time-entries`, {
+      data: {
+        projectId,
+        taskId,
+        startedAt: start.toISOString(),
+        endedAt: end.toISOString(),
+        billable: true,
+      },
+      headers: { "x-csrf-token": getCsrfToken() },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    await page.goto("/dashboard/reports/time");
+
+    // Project dropdown is populated (regression: /projects?limit=200 was a 400)
+    await expect(
+      page.locator("select").first().locator("option", { hasText: projectName }),
+    ).toHaveCount(1, { timeout: 15000 });
+
+    await expect(page.getByRole("heading", { name: "By task" })).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByRole("cell", { name: taskTitle })).toBeVisible();
+  });
+});


### PR DESCRIPTION
Changes picked from the Bizman365/PexloPortal fork (adapted where needed), plus one native feature.

- fix: time report project dropdown was empty — `/projects?limit=200` is rejected by the API's 100 cap. Adds `fetchAllPages()` in `lib/api.ts`.
- fix: `report()` now honors the `invoiced` filter (only `list()` did).
- feat: user-controlled dark mode toggle (`next-themes`, class-based, system default) in dashboard header, mobile nav and portal header.
- feat: portal project detail shows a single current-status pill and a Back button instead of the 4-pill stepper.
- feat: per-task breakdown in the time report (`byTask` in API + "By task" table).
- feat: marking a task done from the dashboard prompts to log time for it via the manual entry modal, skipped if a timer is already running on that task. `ManualEntryModal` moved to `components/`. Also fixes the task detail modal unmounting when a status change filters the task out of the list.

Tests: web/api unit, 41 integration, e2e specs for each change (`theme-toggle`, `time-report`, `portal-project-status`, `task-done-log-time`).