### PR TITLE
Configure analytics at runtime rather than at build time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
       API_URL: http://localhost:3001
       WEB_URL: http://localhost:3000
       NEXT_PUBLIC_API_URL: http://localhost:3001
-      # Must be present for `bun run build`: NEXT_PUBLIC_* is inlined at build
-      # time for prerendered routes, which is the regression under test.
+      # Read at request time by the auth routes; the e2e assertion checks the
+      # tag reaches the served HTML.
       NEXT_PUBLIC_TRACKERS: '[{"src":"http://localhost:3000/__e2e-tracker.js","data-website-id":"e2e"}]'
       STORAGE_PROVIDER: local
       UPLOAD_DIR: ./uploads

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -1,0 +1,22 @@
+/**
+ * These pages are all client components with no server layout of their own, so
+ * Next would statically prerender them at build time. That resolved
+ * NEXT_PUBLIC_TRACKERS during `next build` -- where it is absent, because the
+ * published image must not carry anyone's analytics -- and baked in an empty
+ * tracker list that no runtime configuration could override. /signup and
+ * /accept-invite therefore never reported.
+ *
+ * Rendering them per request lets the root layout read the operator's runtime
+ * environment, the same way /login and /dashboard always have. These are
+ * low-traffic auth pages that already fetch their config client-side, so
+ * nothing is lost by not prerendering them.
+ */
+export const dynamic = "force-dynamic";
+
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/docker/unified.Dockerfile
+++ b/docker/unified.Dockerfile
@@ -34,9 +34,9 @@ ENV NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
 ARG NEXT_PUBLIC_SENTRY_ENABLED=false
 ENV NEXT_PUBLIC_SENTRY_ENABLED=${NEXT_PUBLIC_SENTRY_ENABLED}
 ARG SENTRY_AUTH_TOKEN=
-# Statically prerendered routes (/signup, /accept-invite, /forgot-password, ...)
-# read this at BUILD time. Without it as a build arg they are baked with no
-# tracker and can never report, no matter what the runtime env says.
+# Optional. Analytics is normally configured at runtime -- the auth routes are
+# rendered per request so they pick up the running container's environment.
+# This exists only for operators who prefer to bake a tracker into an image.
 ARG NEXT_PUBLIC_TRACKERS=
 ENV NEXT_PUBLIC_TRACKERS=${NEXT_PUBLIC_TRACKERS}
 RUN bun run --filter @atrium/web build

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -13,7 +13,7 @@ FROM base AS build
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
 COPY . .
-# NEXT_PUBLIC_* is resolved at build time for statically prerendered routes.
+# Optional; analytics is normally configured at runtime. See docs/telemetry.md.
 ARG NEXT_PUBLIC_TRACKERS=
 ENV NEXT_PUBLIC_TRACKERS=${NEXT_PUBLIC_TRACKERS}
 RUN bun run --filter @atrium/web build

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -87,25 +87,20 @@ self-directed**: nothing loads unless you configure it, and the data goes to
 NEXT_PUBLIC_TRACKERS='[{"src":"https://umami.example.com/script.js","data-website-id":"your-id"}]'
 ```
 
-`NEXT_PUBLIC_*` values are resolved at **build time** for statically
-prerendered routes (`/signup`, `/accept-invite`, `/forgot-password`, ...). If
-you build your own image, pass it as a build argument or those pages will be
-baked without the tracker and will never report, regardless of the runtime
-environment:
+Set it as a normal runtime environment variable on your container. Every route
+that can report is rendered per request, so the running container's environment
+is read directly — no rebuild required, and changing the value takes effect on
+restart.
 
-```bash
-docker build --build-arg NEXT_PUBLIC_TRACKERS='[...]' -f docker/unified.Dockerfile .
-```
+The published `vibralabs/atrium` image ships with **no** tracker configured, and
+this is deliberate: because analytics is runtime configuration, the image the
+maintainers publish is the same one everyone runs, and it reports nowhere by
+default. A self-hosted Atrium never sends anything to the maintainers.
 
-On Coolify (and similar platforms that build from source), a plain environment
-variable is applied at **runtime only** and will not reach the build. Add the
-variable and enable the **"Build Variable?"** toggle so it is passed as
-`--build-arg`. Without it, dynamic routes will report and prerendered ones
-silently will not.
-
-The published `vibralabs/atrium` image deliberately ships with **no** tracker
-configured. Analytics is always something you opt into for your own instance;
-a self-hosted Atrium never reports to the maintainers.
+> Historical note: the auth pages (`/signup`, `/accept-invite`, ...) used to be
+> statically prerendered, which resolved this variable at build time and left
+> them permanently untracked in any image built without it. They are now
+> rendered per request (`apps/web/src/app/(auth)/layout.tsx`).
 
 ## Identifiers are stripped before sending
 

--- a/e2e/tests/analytics.e2e.ts
+++ b/e2e/tests/analytics.e2e.ts
@@ -94,11 +94,11 @@ test.describe("Analytics instrumentation", () => {
 test.describe("Tracker injection", () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
-  // Regression guard for the real defect: NEXT_PUBLIC_* is resolved at BUILD
-  // time for statically prerendered routes, so a build without it bakes those
-  // pages with no tracker forever. Assert on the raw HTML response, NOT the
-  // DOM -- next/script injects client-side after hydration, so a DOM query
-  // passes even when the served HTML has no tag at all.
+  // Regression guard: these routes were statically prerendered, which resolved
+  // NEXT_PUBLIC_TRACKERS at build time and left them permanently untracked in
+  // any image built without it. Assert on the raw HTML response, NOT the DOM --
+  // a client-injected tag shows up in the DOM even when the served HTML has no
+  // tag at all, which is what made the first version of this test useless.
   const PRERENDERED: string[] = ["/signup", "/accept-invite", "/forgot-password"];
 
   for (const path of PRERENDERED) {


### PR DESCRIPTION
Follow-up to #65. That PR was merged one commit short of this change, so `/signup` and `/accept-invite` are still not reporting in production.

The published image is the same one self-hosters run, which makes a build-time tracker unworkable: baking one in would point every self-hosted Atrium at the maintainers' analytics, and leaving it out keeps the auth pages silent. Both were true after #65.

The auth pages are client components with no server layout, so Next prerendered them and resolved `NEXT_PUBLIC_TRACKERS` during `next build`. Rendering them per request lets the root layout read the running container's environment, the way `/login` and `/dashboard` always have. Analytics becomes ordinary runtime configuration and the published image reports nowhere by default.

## Verified

Built with the variable absent, then served with it set:

- prerendered routes drop from 8 to 3 (`/`, `/changelog`, `/_not-found`)
- `/signup`, `/accept-invite` and `/forgot-password` all emit the tracker tag

## Also

Corrects `docs/telemetry.md`, which told operators to pass a build argument and to enable Coolify's "Build Variable?" toggle. Neither applies — Coolify deploys a prebuilt image, so its variables are runtime-only. The Dockerfile build args are kept but marked optional.