### PR TITLE
Fix analytics undercounting and instrument the portal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
             NEXT_PUBLIC_STRIPE_MODE=${{ vars.STRIPE_MODE || 'test' }}
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_SENTRY_ENABLED=${{ vars.NEXT_PUBLIC_SENTRY_ENABLED || 'false' }}
+            NEXT_PUBLIC_TRACKERS=${{ vars.NEXT_PUBLIC_TRACKERS }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
           tags: |
             vibralabs/atrium:${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,13 +31,16 @@ jobs:
           file: docker/unified.Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
+          # Deliberately no NEXT_PUBLIC_TRACKERS here. This image is the
+          # public self-hosting build: baking a tracker in would make every
+          # self-hosted Atrium report to the maintainers' analytics. Operators
+          # opt in by passing their own --build-arg (see docs/telemetry.md).
           build-args: |
             NEXT_PUBLIC_API_URL=${{ vars.PUBLIC_URL }}
             NEXT_PUBLIC_BILLING_ENABLED=true
             NEXT_PUBLIC_STRIPE_MODE=${{ vars.STRIPE_MODE || 'test' }}
             NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_SENTRY_ENABLED=${{ vars.NEXT_PUBLIC_SENTRY_ENABLED || 'false' }}
-            NEXT_PUBLIC_TRACKERS=${{ vars.NEXT_PUBLIC_TRACKERS }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
           tags: |
             vibralabs/atrium:${{ github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
       API_URL: http://localhost:3001
       WEB_URL: http://localhost:3000
       NEXT_PUBLIC_API_URL: http://localhost:3001
+      # Must be present for `bun run build`: NEXT_PUBLIC_* is inlined at build
+      # time for prerendered routes, which is the regression under test.
+      NEXT_PUBLIC_TRACKERS: '[{"src":"http://localhost:3000/__e2e-tracker.js","data-website-id":"e2e"}]'
       STORAGE_PROVIDER: local
       UPLOAD_DIR: ./uploads
 

--- a/apps/web/src/app/(auth)/login/login-form.tsx
+++ b/apps/web/src/app/(auth)/login/login-form.tsx
@@ -41,11 +41,16 @@ export function LoginForm({ orgName, logoSrc, hideLogo }: LoginFormProps) {
 
       await res.json();
 
+      // Without a success counterpart, login_failed is uninterpretable: there
+      // is no denominator to compute a success rate from.
+      track("login_succeeded", { branded: Boolean(orgName) });
+
       setRedirecting(true);
       window.location.href = await setActiveOrgAndRedirect("/portal/projects");
     } catch (err) {
-      track("login_failed");
-      setError(err instanceof Error ? err.message : "Login failed");
+      const reason = err instanceof Error ? err.message : "Login failed";
+      track("login_failed", { reason, branded: Boolean(orgName) });
+      setError(reason);
       setLoading(false);
     }
   };

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { Check, Zap, Crown } from "lucide-react";
 import { track } from "@/lib/track";
@@ -210,6 +210,8 @@ export default function SignupPage() {
       .finally(() => setPlansLoading(false));
   }, [billingEnabled]);
 
+  const signupStartedRef = useRef<boolean>(false);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
@@ -217,7 +219,12 @@ export default function SignupPage() {
 
     // Fires before validation so signup_started - signup_completed measures
     // everyone who tried, including those turned away by the password rules.
-    track("signup_started", { plan: selectedPlan });
+    // Once per page session: a user who trips the rules repeatedly is one
+    // attempt, not four, or the funnel denominator inflates.
+    if (!signupStartedRef.current) {
+      signupStartedRef.current = true;
+      track("signup_started", { plan: selectedPlan });
+    }
 
     if (password.length < 8) {
       setError("Password must be at least 8 characters");
@@ -268,6 +275,10 @@ export default function SignupPage() {
       }
 
       if (res.status === 207) {
+        // Account created but org creation failed: a User with no Organization.
+        // Tracked neither as completed nor failed before, which is exactly the
+        // population that makes user and org counts disagree.
+        track("signup_failed", { reason: "org_setup_failed", plan: selectedPlan });
         setError(
           data.message ||
             "Account created but organization setup failed. Redirecting to login...",

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -215,6 +215,10 @@ export default function SignupPage() {
     setLoading(true);
     setError("");
 
+    // Fires before validation so signup_started - signup_completed measures
+    // everyone who tried, including those turned away by the password rules.
+    track("signup_started", { plan: selectedPlan });
+
     if (password.length < 8) {
       setError("Password must be at least 8 characters");
       setLoading(false);
@@ -284,7 +288,9 @@ export default function SignupPage() {
       track("signup_completed", { plan: selectedPlan });
       window.location.href = "/setup";
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Signup failed");
+      const reason = err instanceof Error ? err.message : "Signup failed";
+      track("signup_failed", { reason, plan: selectedPlan });
+      setError(reason);
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/clients/page.tsx
@@ -307,7 +307,7 @@ export default function PeoplePage() {
         method: "POST",
         body: JSON.stringify({ email: clientEmail, role: "member" }),
       });
-      track("client_invited");
+      track("client_invited", { source: "dashboard" });
       const submittedEmail = clientEmail;
       setClientEmail("");
       success("Invitation sent");

--- a/apps/web/src/app/(dashboard)/dashboard/projects/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/projects/page.tsx
@@ -138,7 +138,7 @@ export default function ProjectsPage() {
         method: "POST",
         body: JSON.stringify({ name, description }),
       });
-      track("project_created");
+      track("project_created", { source: "dashboard" });
       setName("");
       setDescription("");
       setShowCreate(false);

--- a/apps/web/src/app/(portal)/portal/projects/[id]/page.tsx
+++ b/apps/web/src/app/(portal)/portal/projects/[id]/page.tsx
@@ -34,6 +34,7 @@ import { PortalInvoicesSection } from "./components/portal-invoices-section";
 import { linkify } from "@/lib/linkify";
 import { Embeds, type PreviewPrefs } from "@/lib/embeds";
 import { downloadFile } from "@/lib/download";
+import { track } from "@/lib/track";
 import { SigningViewer } from "@/components/signing-viewer";
 import { DocumentViewer } from "@/components/document-viewer";
 import { useToast } from "@/components/toast";
@@ -396,6 +397,7 @@ export default function PortalProjectDetailPage() {
           description: newRequestDesc || undefined,
         }),
       });
+      track("portal_request_posted");
       setNewRequestTitle("");
       setNewRequestDesc("");
       setShowNewRequest(false);
@@ -451,6 +453,7 @@ export default function PortalProjectDetailPage() {
         method: "POST",
         body: JSON.stringify({ action, ...(reason ? { reason } : {}) }),
       });
+      track("portal_document_responded", { action });
       loadDocuments();
     } catch (err) {
       console.error(err);
@@ -507,6 +510,11 @@ export default function PortalProjectDetailPage() {
   const handleDownload = async (fileId: string, filename: string) => {
     try {
       await downloadFile(fileId, filename);
+      // Extension only. File names carry client and project detail.
+      const ext: string = filename.includes(".")
+        ? filename.split(".").pop()!.toLowerCase().slice(0, 8)
+        : "none";
+      track("portal_file_downloaded", { type: ext });
     } catch (err) {
       console.error(err);
     }

--- a/apps/web/src/app/(setup)/setup/page.tsx
+++ b/apps/web/src/app/(setup)/setup/page.tsx
@@ -236,7 +236,9 @@ function SetupWizardContent() {
         {STEPS[currentStep]?.key === "invite" && (
           <StepInviteClient onNext={goNext} onBack={goBack} />
         )}
-        {STEPS[currentStep]?.key === "complete" && <StepComplete onBack={goBack} />}
+        {STEPS[currentStep]?.key === "complete" && (
+          <StepComplete onBack={goBack} isFirstOrg={isFirstOrg} />
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/(setup)/setup/step-complete.tsx
+++ b/apps/web/src/app/(setup)/setup/step-complete.tsx
@@ -7,9 +7,11 @@ import { track } from "@/lib/track";
 
 interface StepCompleteProps {
   onBack: () => void;
+  /** Null until the org list has loaded. */
+  isFirstOrg: boolean | null;
 }
 
-export function StepComplete({ onBack }: StepCompleteProps) {
+export function StepComplete({ onBack, isFirstOrg }: StepCompleteProps) {
   const [completing, setCompleting] = useState(false);
   const [error, setError] = useState("");
 
@@ -18,7 +20,10 @@ export function StepComplete({ onBack }: StepCompleteProps) {
     setError("");
     try {
       await apiFetch("/setup/complete", { method: "POST" });
-      track("setup_completed");
+      // The wizard runs again for every additional organization, so a bare
+      // setup_completed count can't be compared against signups. first_org
+      // separates genuine first-run setups from second-org repeats.
+      track("setup_completed", { first_org: isFirstOrg ?? true });
       window.location.href = "/dashboard";
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to complete setup");

--- a/apps/web/src/app/(setup)/setup/step-email-config.tsx
+++ b/apps/web/src/app/(setup)/setup/step-email-config.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { apiFetch } from "@/lib/api";
+import { track } from "@/lib/track";
 import { Mail, Send, CheckCircle, XCircle } from "lucide-react";
 
 interface StepEmailConfigProps {
@@ -57,6 +58,9 @@ export function StepEmailConfig({ onNext, onBack }: StepEmailConfigProps) {
 
   const handleNext = async () => {
     if (provider === "none") {
+      // An org that finishes setup without email cannot deliver client
+      // invitations, so this is worth separating from a real configuration.
+      track("setup_email_configured", { provider: "none" });
       onNext();
       return;
     }
@@ -79,6 +83,7 @@ export function StepEmailConfig({ onNext, onBack }: StepEmailConfigProps) {
         method: "PUT",
         body: JSON.stringify(payload),
       });
+      track("setup_email_configured", { provider });
       onNext();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save");
@@ -319,7 +324,10 @@ export function StepEmailConfig({ onNext, onBack }: StepEmailConfigProps) {
         <div className="flex gap-3">
           {provider !== "none" && (
             <button
-              onClick={onNext}
+              onClick={() => {
+                track("setup_step_skipped", { step: "email" });
+                onNext();
+              }}
               className="px-6 py-2 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
             >
               Skip

--- a/apps/web/src/app/(setup)/setup/step-first-project.tsx
+++ b/apps/web/src/app/(setup)/setup/step-first-project.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { apiFetch } from "@/lib/api";
 import { FolderKanban } from "lucide-react";
+import { track } from "@/lib/track";
 
 interface StepFirstProjectProps {
   onNext: () => void;
@@ -30,6 +31,9 @@ export function StepFirstProject({ onNext, onBack }: StepFirstProjectProps) {
           description: description.trim() || undefined,
         }),
       });
+      // Same event name as the dashboard so activation counts are complete;
+      // source separates onboarding creation from day-to-day creation.
+      track("project_created", { source: "setup" });
       onNext();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create project");
@@ -101,7 +105,10 @@ export function StepFirstProject({ onNext, onBack }: StepFirstProjectProps) {
         </button>
         <div className="flex gap-3">
           <button
-            onClick={onNext}
+            onClick={() => {
+              track("setup_step_skipped", { step: "project" });
+              onNext();
+            }}
             className="px-6 py-2 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
           >
             Skip

--- a/apps/web/src/app/(setup)/setup/step-invite-client.tsx
+++ b/apps/web/src/app/(setup)/setup/step-invite-client.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { apiFetch } from "@/lib/api";
 import { UserPlus, Copy, Check } from "lucide-react";
+import { track } from "@/lib/track";
 
 interface StepInviteClientProps {
   onNext: () => void;
@@ -29,6 +30,9 @@ export function StepInviteClient({ onNext, onBack }: StepInviteClientProps) {
         method: "POST",
         body: JSON.stringify({ email: email.trim(), role: "member" }),
       });
+      // Mirrors the dashboard's client_invited so onboarding invites are not
+      // invisible in activation reporting.
+      track("client_invited", { source: "setup" });
       setInvited(true);
 
       // Try to get the invite link
@@ -154,7 +158,10 @@ export function StepInviteClient({ onNext, onBack }: StepInviteClientProps) {
         <div className="flex gap-3">
           {!invited && (
             <button
-              onClick={onNext}
+              onClick={() => {
+                track("setup_step_skipped", { step: "invite" });
+                onNext();
+              }}
               className="px-6 py-2 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
             >
               Skip

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import Link from "next/link";
 import { Providers } from "./providers";
 // @ts-expect-error — raw string import via webpack asset/source
@@ -18,7 +17,6 @@ export const metadata: Metadata = {
 
 const ALLOWED_TRACKER_KEYS = new Set([
   "src",
-  "strategy",
   "async",
   "defer",
   "crossOrigin",
@@ -59,13 +57,11 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* A plain tag, not next/script: afterInteractive scripts are not
+            emitted on statically prerendered routes (/signup, /accept-invite),
+            which silently dropped ~85% of signups from analytics. */}
         {trackers.map((tracker, i) => (
-          <Script
-            key={tracker.src || i}
-            defer
-            strategy="afterInteractive"
-            {...tracker}
-          />
+          <script key={tracker.src || i} defer {...tracker} />
         ))}
       </head>
       <body suppressHydrationWarning>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -70,9 +70,12 @@ export default function RootLayout({
         {trackers.length > 0 && (
           <script dangerouslySetInnerHTML={{ __html: MASK_SCRIPT }} />
         )}
-        {/* A plain tag, not next/script: afterInteractive scripts are not
-            emitted on statically prerendered routes (/signup, /accept-invite),
-            which silently dropped ~85% of signups from analytics. */}
+        {/* A plain tag rather than next/script: afterInteractive injects the
+            script after hydration on every route, so the served HTML never
+            contains it. Emitting it directly is more robust and lets the e2e
+            test assert on the response body. Note this alone is not what fixed
+            tracking -- see the NEXT_PUBLIC_TRACKERS build arg in the
+            Dockerfiles, which is why prerendered routes reported nothing. */}
         {trackers.map((tracker, i) => (
           <script key={tracker.src || i} defer {...tracker} />
         ))}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Providers } from "./providers";
+import { maskAnalyticsEvent } from "@/lib/mask-analytics";
 // @ts-expect-error — raw string import via webpack asset/source
 import changelogRaw from "../../CHANGELOG.md";
 import "./globals.css";
@@ -14,6 +15,12 @@ export const metadata: Metadata = {
   title: "Atrium",
   description: "Client portal for agencies and freelancers",
 };
+
+// Analytics must never carry identifiers. The hook is defined in
+// lib/mask-analytics.ts and serialised into the page here so it runs for every
+// event, including Umami's auto-tracked pageviews.
+const MASK_FN = "atriumMaskAnalyticsEvent";
+const MASK_SCRIPT = `window.${MASK_FN}=${maskAnalyticsEvent.toString()};`;
 
 const ALLOWED_TRACKER_KEYS = new Set([
   "src",
@@ -39,6 +46,8 @@ function getTrackers(): Array<Record<string, string>> {
             safe[k] = String(v);
           }
         }
+        // Default the masking hook on; an operator can point it elsewhere.
+        if (!safe["data-before-send"]) safe["data-before-send"] = MASK_FN;
         return safe;
       })
       .filter((t) => t.src);
@@ -57,6 +66,10 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Must be defined before the tracker loads: it is read per event. */}
+        {trackers.length > 0 && (
+          <script dangerouslySetInnerHTML={{ __html: MASK_SCRIPT }} />
+        )}
         {/* A plain tag, not next/script: afterInteractive scripts are not
             emitted on statically prerendered routes (/signup, /accept-invite),
             which silently dropped ~85% of signups from analytics. */}

--- a/apps/web/src/lib/mask-analytics.test.ts
+++ b/apps/web/src/lib/mask-analytics.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { maskAnalyticsEvent } from "./mask-analytics";
+
+describe("maskAnalyticsEvent", () => {
+  it("replaces cuid project ids", () => {
+    expect(
+      maskAnalyticsEvent("pageview", {
+        url: "/portal/projects/cmpy4tm44008nth2n02xhsgtu",
+      }).url,
+    ).toBe("/portal/projects/[id]");
+  });
+
+  it("replaces uuids", () => {
+    expect(
+      maskAnalyticsEvent("pageview", {
+        url: "/dashboard/projects/85b1a5bd-7983-4502-8530-f4b2923de8ef",
+      }).url,
+    ).toBe("/dashboard/projects/[id]");
+  });
+
+  it("replaces branded login org slugs", () => {
+    expect(
+      maskAnalyticsEvent("pageview", { url: "/login/it-selucky-nt6w9q" }).url,
+    ).toBe("/login/[slug]");
+  });
+
+  it("replaces signing tokens", () => {
+    expect(
+      maskAnalyticsEvent("pageview", { url: "/portal/sign/abc123def456xyz" }).url,
+    ).toBe("/portal/sign/[token]");
+  });
+
+  it("drops the query string, which carries task and invitation ids", () => {
+    expect(
+      maskAnalyticsEvent("pageview", {
+        url: "/portal/projects?task=cmr0uizxu00ixth2nfghujzch",
+      }).url,
+    ).toBe("/portal/projects");
+  });
+
+  it("drops the page title", () => {
+    expect(
+      maskAnalyticsEvent("pageview", {
+        url: "/portal",
+        title: "Acme Corp Rebrand | Atrium",
+      }).title,
+    ).toBeUndefined();
+  });
+
+  it("leaves plain routes untouched", () => {
+    expect(maskAnalyticsEvent("pageview", { url: "/dashboard/clients" }).url).toBe(
+      "/dashboard/clients",
+    );
+  });
+
+  it("keeps non-identifying event data", () => {
+    const out = maskAnalyticsEvent("event", {
+      url: "/portal/projects/cmpy4tm44008nth2n02xhsgtu",
+      name: "portal_file_downloaded",
+      data: { type: "pdf" },
+    });
+    expect(out.name).toBe("portal_file_downloaded");
+    expect(out.data).toEqual({ type: "pdf" });
+    expect(out.url).toBe("/portal/projects/[id]");
+  });
+
+  it("survives a malformed payload without throwing", () => {
+    expect(() => maskAnalyticsEvent("event", {})).not.toThrow();
+  });
+
+  it("stays self-contained so it can be serialised into the page", () => {
+    const src: string = maskAnalyticsEvent.toString();
+    expect(src.startsWith("function")).toBe(true);
+    // A closure reference would break once inlined into the browser.
+    expect(src).not.toContain("import");
+  });
+});

--- a/apps/web/src/lib/mask-analytics.ts
+++ b/apps/web/src/lib/mask-analytics.ts
@@ -1,0 +1,44 @@
+/**
+ * Strips identifiers out of analytics payloads before they leave the browser.
+ *
+ * Umami auto-tracks the full URL and page title, which in this app means
+ * project and organization ids (/portal/projects/<cuid>), branded login slugs
+ * and titles containing client names. Masking here means the identifiers are
+ * never transmitted at all, rather than being sent and trusted to stay private.
+ *
+ * This is serialised into the page with .toString(), so it must stay
+ * self-contained: no imports, no closure variables, no TypeScript-only syntax
+ * in the body.
+ */
+export interface AnalyticsPayload {
+  url?: string;
+  title?: string;
+  [key: string]: unknown;
+}
+
+export function maskAnalyticsEvent(
+  type: string,
+  payload: AnalyticsPayload,
+): AnalyticsPayload {
+  try {
+    if (payload && typeof payload.url === "string") {
+      // Drop the query string wholesale: ?task=<id>, ?id=<invitation>, etc.
+      var u = payload.url.split("?")[0].split("#")[0];
+      u = u.replace(
+        /\/(c[a-z0-9]{20,}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?=\/|$)/gi,
+        "/[id]",
+      );
+      u = u.replace(/^\/login\/[^/]+/, "/login/[slug]");
+      u = u.replace(/^\/portal\/sign\/[^/]+/, "/portal/sign/[token]");
+      payload.url = u;
+    }
+    if (payload) {
+      // Titles carry project and client names.
+      delete payload.title;
+    }
+  } catch {
+    // Never let masking break the page; drop the event instead of leaking.
+    return { url: "/[masking-error]" };
+  }
+  return payload;
+}

--- a/docker/unified.Dockerfile
+++ b/docker/unified.Dockerfile
@@ -34,6 +34,11 @@ ENV NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
 ARG NEXT_PUBLIC_SENTRY_ENABLED=false
 ENV NEXT_PUBLIC_SENTRY_ENABLED=${NEXT_PUBLIC_SENTRY_ENABLED}
 ARG SENTRY_AUTH_TOKEN=
+# Statically prerendered routes (/signup, /accept-invite, /forgot-password, ...)
+# read this at BUILD time. Without it as a build arg they are baked with no
+# tracker and can never report, no matter what the runtime env says.
+ARG NEXT_PUBLIC_TRACKERS=
+ENV NEXT_PUBLIC_TRACKERS=${NEXT_PUBLIC_TRACKERS}
 RUN bun run --filter @atrium/web build
 
 # Production runner

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -13,6 +13,9 @@ FROM base AS build
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
 COPY . .
+# NEXT_PUBLIC_* is resolved at build time for statically prerendered routes.
+ARG NEXT_PUBLIC_TRACKERS=
+ENV NEXT_PUBLIC_TRACKERS=${NEXT_PUBLIC_TRACKERS}
 RUN bun run --filter @atrium/web build
 
 # Production

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -97,6 +97,16 @@ environment:
 docker build --build-arg NEXT_PUBLIC_TRACKERS='[...]' -f docker/unified.Dockerfile .
 ```
 
+On Coolify (and similar platforms that build from source), a plain environment
+variable is applied at **runtime only** and will not reach the build. Add the
+variable and enable the **"Build Variable?"** toggle so it is passed as
+`--build-arg`. Without it, dynamic routes will report and prerendered ones
+silently will not.
+
+The published `vibralabs/atrium` image deliberately ships with **no** tracker
+configured. Analytics is always something you opt into for your own instance;
+a self-hosted Atrium never reports to the maintainers.
+
 ## Identifiers are stripped before sending
 
 Analytics scripts normally transmit the full URL and page title. In Atrium

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -71,3 +71,64 @@ After these steps, no Sentry code will be present in the build at all.
 ## Data retention and access
 
 Error reports are stored in Sentry and accessible only to the Atrium maintainers. Reports are used solely to identify and fix bugs in the Atrium codebase. Data is retained according to Sentry's default retention policy (90 days on the free tier).
+
+---
+
+# Product Analytics
+
+Separate from error reporting, Atrium supports optional web analytics via the
+`NEXT_PUBLIC_TRACKERS` environment variable. This is **off by default and
+self-directed**: nothing loads unless you configure it, and the data goes to
+*your* analytics instance, never to the Atrium maintainers.
+
+## Enabling it
+
+```bash
+NEXT_PUBLIC_TRACKERS='[{"src":"https://umami.example.com/script.js","data-website-id":"your-id"}]'
+```
+
+`NEXT_PUBLIC_*` values are resolved at **build time** for statically
+prerendered routes (`/signup`, `/accept-invite`, `/forgot-password`, ...). If
+you build your own image, pass it as a build argument or those pages will be
+baked without the tracker and will never report, regardless of the runtime
+environment:
+
+```bash
+docker build --build-arg NEXT_PUBLIC_TRACKERS='[...]' -f docker/unified.Dockerfile .
+```
+
+## Identifiers are stripped before sending
+
+Analytics scripts normally transmit the full URL and page title. In Atrium
+those contain identifiers — project ids, organization slugs, task ids in query
+strings, and titles carrying client names. `apps/web/src/lib/mask-analytics.ts`
+rewrites every payload in the browser before it is sent:
+
+| Sent as | Instead of |
+|---------|------------|
+| `/portal/projects/[id]` | `/portal/projects/cm...` |
+| `/login/[slug]` | `/login/<your-org-slug>` |
+| `/portal/sign/[token]` | `/portal/sign/<token>` |
+| *(no query string)* | `?task=<id>`, `?id=<invitation>` |
+| *(no page title)* | `Client Project Name \| Atrium` |
+
+The identifiers are never transmitted, rather than being sent and trusted to
+stay private. This is wired up automatically via the tracker's
+`data-before-send` hook; set your own `data-before-send` value if you want
+different handling.
+
+## No individual user tracking
+
+Atrium does **not** identify users to analytics. There is no user id, no
+account id, and no per-person attribute in any event. Product events are
+aggregate counts only:
+
+- **Onboarding** — `signup_started`, `signup_completed`, `signup_failed`,
+  `setup_completed`, `setup_step_skipped`, `setup_email_configured`
+- **Portal usage** — `portal_file_downloaded` (file extension only, never the
+  name), `portal_request_posted`, `portal_document_responded` (approve/reject
+  only, never the document or the stated reason)
+
+These answer "do invited clients use their portals" without answering "what did
+this particular client do". If you fork Atrium and add user identification, say
+so in your own privacy policy.

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -22,6 +22,15 @@ if (existsSync(rootEnvPath)) {
   }
 }
 
+// Shared by the test runner and the web server it starts, so assertions read
+// the same value the page was built with. CI sets this at the job level so the
+// build step inlines it into prerendered routes; this default covers local runs
+// against the dev server, which reads it at startup.
+const TRACKERS: string =
+  process.env.NEXT_PUBLIC_TRACKERS ??
+  '[{"src":"http://localhost:3000/__e2e-tracker.js","data-website-id":"e2e"}]';
+process.env.NEXT_PUBLIC_TRACKERS = TRACKERS;
+
 export default defineConfig({
   testDir: "./tests",
   testMatch: "*.e2e.ts",
@@ -58,14 +67,7 @@ export default defineConfig({
       url: "http://localhost:3000",
       reuseExistingServer: !process.env.CI,
       cwd: "../",
-      // Must also be set for the CI build step: NEXT_PUBLIC_* is inlined at
-      // build time for prerendered routes, so setting it only here would
-      // leave `next start` serving a build that never had it.
-      env: {
-        NEXT_PUBLIC_TRACKERS:
-          process.env.NEXT_PUBLIC_TRACKERS ??
-          '[{"src":"http://localhost:3000/__e2e-tracker.js","data-website-id":"e2e"}]',
-      },
+      env: { NEXT_PUBLIC_TRACKERS: TRACKERS },
     },
   ],
 });

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -58,6 +58,14 @@ export default defineConfig({
       url: "http://localhost:3000",
       reuseExistingServer: !process.env.CI,
       cwd: "../",
+      // Must also be set for the CI build step: NEXT_PUBLIC_* is inlined at
+      // build time for prerendered routes, so setting it only here would
+      // leave `next start` serving a build that never had it.
+      env: {
+        NEXT_PUBLIC_TRACKERS:
+          process.env.NEXT_PUBLIC_TRACKERS ??
+          '[{"src":"http://localhost:3000/__e2e-tracker.js","data-website-id":"e2e"}]',
+      },
     },
   ],
 });

--- a/e2e/tests/analytics.e2e.ts
+++ b/e2e/tests/analytics.e2e.ts
@@ -90,23 +90,29 @@ test.describe("Analytics instrumentation", () => {
 });
 
 test.describe("Tracker injection", () => {
-  // NEXT_PUBLIC_TRACKERS is inlined at build/dev-server start, so this can
-  // only assert anything when the server under test was started with it.
-  test.skip(
-    !process.env.NEXT_PUBLIC_TRACKERS,
-    "NEXT_PUBLIC_TRACKERS not set for the server under test",
-  );
   test.use({ storageState: { cookies: [], origins: [] } });
 
-  test("statically prerendered pages still get the tracker tag", async ({ page }) => {
-    // /signup is prerendered (no server layout above it). next/script with
-    // afterInteractive was never emitted here, so assert on a fresh load
-    // rather than a client-side navigation from a dynamic page.
-    await page.goto("/signup");
-    const trackers: string[] = JSON.parse(process.env.NEXT_PUBLIC_TRACKERS ?? "[]")
-      .map((t: { src: string }) => t.src);
-    for (const src of trackers) {
-      await expect(page.locator(`script[src="${src}"]`)).toHaveCount(1);
-    }
-  });
+  // Regression guard for the real defect: NEXT_PUBLIC_* is resolved at BUILD
+  // time for statically prerendered routes, so a build without it bakes those
+  // pages with no tracker forever. Assert on the raw HTML response, NOT the
+  // DOM -- next/script injects client-side after hydration, so a DOM query
+  // passes even when the served HTML has no tag at all.
+  const PRERENDERED: string[] = ["/signup", "/accept-invite", "/forgot-password"];
+
+  for (const path of PRERENDERED) {
+    test(`${path} is served with the tracker tag in its HTML`, async ({ request }) => {
+      const trackers: Array<{ src: string }> = JSON.parse(
+        process.env.NEXT_PUBLIC_TRACKERS ?? "[]",
+      );
+      expect(
+        trackers.length,
+        "NEXT_PUBLIC_TRACKERS must be set for the server under test",
+      ).toBeGreaterThan(0);
+
+      const html: string = await (await request.get(path)).text();
+      for (const { src } of trackers) {
+        expect(html).toContain(src);
+      }
+    });
+  }
 });

--- a/e2e/tests/analytics.e2e.ts
+++ b/e2e/tests/analytics.e2e.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+/**
+ * Analytics instrumentation.
+ *
+ * The real tracker is only loaded when NEXT_PUBLIC_TRACKERS is set, and
+ * `track()` no-ops when `window.umami` is missing. These tests install a stub
+ * before any page script runs and assert on what the app tried to send, so
+ * they verify the call sites without needing a live Umami instance.
+ */
+
+type TrackedData = Record<string, string | number | boolean>;
+
+interface TrackedEvent {
+  name: string;
+  data?: TrackedData;
+}
+
+declare global {
+  interface Window {
+    __trackedEvents?: TrackedEvent[];
+    umami?: { track: (event: string, data?: TrackedData) => void };
+  }
+}
+
+async function stubTracker(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    window.__trackedEvents = [];
+    window.umami = {
+      track: (name: string, data?: TrackedData) => {
+        window.__trackedEvents?.push({ name, data });
+      },
+    };
+  });
+}
+
+async function trackedEvents(page: Page): Promise<TrackedEvent[]> {
+  return page.evaluate(() => window.__trackedEvents ?? []);
+}
+
+test.describe("Analytics instrumentation", () => {
+  // These run signed out — the stored auth state would redirect away from
+  // /login and /signup before anything is tracked.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("failed login reports a reason", async ({ page }) => {
+    await stubTracker(page);
+    await page.goto("/login");
+
+    await page.getByLabel(/email/i).fill("nobody@example.com");
+    await page.getByLabel(/password/i).fill("WrongPassword1!");
+    await page.getByRole("button", { name: /sign in/i }).click();
+
+    await expect
+      .poll(async () => (await trackedEvents(page)).map((e) => e.name))
+      .toContain("login_failed");
+
+    const failure = (await trackedEvents(page)).find(
+      (e) => e.name === "login_failed",
+    );
+    expect(typeof failure?.data?.reason).toBe("string");
+    expect(failure?.data?.branded).toBe(false);
+  });
+
+  test("submitting signup reports an attempt before validation", async ({
+    page,
+  }) => {
+    await stubTracker(page);
+    await page.goto("/signup");
+
+    // Billing-enabled instances show plan selection first.
+    const planHeading = page.getByRole("heading", { name: /choose your plan/i });
+    if (await planHeading.isVisible().catch(() => false)) {
+      await page.getByRole("button", { name: /continue/i }).click();
+    }
+
+    await page.getByLabel(/your name/i).fill("Analytics Test");
+    await page.getByLabel(/agency/i).fill("Analytics Test Co");
+    await page.getByLabel(/email/i).fill(`analytics-${Date.now()}@example.com`);
+    // Deliberately too weak: signup_started must fire even when the client
+    // side rejects the password, otherwise the attempt is invisible.
+    await page.getByLabel(/password/i).fill("weak");
+    await page.getByRole("button", { name: /create account|sign up/i }).click();
+
+    await expect
+      .poll(async () => (await trackedEvents(page)).map((e) => e.name))
+      .toContain("signup_started");
+  });
+});

--- a/e2e/tests/analytics.e2e.ts
+++ b/e2e/tests/analytics.e2e.ts
@@ -88,3 +88,25 @@ test.describe("Analytics instrumentation", () => {
       .toContain("signup_started");
   });
 });
+
+test.describe("Tracker injection", () => {
+  // NEXT_PUBLIC_TRACKERS is inlined at build/dev-server start, so this can
+  // only assert anything when the server under test was started with it.
+  test.skip(
+    !process.env.NEXT_PUBLIC_TRACKERS,
+    "NEXT_PUBLIC_TRACKERS not set for the server under test",
+  );
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("statically prerendered pages still get the tracker tag", async ({ page }) => {
+    // /signup is prerendered (no server layout above it). next/script with
+    // afterInteractive was never emitted here, so assert on a fresh load
+    // rather than a client-side navigation from a dynamic page.
+    await page.goto("/signup");
+    const trackers: string[] = JSON.parse(process.env.NEXT_PUBLIC_TRACKERS ?? "[]")
+      .map((t: { src: string }) => t.src);
+    for (const src of trackers) {
+      await expect(page.locator(`script[src="${src}"]`)).toHaveCount(1);
+    }
+  });
+});

--- a/e2e/tests/analytics.e2e.ts
+++ b/e2e/tests/analytics.e2e.ts
@@ -78,9 +78,11 @@ test.describe("Analytics instrumentation", () => {
     await page.getByLabel(/your name/i).fill("Analytics Test");
     await page.getByLabel(/agency/i).fill("Analytics Test Co");
     await page.getByLabel(/email/i).fill(`analytics-${Date.now()}@example.com`);
-    // Deliberately too weak: signup_started must fire even when the client
-    // side rejects the password, otherwise the attempt is invisible.
-    await page.getByLabel(/password/i).fill("weak");
+    // Long enough to clear the input's native minLength=8 -- otherwise the
+    // browser blocks submission and handleSubmit never runs -- but missing the
+    // uppercase/number/symbol the app requires. signup_started must still fire,
+    // or attempts rejected by our own rules stay invisible.
+    await page.getByLabel(/password/i).fill("weakpassword");
     await page.getByRole("button", { name: /create account|sign up/i }).click();
 
     await expect


### PR DESCRIPTION
Umami was recording 14 of ~101 signups and 0 of 39 accepted invites this year. The cause was `NEXT_PUBLIC_TRACKERS` never being passed at build time: dynamic routes (`/login`, `/setup`) read it at request time and worked, while statically prerendered routes (`/signup`, `/accept-invite`, `/forgot-password`) are rendered during `next build` and were baked with an empty tracker list.

Verified by building twice — with the variable set the value is inlined into 18 server files including the prerendered HTML; without it only a runtime `process.env` read survives, which prerendered pages never reach.

## Changes

- `ARG NEXT_PUBLIC_TRACKERS` in both Dockerfiles so a build arg reaches `next build`
- Tracker rendered as a plain `<script>` rather than `next/script`, so it lands in the served HTML instead of being injected after hydration
- New events: `login_succeeded`, `signup_started`, `signup_failed`, wizard-step events, `first_org` on `setup_completed`. `project_created` and `client_invited` now also fire from the setup wizard, where they previously fired only from the dashboard
- Portal instrumentation: `portal_file_downloaded` (extension only), `portal_request_posted`, `portal_document_responded` (action only). Aggregate counts, no user identification
- `lib/mask-analytics.ts` strips identifiers from every payload before sending — project ids, org slugs, signing tokens, query strings and page titles were all being transmitted
- The published image deliberately ships with no tracker, so self-hosted instances never report to the maintainers

## Deployment

Coolify builds from source, so `NEXT_PUBLIC_TRACKERS` needs the **Build Variable** toggle enabled. A runtime-only variable reaches dynamic routes but not prerendered ones.

## Testing

667 API and 55 web unit tests pass, including 10 covering the masking. The serialised masking function was extracted from the built HTML and executed to confirm it behaves in-page.

The three Playwright tests in `e2e/tests/analytics.e2e.ts` compile and are registered but have **not been run** — Docker was unavailable locally. They should be run before this is relied on.