### PR TITLE
chore: reformat FUNDING.yml to trigger sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
-github: [Vibra-Labs]
+github:
+  - Vibra-Labs


### PR DESCRIPTION
GitHub never indexed the FUNDING.yml added in #62 (repo reports no funding links and shows no Sponsor button, although the Vibra-Labs Sponsors listing is live). A change to the file on main forces a re-parse. Content is unchanged, just the multi-line list form.